### PR TITLE
Add workflow for building and uploading PDF.

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -14,7 +14,7 @@ jobs:
           latexmk_use_lualatex: true
       - name: Extract PDF
         run: |
-          mkdir public
+          mkdir -p public
           cp doc/hydras.pdf public/
       # Depending on whether we are on master or not, we deploy to
       # GitHub Pages or as an artifact

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,0 +1,33 @@
+name: Build LaTeX document
+on: [push, pull_request]
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: hydras.tex
+          working_directory: doc
+          latexmk_use_lualatex: true
+      - name: Extract PDF
+        run: |
+          mkdir public
+          cp doc/hydras.pdf public/
+      # Depending on whether we are on master or not, we deploy to
+      # GitHub Pages or as an artifact
+      - name: Deploy to GitHub pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          build_dir: public
+          jekyll: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy artifact
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/master'
+        uses: actions/upload-artifact@v2
+        with:
+          path: public


### PR DESCRIPTION
This will automatically build and deploy the PDF every time it is updated:

- When a commit is pushed to `master`, the PDF will be deployed to GitHub Pages, allowing to view it online at https://coq-community.org/hydra-battles/hydras.pdf (preview at https://Zimmi48.github.io/hydra-battles/hydras.pdf).

- When a commit is pushed to another branch or a pull request, the PDF will be deployed as an artifact which can be downloaded and unzipped for reviewing (preview at https://github.com/Zimmi48/hydra-battles/actions/runs/318159714).