### PR TITLE
enable CI testing of Coq 8.13 and MathComp 1.12, update boilerplate

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Docker CI
 
 on:
   push:
@@ -15,8 +15,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:8.12'
-          - 'coqorg/coq:8.11'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.13'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.12'
+          - 'mathcomp/mathcomp:1.11.0-coq-8.11'
         opam_file:
           - 'coq-hydra-battles.opam'
           - 'coq-addition-chains.opam'

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,13 @@
 *.snm
 *.pygtex
 *.pygstyle
-src/html/
+theories/html/
 .lia.cache
 Makefile.coq
 Makefile.coq.conf
 .Makefile.coq.d
+bigfib.ml
+bigfib.mli
+bigmod.ml
+bigmod.mli
+_build/

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -8,3 +8,6 @@ coqdoc: $(GLOBFILES) $(VFILES)
 	$(HIDE)mkdir -p $(COQDOCDIR)
 	$(HIDE)$(COQDOC) $(COQDOCHTMLFLAGS) $(COQDOCLIBS) -d $(COQDOCDIR) $(VFILES)
 .PHONY: coqdoc
+
+clean::
+	$(HIDE)rm -f bigfib.ml bigfib.mli bigmod.ml bigmod.mli

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 
-[action-shield]: https://github.com/coq-community/hydra-battles/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/coq-community/hydra-battles/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/coq-community/hydra-battles/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/hydra-battles/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/hydra-battles#contributions-are-welcome-

--- a/coq-addition-chains.opam
+++ b/coq-addition-chains.opam
@@ -15,18 +15,19 @@ with the least number of multiplication as possible. We present a few implementa
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.11" & < "8.13~"}
+  "coq" {>= "8.11" & < "8.14~"}
   "coq-paramcoq" {>= "1.1.2" & < "1.2~"}
-  "coq-mathcomp-ssreflect" {>= "1.11.0" & < "1.12~"}
-  "coq-mathcomp-algebra" {>= "1.11.0" & < "1.12~"}
+  "coq-mathcomp-ssreflect" {>= "1.11.0" & < "1.13~"}
+  "coq-mathcomp-algebra" {>= "1.11.0" & < "1.13~"}
 ]
 
 tags: [
   "category:Mathematics/Combinatorics and Graph Theory"
-  "keyword:addition-chains"
+  "keyword:addition chains"
   "keyword:exponentiation algorithms"
   "logpath:additions"
 ]
 authors: [
   "Pierre Castéran"
+  "Yves Bertot"
 ]

--- a/coq-hydra-battles.opam
+++ b/coq-hydra-battles.opam
@@ -18,7 +18,7 @@ properties of epsilon0)."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.11" & < "8.13~"}
+  "coq" {>= "8.11" & < "8.14~"}
   "coq-equations" {>= "1.2" & < "1.3~"}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -41,12 +41,16 @@ license:
   identifier: MIT
 
 supported_coq_versions:
-  text: 8.11 or 8.12
-  opam: '{>= "8.11" & < "8.13~"}'
+  text: 8.11 to 8.13
+  opam: '{>= "8.11" & < "8.14~"}'
 
 tested_coq_opam_versions:
-- version: '8.12'
-- version: '8.11'
+- version: '1.12.0-coq-8.13'
+  repo: 'mathcomp/mathcomp'
+- version: '1.12.0-coq-8.12'
+  repo: 'mathcomp/mathcomp'
+- version: '1.11.0-coq-8.11'
+  repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:


### PR DESCRIPTION
Since 8.13.0 is out soon, it makes sense to test 8.13 in CI (currently, it uses 8.13+beta1), and also MathComp 1.12. I also updated the build boilerplate - in particular, CI should be a bit faster since the Docker images already have MathComp installed.