### PR TITLE
Fix most warnings (especially in 8.13)

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,9 @@
 -R theories/ordinals hydras
 -R theories/additions additions
 
+-arg -w -arg -notation-overridden
+-arg -w -arg -ambiguous-paths
+
 theories/ordinals/OrdinalNotations/ON_Omega.v
 theories/ordinals/OrdinalNotations/ON_Generic.v
 theories/ordinals/OrdinalNotations/ON_Finite.v

--- a/theories/additions/Dichotomy.v
+++ b/theories/additions/Dichotomy.v
@@ -129,7 +129,7 @@ Proof.
     discriminate.
 Qed.
 
-Hint Resolve dicho_aux_le_xOXO dicho_aux_le_xOXI 
+Global Hint Resolve dicho_aux_le_xOXO dicho_aux_le_xOXI 
              dicho_aux_le_xIXO dicho_aux_le_xIXI : chains.
 
 Lemma dicho_aux_lt : forall p, 3 < p ->

--- a/theories/additions/Euclidean_Chains.v
+++ b/theories/additions/Euclidean_Chains.v
@@ -458,7 +458,7 @@ $2^k.3^p$, using Fcompose and previous lemmas.
 Let us look at a simple example *)
 
 
-Hint Resolve F1_correct F1_proper
+Global Hint Resolve F1_correct F1_proper
      F3_correct F3_proper Fcompose_correct Fcompose_proper
      Fexp2_correct Fexp2_proper : chains.
 
@@ -965,7 +965,7 @@ Proof.
 Qed.
 
 
-Hint Resolve KFF_correct KFF_proper KFK_correct KFK_proper : chains.
+Global Hint Resolve KFF_correct KFF_proper KFK_correct KFK_proper : chains.
 
 Lemma k3_1_correct : Kchain_correct 3 1 k3_1.
 Proof.
@@ -981,7 +981,7 @@ Proof.
   add_op_proper M H3; rewrite H2; reflexivity.
 Qed.
 
-Hint Resolve k3_1_correct k3_1_proper : chains.          
+Global Hint Resolve k3_1_correct k3_1_proper : chains.
 
 (** an example of correct chain construction  *)
 
@@ -1096,7 +1096,7 @@ Definition  OK (s: signature)
                             proper_statement s c.
 
 
-Hint Resolve pos_gt_3 : chains.
+Global Hint Resolve pos_gt_3 : chains.
 
 Section Gamma.
 

--- a/theories/additions/Monoid_instances.v
+++ b/theories/additions/Monoid_instances.v
@@ -215,16 +215,16 @@ Section Nmodulo.
     intro H;subst m. discriminate. 
   Qed.
   
-  Hint Resolve m_neq_0 : chains.
+  Local Hint Resolve m_neq_0 : chains.
   
   Definition mult_mod ( x y : N) := (x * y) mod m.
   Definition mod_eq ( x y: N) := x mod m = y mod m.
   
-  Global Instance mod_equiv : Equiv N := mod_eq.
+  Local Instance mod_equiv : Equiv N := mod_eq.
 
-  Global Instance mod_op : Mult_op N := mult_mod.
+  Local Instance mod_op : Mult_op N := mult_mod.
   
-  Global Instance mod_Equiv : Equivalence mod_equiv.
+  Local Instance mod_Equiv : Equivalence mod_equiv.
   Proof.
     split.
     - intros x; reflexivity.

--- a/theories/additions/More_on_positive.v
+++ b/theories/additions/More_on_positive.v
@@ -23,7 +23,7 @@ Proof.
   discriminate.
 Qed.
 
-Hint Resolve Pos_to_nat_neq_0 : chains.
+Global Hint Resolve Pos_to_nat_neq_0 : chains.
 
 
 (** ** Relationship with [nat] and [N] 
@@ -34,7 +34,7 @@ Proof. discriminate. Qed.
 Lemma Npos_gt_0 : forall p, (0 < N.pos p)%N.
 Proof. reflexivity. Qed.
 
-Hint Resolve Npos_diff_zero  Npos_gt_0 : chains.
+Global Hint Resolve Npos_diff_zero  Npos_gt_0 : chains.
 
 
 Lemma pos2N_inj_lt : forall n p, (n < p)%positive <-> (N.pos n < N.pos p)%N.
@@ -87,7 +87,7 @@ Proof.
  apply Pos2Nat.inj_le; apply pos_le_mul.
 Qed.
 
-Hint Resolve Pos2Nat_le_1_p : chains.
+Global Hint Resolve Pos2Nat_le_1_p : chains.
 
 (** ** Surjection from [N] into [positive] 
 *)
@@ -239,7 +239,7 @@ Proof.
  -  split; intros; now compute.
 Qed.
 
-Hint Resolve pos_gt_3 : chains.
+Global Hint Resolve pos_gt_3 : chains.
 
 (** ** Lemmas on Euclidean division 
     N.pos_div_eucl (a:positive) (b:N) : N * N 

--- a/theories/additions/dune
+++ b/theories/additions/dune
@@ -1,4 +1,5 @@
 (coq.theory
  (name additions)
  (package coq-addition-chains)
- (synopsis "Exponentiation algorithms following addition chains"))
+ (synopsis "Exponentiation algorithms following addition chains")
+ (flags -w -notation-overridden -w -ambiguous-paths))

--- a/theories/ordinals/Epsilon0/Canon.v
+++ b/theories/ordinals/Epsilon0/Canon.v
@@ -785,6 +785,6 @@ Proof.
   simpl;   apply limitb_canonS_not_zero; auto.
 Qed.
 
-Hint Resolve CanonS_lt Canon_lt Canon_of_limit_not_null : E0.
+Global Hint Resolve CanonS_lt Canon_lt Canon_of_limit_not_null : E0.
 
 

--- a/theories/ordinals/Epsilon0/E0.v
+++ b/theories/ordinals/Epsilon0/E0.v
@@ -31,7 +31,7 @@ Class E0 : Type := mkord {cnf : T1; cnf_ok : nf cnf}.
 
 Arguments cnf : clear implicits.
 
-Hint Resolve cnf_ok : E0.
+Global Hint Resolve cnf_ok : E0.
 
 (** ** Lifting functions from [T1] to [E0] *)
 
@@ -167,7 +167,7 @@ Proof.
 Qed.
 
 
-Hint Resolve E0_eq_intro : E0.
+Global Hint Resolve E0_eq_intro : E0.
 
 Ltac orefl := (apply E0_eq_intro; try reflexivity).
 
@@ -224,7 +224,7 @@ Proof.
   unfold Phi0; apply Limitb_Omega_term.
 Qed.
 
-Hint Resolve Limitb_Phi0 : E0.
+Global Hint Resolve Limitb_Phi0 : E0.
 
 
 
@@ -289,7 +289,7 @@ Proof.
     now   apply T1.nf_Acc. 
 Defined.
 
-Hint Resolve Lt_wf : E0.
+Global Hint Resolve Lt_wf : E0.
 
 Lemma Lt_succ_le (alpha beta: E0):  beta o< alpha -> Succ beta o<= alpha.
 Proof.
@@ -334,14 +334,14 @@ Proof.
     apply LT_succ;auto.
 Qed.
 
-Hint Resolve Pred_Lt : E0.
+Global Hint Resolve Pred_Lt : E0.
 
 
 Lemma Succ_succb (alpha : E0) : Succb (Succ alpha).
 destruct alpha; unfold Succb, Succ; cbn; apply T1.succ_succb.
 Qed.
 
-Hint Resolve Succ_succb : E0.
+Global Hint Resolve Succ_succb : E0.
 
 Ltac ord_eq alpha beta := assert (alpha = beta);
       [apply E0_eq_intro ; try reflexivity|].
@@ -388,7 +388,7 @@ Proof.
   intros H H0. rewrite (succ_not_limit _ H) in H0. discriminate.  
 Qed.
 
-Hint Resolve Limit_not_Zero Succ_not_Zero Lt_Succ Succ_not_Limitb : E0.
+Global Hint Resolve Limit_not_Zero Succ_not_Zero Lt_Succ Succ_not_Limitb : E0.
 
 Lemma lt_Succ_inv : forall alpha beta, beta o< alpha <->
                                        Succ beta o<= alpha.

--- a/theories/ordinals/Epsilon0/Epsilon0rpo.v
+++ b/theories/ordinals/Epsilon0/Epsilon0rpo.v
@@ -173,7 +173,7 @@ Proof.
  simpl; auto with arith.
 Qed.
 
-Hint Resolve T1_size2 T1_size3 : rpo.
+Global Hint Resolve T1_size2 T1_size3 : rpo.
 
 
 (** let us recall subterm properties on T1 *)
@@ -198,9 +198,9 @@ apply  lt_le_incl.
 Qed.
 
 
-Hint Resolve nat_lt_cons : rpo.
-Hint Resolve lt_subterm2 lt_subterm1 : rpo.
-Hint Resolve T1_size3 T1_size2 T1_size1 : rpo.
+Global Hint Resolve nat_lt_cons : rpo.
+Global Hint Resolve lt_subterm2 lt_subterm1 : rpo.
+Global Hint Resolve T1_size3 T1_size2 T1_size1 : rpo.
 
 
 Lemma nat_2_term_mono : forall n n', (n < n')%nat -> 
@@ -404,14 +404,14 @@ Remark R1 : Acc P.prec nat_0.
   destruct y; try contradiction.
 Qed.
 
-Hint Resolve R1 : rpo.
+Global Hint Resolve R1 : rpo.
 
 Remark R2 : Acc P.prec ord_zero. 
   split.
   destruct y; try contradiction; auto with rpo.
 Qed.
 
-Hint Resolve R2 : rpo.
+Global Hint Resolve R2 : rpo.
 
 Remark R3 : Acc P.prec nat_S.
   split.
@@ -419,14 +419,14 @@ Remark R3 : Acc P.prec nat_S.
 Qed.
 
 
-Hint Resolve R3 : rpo.
+Global Hint Resolve R3 : rpo.
 
 Remark R4 : Acc P.prec ord_cons.
   split.
   destruct y; try contradiction;auto with rpo.
 Qed.
 
-Hint Resolve R4 : rpo.
+Global Hint Resolve R4 : rpo.
 
 Theorem well_founded_rpo : well_founded rpo.
 Proof.
@@ -439,7 +439,7 @@ Section  well_founded.
   
   Let R := restrict  nf lt.
 
-  Hint Unfold restrict R : rpo.
+  Local Hint Unfold restrict R : rpo.
 
   Lemma R_inc_rpo : forall o o', R o o' -> rpo (T1_2_term o) (T1_2_term o').
   Proof.

--- a/theories/ordinals/Epsilon0/F_alpha.v
+++ b/theories/ordinals/Epsilon0/F_alpha.v
@@ -254,7 +254,7 @@ Section Properties.
       rewrite F_zero_eqn. rewrite LF1; abstract lia.
     Qed.
 
-    Hint Resolve F_One_Zero_dom mono_F_Zero Lt_n_F_Zero_n : T1.
+    Local Hint Resolve F_One_Zero_dom mono_F_Zero Lt_n_F_Zero_n : T1.
 
     Lemma F_One_Zero_ge :  F_ Zero <<= F_ 1.
     Proof.
@@ -262,7 +262,7 @@ Section Properties.
         rewrite F_zero_eqn, LF1; abstract lia.  
     Qed. 
 
-    Hint Resolve  F_One_Zero_ge : T1.
+    Local Hint Resolve  F_One_Zero_ge : T1.
 
     Lemma PZero : P Zero.
     Proof. 

--- a/theories/ordinals/Epsilon0/H_alpha.v
+++ b/theories/ordinals/Epsilon0/H_alpha.v
@@ -412,7 +412,7 @@ Section Proof_of_Abstract_Properties.
        - apply Succ_succb.
     Qed.
 
-    Hint Resolve PD_Zero PA_Zero : E0.
+    Local Hint Resolve PD_Zero PA_Zero : E0.
 
     Lemma PC_Zero :  H_ Zero <<= H_ (Succ Zero).
     Proof.
@@ -421,7 +421,7 @@ Section Proof_of_Abstract_Properties.
         rewrite Pred_of_Succ, H_eq1; auto with arith.
     Qed. 
 
-    Hint Resolve  PC_Zero : core.
+    Local Hint Resolve  PC_Zero : core.
 
     Lemma PZero : P Zero.
     Proof. 

--- a/theories/ordinals/Epsilon0/L_alpha.v
+++ b/theories/ordinals/Epsilon0/L_alpha.v
@@ -12,7 +12,7 @@ From Equations Require Import Equations.
 Import RelationClasses Relations.
 
 Instance Olt : WellFounded Lt := Lt_wf.
-Hint Resolve Olt : E0.
+Global Hint Resolve Olt : E0.
 
 (** Using Coq-Equations for building a function which satisfies 
     [Large_sets.L_spec] *)

--- a/theories/ordinals/Epsilon0/Large_Sets_Examples.v
+++ b/theories/ordinals/Epsilon0/Large_Sets_Examples.v
@@ -46,7 +46,7 @@ Compute  (gnaw (omega * omega) (interval 6 700)).
 
 Compute pp (  gnaw (omega * omega) (interval 6 509)).
 
-Hint Resolve iota_from_lt_not_In: core.
+Global Hint Resolve iota_from_lt_not_In: core.
 
 Example Ex1 : mlarge (omega * omega) (interval 6 510).
 Proof with try (auto with arith || discriminate ).

--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -175,7 +175,7 @@ Definition le (alpha beta :T1) :=
   | _ => True
   end. 
 
-Hint Unfold le : T1. 
+Global Hint Unfold le : T1. 
 
 
 
@@ -368,7 +368,7 @@ Proof.
   - elimtype False; abstract lia. 
 Qed. 
 
-Hint Resolve zero_lt head_lt coeff_lt tail_lt  : T1.
+Global Hint Resolve zero_lt head_lt coeff_lt tail_lt  : T1.
 
 Open Scope t1_scope.
 
@@ -394,7 +394,7 @@ destruct b.
   all : destruct (lt_b b2_1 b1); simpl in *;auto.
 Qed. 
 
-Hint Resolve zero_nf single_nf ocons_nf: T1.
+Global Hint Resolve zero_nf single_nf ocons_nf: T1.
 
 
 Lemma nf_inv1 : forall a n b, nf (ocons a n b) -> nf a.
@@ -460,7 +460,7 @@ Inductive nf_helper : T1 -> T1 -> Prop :=
 
 
 
-Hint Constructors nf_helper : T1.
+Global Hint Constructors nf_helper : T1.
 
 
 
@@ -619,7 +619,7 @@ Qed.
 Theorem not_lt_zero alpha : ~ lt alpha  zero.
 Proof.  destruct alpha; compute; discriminate. Qed.
 
-Hint Resolve not_lt_zero : T1.
+Global Hint Resolve not_lt_zero : T1.
 
 
  Inductive lt_cases (a  b : T1) (n :nat) (a' b':T1) (n':nat) : Type :=
@@ -678,7 +678,7 @@ Qed.
 
 
 
-Hint Resolve lt_irrefl : T1.
+Global Hint Resolve lt_irrefl : T1.
 
 
 Lemma lt_inv_nb : forall a n n' b b',
@@ -899,7 +899,7 @@ Proof.
     eapply lt_trans;eauto.
 Qed.
 
-Hint Resolve lt_le_incl le_refl : T1.
+Global Hint Resolve lt_le_incl le_refl : T1.
 
 
 Lemma lt_inv_le : forall a n b a' n' b', 
@@ -929,7 +929,7 @@ Proof.
  -  auto with T1.
 Qed.
 
-Hint Resolve zero_le le_tail : T1.
+Global Hint Resolve zero_le le_tail : T1.
 
 Theorem le_phi0 : forall a n  b , 
                     le (phi0 a) (ocons a n b).
@@ -1332,7 +1332,7 @@ Proof. now  destruct 1. Qed.
 Lemma LE_le alpha beta : alpha t1<= beta -> le alpha beta.
 Proof. now destruct 1. Qed.
 
-Hint Resolve LT_nf_r LT_nf_l LT_lt LE_nf_r LE_nf_l LE_le : T1.
+Global Hint Resolve LT_nf_r LT_nf_l LT_lt LE_nf_r LE_nf_l LE_le : T1.
 
 Lemma not_zero_lt : forall alpha, nf alpha -> alpha <> zero -> zero t1< alpha.
 Proof.
@@ -1407,7 +1407,7 @@ Lemma LT4 : forall alpha  n  beta beta',
     ocons alpha n beta t1< ocons alpha n beta'.
 Proof.   repeat split; auto; apply tail_lt.  destruct H1; tauto. Qed.
 
-Hint Resolve LT1 LT2 LT3 LT4: T1.
+Global Hint Resolve LT1 LT2 LT3 LT4: T1.
 
 
 Lemma LT_irrefl (alpha : T1) : ~ alpha t1< alpha.
@@ -1451,9 +1451,9 @@ Proof.
   intros; apply ocons_nf; auto; destruct H;tauto.
 Qed.
 
-Hint Resolve nf_ocons_LT: T1.
+Global Hint Resolve nf_ocons_LT: T1.
 
-Hint Resolve nf_inv1 nf_inv2 nf_inv3 : T1.
+Global Hint Resolve nf_inv1 nf_inv2 nf_inv3 : T1.
 
 Lemma head_LT_cons : forall alpha n beta, nf (ocons alpha n beta) ->
                                           alpha t1< ocons alpha n beta.
@@ -1552,7 +1552,7 @@ Qed.
 Module Direct_proof.
   Section well_foundedness_proof.
     
-    Hint Unfold restrict LT: T1.
+    Local Hint Unfold restrict LT: T1.
 
     Lemma Acc_zero : Acc LT  zero.
     Proof.
@@ -2673,7 +2673,7 @@ Proof. compute; auto with T1. Qed.
 
 
 
-Hint Resolve nf_phi0 : T1.
+Global Hint Resolve nf_phi0 : T1.
 
 Definition omega_omega := phi0 omega.
 
@@ -3475,7 +3475,7 @@ Proof.
 Qed.
 
 
-Hint Resolve limitb_not_zero : T1.
+Global Hint Resolve limitb_not_zero : T1.
 
 
 Lemma limitb_succ_tail :

--- a/theories/ordinals/Gamma0/Gamma0.v
+++ b/theories/ordinals/Gamma0/Gamma0.v
@@ -36,7 +36,7 @@ Proof.
   inversion_clear 1;auto with T2.
 Qed.
 
-Hint Resolve nf_a nf_b nf_c : T2.
+Global Hint Resolve nf_a nf_b nf_c : T2.
 
 Ltac nf_inv := ((eapply nf_a; eassumption)|| 
                 (eapply nf_b; eassumption)|| 
@@ -93,7 +93,7 @@ Proof.
   case gamma;auto with arith T2.
 Qed.
 
-Hint Resolve psi_le_cons le_zero_alpha: T2.
+Global Hint Resolve psi_le_cons le_zero_alpha: T2.
 
 Lemma le_psi_term_le : forall alpha beta, alpha t2<= beta ->
                                           psi_term alpha t2<= psi_term beta.
@@ -209,7 +209,7 @@ Section lemmas_on_length.
 
 End lemmas_on_length.
 
-Hint Resolve tricho_lt_7 tricho_lt_5 tricho_lt_4 tricho_lt_4' tricho_lt_3 tricho_lt_2 tricho_lt_2 : T2.
+Global Hint Resolve tricho_lt_7 tricho_lt_5 tricho_lt_4 tricho_lt_4' tricho_lt_3 tricho_lt_2 tricho_lt_2 : T2.
 
 Open Scope T2_scope.
 
@@ -627,7 +627,7 @@ Proof.
   - eapply psi_le_cons.
 Qed.
 
-Hint Resolve lt_beta_cons lt_alpha_cons : T2.
+Global Hint Resolve lt_beta_cons lt_alpha_cons : T2.
 
 Lemma le_cons_tail alpha beta n gamma gamma':
   gamma t2<= gamma' -> 
@@ -674,7 +674,7 @@ Proof.
   case a; case b; auto with T2.
 Qed.
 
-Hint Resolve le_one_cons : T2.
+Global Hint Resolve le_one_cons : T2.
 
 Lemma fin_lt_omega : forall n, fin  n t2<  omega.
 Proof.
@@ -818,7 +818,7 @@ Arguments compare_Lt [alpha beta].
 Arguments compare_Eq [alpha beta].
 
 
-Hint Resolve compare_Eq compare_Lt compare_Gt : T2.
+Global Hint Resolve compare_Eq compare_Lt compare_Gt : T2.
 
 Lemma compare_rw_lt  alpha beta : alpha t2< beta ->
                                   compare alpha beta = Lt.
@@ -1186,7 +1186,7 @@ Qed.
 
 
 
-Hint Resolve T2_size1 T2_size2 T2_size3 T2_size4 : T2.
+Global Hint Resolve T2_size1 T2_size2 T2_size3 T2_size4 : T2.
 
 
 (** let us recall subterm properties on T2 *)
@@ -1198,7 +1198,7 @@ Proof.
   intros; apply lt_trans with (gcons a b' n' c');auto with T2 .
 Qed.
 
-Hint Resolve nat_lt_cons lt_subterm1 : T2.
+Global Hint Resolve nat_lt_cons lt_subterm1 : T2.
 
 
 Lemma nat_2_term_mono : forall n n', (n < n')%nat -> 
@@ -1589,7 +1589,7 @@ Section lt_incl_rpo.
   Remark nf_b2 : nf b2.
   Proof. nf_inv. Qed.
 
-  Hint Resolve nf1 nf2 nf_a1 nf_a2 nf_b1 nf_b2 : T2.
+  Local Hint Resolve nf1 nf2 nf_a1 nf_a2 nf_b1 nf_b2 : T2.
 
   Remark nf_c1 : nf c1.
   Proof.  nf_inv.  Qed.
@@ -1597,7 +1597,7 @@ Section lt_incl_rpo.
   Remark nf_c2 : nf c2.
   Proof. nf_inv.  Qed.
 
-  Hint Resolve nf_c1 nf_c2 : T2.
+  Local Hint Resolve nf_c1 nf_c2 : T2.
 
   Hypothesis H : gcons a1 b1 n1 c1 t2< gcons a2 b2 n2 c2.
 
@@ -1885,14 +1885,14 @@ Proof.
   split; destruct y; try contradiction.
 Qed.
 
-Hint Resolve R1 : T2.
+Global Hint Resolve R1 : T2.
 
 Remark R2 : Acc P.prec ord_zero.
 Proof.
   split; destruct y; try contradiction; auto with T2.
 Qed.
 
-Hint Resolve R2 : T2.
+Global Hint Resolve R2 : T2.
 
 Remark R3 : Acc P.prec nat_S.
 Proof.
@@ -1900,21 +1900,21 @@ Proof.
 Qed.
 
 
-Hint Resolve R3 : T2.
+Global Hint Resolve R3 : T2.
 
 Remark R4 : Acc P.prec ord_cons.
 Proof.
   split; destruct y; try contradiction;auto with T2.
 Qed.
 
-Hint Resolve R4 : T2.
+Global Hint Resolve R4 : T2.
 
 Remark R5 : Acc P.prec ord_psi.
 Proof.
   split; destruct y; try contradiction;auto with T2.
 Qed.
 
-Hint Resolve R5 : T2.
+Global Hint Resolve R5 : T2.
 
 Theorem well_founded_rpo : well_founded rpo.
 Proof.
@@ -1926,7 +1926,7 @@ Section  well_founded.
   
   Let R := restrict  nf lt.
 
-  Hint Unfold restrict R : T2.
+  Local Hint Unfold restrict R : T2.
 
   Lemma R_inc_rpo : forall o o', R o o' -> rpo (T2_2_term o) (T2_2_term o').
   Proof.

--- a/theories/ordinals/Gamma0/T2.v
+++ b/theories/ordinals/Gamma0/T2.v
@@ -69,7 +69,7 @@ Inductive is_finite:  T2 ->  Set :=
  zero_finite : is_finite zero
 |succ_finite : forall n, is_finite (gcons zero zero n zero).
 
-Hint Constructors is_finite : T2.
+Global Hint Constructors is_finite : T2.
 
 Notation "'omega'"  := [zero,one] : T2_scope.
 
@@ -146,10 +146,10 @@ lt_7 : forall alpha1 beta1 n1   gamma1 gamma2,
     gcons alpha1 beta1 n1 gamma1 t2< gcons alpha1 beta1 n1 gamma2
 where  "o1 t2< o2" := (lt o1 o2): T2_scope.
 
-Hint Constructors lt : T2.
+Global Hint Constructors lt : T2.
 
 Definition le t t' := t = t' \/ t t2< t'.
-Hint Unfold le : T2.
+Global Hint Unfold le : T2.
 
 Notation "o1 t2<= o2" := (le o1 o2): T2_scope.
 
@@ -214,7 +214,7 @@ Inductive nf : T2 -> Prop :=
                              nf a -> nf b -> 
                              nf(gcons a' b' n' c')-> 
                              nf(gcons a b n (gcons a' b' n' c')).
-Hint Constructors nf : T2. 
+Global Hint Constructors nf : T2. 
 
 Lemma  nf_fin i : nf (fin i).
 Proof.

--- a/theories/ordinals/Hydra/Epsilon0_Needed_Free.v
+++ b/theories/ordinals/Hydra/Epsilon0_Needed_Free.v
@@ -25,7 +25,7 @@ Section Impossibility_Proof.
           (Hy : BoundedVariant Var mu).
 
 
-  Hint Resolve nf_m : hydra.
+  Local Hint Resolve nf_m : hydra.
   Let big_h := big_h mu.
   Let small_h := small_h mu m.
   

--- a/theories/ordinals/Hydra/Epsilon0_Needed_Generic.v
+++ b/theories/ordinals/Hydra/Epsilon0_Needed_Generic.v
@@ -28,7 +28,7 @@ Section Bounded.
     intro h0; now destruct (m_bounded h0).
   Qed.
 
-  Hint Resolve Rem0 : hydra.
+  Local Hint Resolve Rem0 : hydra.
   
 
 

--- a/theories/ordinals/Hydra/Hydra_Termination.v
+++ b/theories/ordinals/Hydra/Hydra_Termination.v
@@ -57,7 +57,7 @@ Proof with auto with T1.
   apply nf_phi0; now  apply m_nf.   
 Qed.   
 
-Hint Resolve m_nf nf_phi0 ms_nf : T1.
+Global Hint Resolve m_nf nf_phi0 ms_nf : T1.
 
 Lemma ms_eqn3 :  forall h n s,  ms (hcons_mult h  n s) =
                                 o_finite_mult n (phi0 (m h)) o+ ms s.

--- a/theories/ordinals/Hydra/Omega2_Small.v
+++ b/theories/ordinals/Hydra/Omega2_Small.v
@@ -33,7 +33,7 @@ Section Impossibility_Proof.
     (** *** Proof of the inequality [m small_h o< m big_h] 
      *)
 
-  Hint Constructors R1 S1 S2 : hydra.
+  Local Hint Constructors R1 S1 S2 : hydra.
 
   Lemma m_big_h_not_null : m big_h <> zero.
   Proof.
@@ -118,9 +118,9 @@ Section Impossibility_Proof.
  (*m_strict_mono m Hvar*) 
 
 
-Hint Constructors step clos_trans_1n : hydra.
-Hint Resolve lex_1 lex_2: hydra.
-Hint Unfold   lt : hydra.
+Local Hint Constructors step clos_trans_1n : hydra.
+Local Hint Resolve lex_1 lex_2: hydra.
+Local Hint Unfold lt : hydra.
 
 
 Lemma step_to_battle : forall p q, step p q -> iota p -+-> iota q.
@@ -128,7 +128,7 @@ Proof.
   destruct 1; [ apply succ_rounds |  apply limit_rounds].
 Qed.
 
-Hint Resolve step_to_battle : hydra. 
+Local Hint Resolve step_to_battle : hydra.
 
 
 Lemma m_ge : m big_h o<= m small_h.

--- a/theories/ordinals/Hydra/Omega_Small.v
+++ b/theories/ordinals/Hydra/Omega_Small.v
@@ -62,7 +62,7 @@ Section Impossibility_Proof.
     exists (m big_h); right;  repeat constructor.     
   Qed.
 
-  Hint Resolve big_to_small : hydra.
+  Local Hint Resolve big_to_small : hydra.
 
   
   Lemma m_lt : m small_h < m big_h.

--- a/theories/ordinals/OrdinalNotations/ON_Generic.v
+++ b/theories/ordinals/OrdinalNotations/ON_Generic.v
@@ -79,7 +79,7 @@ Proof.
   apply wf.
 Defined.
 
-Hint Resolve wf_measure : core.
+Global Hint Resolve wf_measure : core.
 
 
 Definition ZeroLimitSucc_dec {A:Type}{lt: relation A}

--- a/theories/ordinals/OrdinalNotations/ON_Omega2.v
+++ b/theories/ordinals/OrdinalNotations/ON_Omega2.v
@@ -93,8 +93,8 @@ Proof.
   destruct alpha; right; cbn; abstract lia.
 Qed.
 
-Hint Constructors clos_refl lexico : O2.
-Hint Unfold lt le : O2.
+Global Hint Constructors clos_refl lexico : O2.
+Global Hint Unfold lt le : O2.
 
 
 

--- a/theories/ordinals/OrdinalNotations/ON_mult.v
+++ b/theories/ordinals/OrdinalNotations/ON_mult.v
@@ -44,9 +44,9 @@ Definition compare (alpha beta: t) : comparison :=
   | c => c
   end.
 
-Hint Constructors clos_refl lexico: core.
+Local Hint Constructors clos_refl lexico: core.
 
-Hint Unfold  lt le : core.
+Local Hint Unfold  lt le : core.
 
 
 (** * Properties *)

--- a/theories/ordinals/OrdinalNotations/ON_plus.v
+++ b/theories/ordinals/OrdinalNotations/ON_plus.v
@@ -39,8 +39,8 @@ Definition lt : relation t := le_AsB _ _ ltA ltB.
 
 Definition le := clos_refl _ lt.
 
-Hint Unfold lt le : core.
-Hint Constructors le_AsB: core.
+Local Hint Unfold lt le : core.
+Local Hint Constructors le_AsB: core.
 
 Instance lt_strorder : StrictOrder lt.
 Proof.

--- a/theories/ordinals/Prelude/MoreLists.v
+++ b/theories/ordinals/Prelude/MoreLists.v
@@ -274,7 +274,7 @@ Qed.
 
 
 
-Hint Constructors sorted_ge : lists.
+Global Hint Constructors sorted_ge : lists.
 
 
 Lemma sorted_inv_gt : forall n p s, sorted_ge n (p::s) ->

--- a/theories/ordinals/Prelude/Sort_spec.v
+++ b/theories/ordinals/Prelude/Sort_spec.v
@@ -127,7 +127,7 @@ End R_given.
 
 
 Arguments LocallySorted {A} _ _.
-Hint Constructors LocallySorted : lists.
+Global Hint Constructors LocallySorted : lists.
 
 (** A sort must work on any decidable total pre-order *)
 

--- a/theories/ordinals/Schutte/AP.v
+++ b/theories/ordinals/Schutte/AP.v
@@ -104,7 +104,7 @@ Proof with auto with schutte.
 Qed.
 
 
-Hint Resolve zero_lt_omega : schutte.
+Global Hint Resolve zero_lt_omega : schutte.
 
 Lemma AP_finite_eq_one : forall n: nat, AP n -> n = 1.
 Proof with auto with schutte.
@@ -210,7 +210,7 @@ Section AP_Unbounded.
       
   Qed.
 
-  Hint Resolve mono_seq mono_seq2 : schutte.
+  Local Hint Resolve mono_seq mono_seq2 : schutte.
 
 
   Remark alpha_lt_beta : alpha < beta.

--- a/theories/ordinals/Schutte/CNF.v
+++ b/theories/ordinals/Schutte/CNF.v
@@ -49,8 +49,8 @@ Definition exponents_le (alpha : Ord) :=
 
 (* begin hide *)
 
-Hint Constructors LocallySorted : schutte.
-Hint Unfold sorted : schutte.
+Global Hint Constructors LocallySorted : schutte.
+Global Hint Unfold sorted : schutte.
 
 (* end hide *)
 

--- a/theories/ordinals/Schutte/Ordering_Functions.v
+++ b/theories/ordinals/Schutte/Ordering_Functions.v
@@ -129,7 +129,7 @@ Lemma ordering_function_mono (f : Ord -> Ord) (A B: Ensemble Ord) :
     In A alpha -> In A beta -> alpha < beta -> f alpha < f beta.
 Proof.  destruct 1 ;  tauto. Qed.
 
-Hint Resolve ordering_function_mono : schutte.
+Global Hint Resolve ordering_function_mono : schutte.
 
 Lemma  ordering_function_mono_weak (f : Ord -> Ord) (A B: Ensemble Ord) : 
  ordering_function f A B ->
@@ -141,7 +141,7 @@ Proof.
  -  right;auto.
 Qed.
 
-Hint Resolve ordering_function_mono_weak : schutte.
+Global Hint Resolve ordering_function_mono_weak : schutte.
 
 Lemma ordering_function_monoR : forall f A B, ordering_function f A B ->
    forall a b, In A a -> In A b -> f a < f b -> a < b.
@@ -151,7 +151,7 @@ Proof.
   - destruct (@lt_irr (f a)); apply lt_trans with (f b);auto.
 Qed.
 
-Hint Resolve ordering_function_monoR : schutte.
+Global Hint Resolve ordering_function_monoR : schutte.
 
 
 Lemma Ordering_bijection : forall f A B, ordering_function f A B ->
@@ -180,7 +180,7 @@ Proof with auto with schutte.
   -  right; eapply ordering_function_monoR; eauto.
 Qed.
 
-Hint Resolve ordering_function_mono_weakR : schutte.
+Global Hint Resolve ordering_function_mono_weakR : schutte.
 
 
 Lemma ordering_function_seg : forall A B, ordering_segment A B ->
@@ -252,7 +252,7 @@ Section ordering_function_unicity_1.
  Remark SA2 : segment A2.
  Proof.  case O2;intuition.  Qed.
  
- Hint Resolve SA2 SA1 : schutte.
+ Local Hint Resolve SA2 SA1 : schutte.
 
   Lemma A1_A2 :forall a, In A1 a -> A2 a /\ f1 a = f2 a.
  Proof with eauto with schutte.
@@ -456,7 +456,7 @@ Section building_ordering_function_1.
   apply AX2; exists beta;  destruct 1;tauto.
  Qed.
 
-Hint Resolve  of_beta': schutte.
+ Local Hint Resolve of_beta': schutte.
 
 Remark A_denum : countable _A.
 Proof.
@@ -658,7 +658,7 @@ Qed.
       case (@lt_irr _ H2).
  Qed.
 
- Hint Resolve g_bij : schutte.
+ Local Hint Resolve g_bij : schutte.
 
 
 Let g_1 := inv_fun inh_Ord B (image B g) g.
@@ -668,7 +668,7 @@ Proof.
  unfold  g_1; apply inv_fun_bij; auto with schutte.
 Qed.
 
-Hint Resolve g_1_bij : schutte.
+Local Hint Resolve g_1_bij : schutte.
 
 
 Lemma g_1_of : ordering_function g_1 (image B g) B.
@@ -1016,7 +1016,7 @@ Proof with eauto with schutte.
 Qed.
 
 
-Hint Resolve  alpha_A : schutte.
+Local Hint Resolve  alpha_A : schutte.
  
 Remark R7 : |_| U <= alpha_ .
 Proof. 

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -18,7 +18,7 @@ Declare Scope schutte_scope.
 
 Set Implicit Arguments.
 
-Hint Unfold In : schutte.
+Global Hint Unfold In : schutte.
 Arguments Included [U] _ _.
 Arguments countable [U] _.
 Arguments Same_set [U] _ _.
@@ -39,7 +39,7 @@ Infix "<" := lt : schutte_scope.
 Definition ordinal : Ensemble Ord := Full_set Ord.
 Definition big0 alpha : Ensemble Ord := fun beta =>  beta < alpha.
 
-Hint Unfold ordinal : schutte.
+Global Hint Unfold ordinal : schutte.
 
 (* begin hide *)
 Lemma ordinal_ok : forall a : Ord, ordinal a.
@@ -49,14 +49,14 @@ Qed.
 
 (* end hide *)
 
-Hint Resolve ordinal_ok : schutte. 
+Global Hint Resolve ordinal_ok : schutte. 
 
 (** * The three axioms by Schutte *)
 
 (** First Schutte's axiom  : Ord is well-ordered wrt lt *)
 
 Axiom AX1 : WO lt.
-Hint Resolve AX1 : schutte. 
+Global Hint Resolve AX1 : schutte. 
 
 Global Instance WO_ord : WO  lt := AX1.
 
@@ -83,7 +83,7 @@ Qed.
 
 
 
-Hint Resolve  AX1 Inh_Ord_Ord Inh_OSets inh_Ord : schutte.
+Global Hint Resolve  AX1 Inh_Ord_Ord Inh_OSets inh_Ord : schutte.
 
 Definition le := Le lt.
 
@@ -242,7 +242,7 @@ Proof.
   left;auto.
 Qed.
 
-Hint Resolve le_refl : schutte.
+Global Hint Resolve le_refl : schutte.
 
 Lemma eq_le : forall a b : Ord,  a = b -> a <= b.
 Proof.
@@ -291,7 +291,7 @@ Proof.
   -  intros H0 H1;case (@lt_irr a);eapply lt_trans;eauto.
 Qed.
 
-Hint Resolve eq_le lt_le lt_trans le_trans le_lt_trans 
+Global Hint Resolve eq_le lt_le lt_trans le_trans le_lt_trans 
      lt_le_trans lt_irr le_not_gt:
   schutte.
 
@@ -335,7 +335,7 @@ Proof.
   intros a b  H1; tricho a b H2; auto with schutte;  contradiction.  
 Qed.
 
-Hint Unfold Included : schutte.
+Global Hint Unfold Included : schutte.
 
 (** ** Global properties *)
 
@@ -438,7 +438,7 @@ Proof.
   destruct  (succ_ok  alpha);  tauto.
 Qed.
 
-Hint Resolve lt_succ : schutte.
+Global Hint Resolve lt_succ : schutte.
 
 Lemma lt_succ_le (alpha beta : Ord):
   alpha < beta -> succ alpha <= beta.
@@ -505,7 +505,7 @@ Proof.
 Qed.
 
 
-Hint Resolve zero_lt_succ zero_le : schutte.
+Global Hint Resolve zero_lt_succ zero_le : schutte.
 
 (** Less than finite is finite ... *)
 
@@ -529,7 +529,7 @@ Proof.
      simpl (finite (S m)); apply lt_succ; auto with schutte.
 Qed.
 
-Hint Resolve finite_mono : schutte.
+Global Hint Resolve finite_mono : schutte.
 
 Lemma finite_inj : forall i j, F i = F j -> i = j.
 Proof.
@@ -779,13 +779,13 @@ Proof.
     rewrite H0;intro;case (@Lt_irreflexive  Ord lt AX1 (s j));auto.
 Qed.
 
-Hint Resolve Countable.seq_range_countable seq_mono_intro : schutte.
+Global Hint Resolve Countable.seq_range_countable seq_mono_intro : schutte.
 
 
 Lemma In_full {A:Type} (a:A) : In (Full_set A ) a.
 Proof. split. Qed.
 
-Hint Resolve In_full: core.
+Global Hint Resolve In_full: core.
 
 Lemma lt_omega_limit (s : nat -> Ord) :
   seq_mono s -> forall i, s i <  omega_limit s.
@@ -918,7 +918,7 @@ Proof.
  apply AX2;   now exists alpha.
 Qed.
 
-Hint Resolve countable_members : schutte.
+Global Hint Resolve countable_members : schutte.
 
 Lemma le_sup_members (alpha : Ord) :  |_| (members alpha) <= alpha.
 Proof.

--- a/theories/ordinals/Schutte/Well_Orders.v
+++ b/theories/ordinals/Schutte/Well_Orders.v
@@ -13,7 +13,7 @@ Arguments In [U].
 Arguments Included [U].
 
 Set Implicit Arguments.
-Hint Unfold In : core.
+Global Hint Unfold In : core.
 
 
 Section the_context.

--- a/theories/ordinals/primrec/primRec.v
+++ b/theories/ordinals/primrec/primRec.v
@@ -1446,7 +1446,7 @@ Qed.
 
 Lemma beq_nat_not_refl : forall a b : nat, a <> b -> beq_nat a b = false.
 Proof.
-double induction a b.
+induction a; destruct b.
 intros.
 elim H.
 auto.

--- a/theories/ordinals/rpo/list_permut.v
+++ b/theories/ordinals/rpo/list_permut.v
@@ -98,8 +98,8 @@ Proof.
 unfold list_permut, meq; intros; apply sym_eq; trivial.
 Qed.
 
-Hint Immediate list_permut_refl : core.
-Hint Resolve list_permut_sym : core.
+Global Hint Immediate list_permut_refl : core.
+Global Hint Resolve list_permut_sym : core.
 
 (** Transitivity. *)
 Theorem list_permut_trans :


### PR DESCRIPTION
I used Pierre-Marie Pédrot's script to add explicit locality to hints (otherwise, there is a warning in 8.13). I also fix or ignore some other warnings that are standard. This lessens the noise generated in CI considerably.