### PR TITLE
use matrix to build both opam files in CI

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -17,12 +17,15 @@ jobs:
         image:
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'
+        opam_file:
+          - 'coq-hydra-battles.opam'
+          - 'coq-addition-chains.opam'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - uses: coq-community/docker-coq-action@v1
         with:
-          opam_file: 'coq-hydra-battles.opam'
+          opam_file: ${{ matrix.opam_file }}
           custom_image: ${{ matrix.image }}
 
 # See also:


### PR DESCRIPTION
This is to enable checking the whole Coq development for every revision, not just the hydra-battles part.