### PR TITLE
enable building with Coq master in CI

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'mathcomp/mathcomp-dev:coq-dev'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
           - 'mathcomp/mathcomp:1.12.0-coq-8.12'
           - 'mathcomp/mathcomp:1.11.0-coq-8.11'

--- a/coq-addition-chains.opam
+++ b/coq-addition-chains.opam
@@ -15,10 +15,10 @@ with the least number of multiplication as possible. We present a few implementa
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.11" & < "8.14~"}
-  "coq-paramcoq" {>= "1.1.2" & < "1.2~"}
-  "coq-mathcomp-ssreflect" {>= "1.11.0" & < "1.13~"}
-  "coq-mathcomp-algebra" {>= "1.11.0" & < "1.13~"}
+  "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
+  "coq-paramcoq" {(>= "1.1.2" & < "1.2~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.11.0" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-algebra"
 ]
 
 tags: [

--- a/coq-hydra-battles.opam
+++ b/coq-hydra-battles.opam
@@ -18,14 +18,16 @@ properties of epsilon0)."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {>= "8.11" & < "8.14~"}
-  "coq-equations" {>= "1.2" & < "1.3~"}
+  "coq" {(>= "8.11" & < "8.14~") | (= "dev")}
+  "coq-equations" {(>= "1.2" & < "1.3~") | (= "dev")}
 ]
 
 tags: [
   "category:Mathematics/Combinatorics and Graph Theory"
+  "category:Mathematics/Logic/Foundations"
   "keyword:Ketonen-Solovay machinery"
   "keyword:ordinals"
+  "keyword:primitive recursive functions"
   "logpath:hydras"
 ]
 authors: [

--- a/meta.yml
+++ b/meta.yml
@@ -41,10 +41,12 @@ license:
   identifier: MIT
 
 supported_coq_versions:
-  text: 8.11 to 8.13
-  opam: '{>= "8.11" & < "8.14~"}'
+  text: 8.11 or later
+  opam: '{(>= "8.11" & < "8.14~") | (= "dev")}'
 
 tested_coq_opam_versions:
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.12'
@@ -55,16 +57,18 @@ tested_coq_opam_versions:
 dependencies:
 - opam:
     name: coq-equations
-    version: '{>= "1.2" & < "1.3~"}'
+    version: '{(>= "1.2" & < "1.3~") | (= "dev")}'
   description: |-
-    [Equations](https://github.com/mattam82/Coq-Equations) 1.2
+    [Equations](https://github.com/mattam82/Coq-Equations) 1.2 or later
 
 namespace: hydras
 
 keywords:
 - name: Ketonen-Solovay machinery
 - name: ordinals
+- name: primitive recursive functions
 
 categories:
 - name: Mathematics/Combinatorics and Graph Theory
+- name: Mathematics/Logic/Foundations
 ---


### PR DESCRIPTION
For many projects, it can be valuable to build with Coq master in CI. We also want to test goedel against Coq master periodically, which is not possible without this change in opam files.