### PR TITLE
Snippeting chapter9

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -14,6 +14,7 @@ theories/ordinals/OrdinalNotations/ON_plus.v
 theories/ordinals/OrdinalNotations/ON_O.v
 theories/ordinals/OrdinalNotations/ON_Omega2.v
 theories/ordinals/OrdinalNotations/Example_3PlusOmega.v
+theories/ordinals/OrdinalNotations/OmegaOmega.v
 theories/ordinals/Prelude/Comparable.v
 theories/ordinals/Prelude/First_toggle.v
 theories/ordinals/Prelude/Simple_LexProd.v
@@ -68,7 +69,6 @@ theories/ordinals/Schutte/Correctness_E0.v
 theories/ordinals/Schutte/PartialFun.v
 theories/ordinals/Schutte/Lub.v
 theories/ordinals/Schutte/GRelations.v
-theories/ordinals/OmegaOmega/OO.v
 theories/ordinals/Hydra/Battle_length.v
 theories/ordinals/Hydra/Omega_Small.v
 theories/ordinals/Hydra/BigBattle.v

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -54,19 +54,19 @@ than 45K lines of scripts. The part dedicated to primitive recursive functions a
 Thus, we propose a partial exploration of this library, through examples and exercises. Our additions to the original library --- mainly examples and counter-examples ---,
 are stored in the directory \texttt{theories/ordinals/MoreAck}.
 
-In particular, the library \href{../theories/html/hydras.MoreAck.AckNotPR.html}{MoreAck.AckNotPR} contains the well-known  proof that the Ackermann function is not primitive recursive (see Section~\vref{sect:ack-not-PR}).
-MoreOver, the library \href{../theories/html/hydras.Hydra.Hydra_Theorems.html}{Hydra.Hydra\_Theorems} contains 
+In particular, the library \href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/MoreAck/AckNotPR.v}{MoreAck.AckNotPR} contains the well-known  proof that the Ackermann function is not primitive recursive (see Section~\vref{sect:ack-not-PR}).
+Moreover, the library \href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Hydra/Hydra_Theorems.v}{Hydra.Hydra\_Theorems} contains 
 a proof that the length of an hydra battle (according to the initial replication factor) is not primitive recursive in general.
 
 \section{Basic definitions}
 \index{maths}{Primitive recursive functions}
 
 The formal definition of primitive recursive functions lies in the library
-\href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec},
+\href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Ackermann/primRec.v}{Ackermann.primRec},
 with preliminary definitions in 
-\href{../theories/html/hydras.Ackermann.extEqualNat.html}{Ackermann.extEqualNat}
+\href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Ackermann/extEqualNat.v}{Ackermann.extEqualNat}
 and
-\href{../theories/html/hydras.Ackermann.misc.html}{Ackermann.misc}.
+\href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Ackermann/misc.v}{Ackermann.misc}.
 
 \subsection{Functions of arbitrary arity}
 
@@ -399,7 +399,7 @@ Prove that the following functions are primitive recursive.
 \textbf{Hint:} You may have to look again at the lemmas of the library
 \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec} if you meet some difficulty.
 You may start this exercise with the file
-    \href{https://https://github.com/coq-community/hydra-battles/blob/master/exercises/primrec/MorePRExamples.v}{exercises/primrec/MorePRExamples.v}.
+    \href{https://github.com/coq-community/hydra-battles/blob/master/exercises/primrec/MorePRExamples.v}{exercises/primrec/MorePRExamples.v}.
 \end{exercise}
 
 
@@ -410,7 +410,7 @@ Show that the function \texttt{min: naryFunc\,2} is primitive
 recursive.
 
 \emph{You may start this exercise with
-    \href{https://https://github.com/coq-community/hydra-battles/blob/master/exercises/primrec/MinPR.v}{exercises/primrec/MinPR.v}.}
+    \href{https://github.com/coq-community/hydra-battles/blob/master/exercises/primrec/MinPR.v}{exercises/primrec/MinPR.v}.}
 
 \end{exercise}
 

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -1,4 +1,5 @@
 \chapter{Primitive recursive functions}
+\label{chapter:primrec}
 
 \section{Introduction}
 Primitive recursive functions are a small class of total functions, corresponding to the expressive power of a simple imperative programming language without \textbf{while} loops, in which every program execution terminates.
@@ -54,19 +55,19 @@ than 45K lines of scripts. The part dedicated to primitive recursive functions a
 Thus, we propose a partial exploration of this library, through examples and exercises. Our additions to the original library --- mainly examples and counter-examples ---,
 are stored in the directory \texttt{theories/ordinals/MoreAck}.
 
-In particular, the library \href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/MoreAck/AckNotPR.v}{MoreAck.AckNotPR} contains the well-known  proof that the Ackermann function is not primitive recursive (see Section~\vref{sect:ack-not-PR}).
-Moreover, the library \href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Hydra/Hydra_Theorems.v}{Hydra.Hydra\_Theorems} contains 
+In particular, the library \href{../theories/html/hydras.MoreAck.html}{MoreAck.AckNotPR} contains the well-known  proof that the Ackermann function is not primitive recursive (see Section~\vref{sect:ack-not-PR}).
+Moreover, the library \href{../theories/html/hydras.Hydra_Theorems.html}{Hydra.Hydra\_Theorems} contains 
 a proof that the length of an hydra battle (according to the initial replication factor) is not primitive recursive in general.
 
 \section{Basic definitions}
 \index{maths}{Primitive recursive functions}
 
 The formal definition of primitive recursive functions lies in the library
-\href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Ackermann/primRec.v}{Ackermann.primRec},
+\href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec},
 with preliminary definitions in 
-\href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Ackermann/extEqualNat.v}{Ackermann.extEqualNat}
+\href{../theories/html/hydras.Ackermann.extEqualNat.html}{Ackermann.extEqualNat}
 and
-\href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/Ackermann/misc.v}{Ackermann.misc}.
+\href{../theories/html/hydras.Ackermann.misc.html}{Ackermann.misc}.
 
 \subsection{Functions of arbitrary arity}
 

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -371,7 +371,19 @@ multiplication with the identity and the constant function which returns $2$.
 \emph{Note that the lemma \texttt{const1\_NIsPR} considers this function as an unary function (unlike \texttt{const0\_NIsPR})}. 
 \input{movies/snippets/PrimRecExamples/doubleIsPRa}
 
+\begin{Coqanswer}
+3 subgoals (ID 184)
+  
+  ============================
+  isPR 1 (fun _ : nat => 2)
 
+subgoal 2 (ID 185) is:
+ isPR 1 (fun x : nat => x)
+subgoal 3 (ID 186) is:
+ isPR 2 Init.Nat.mul
+\end{Coqanswer}
+
+\input{movies/snippets/PrimRecExamples/doubleIsPRb}
 
 \index{primrec}{Exercises}
 \begin{exercise}
@@ -665,9 +677,67 @@ The remaining cases are proved within a mutual  induction.
 
 \index{coq}{Mutual induction}
 
-\input{movies/snippets/AckNotPR/majorAnyPR}
+\input{movies/snippets/AckNotPR/majorAnyPRa}
 
+\begin{Coqanswer}
+ x : PrimRec m
+ x0 : nat
+ H : forall v : t nat n,
+   max_v (map (fun f : naryFunc n => v_apply f v)
+           (evalPrimRecs n m g)) <=
+   Ack x0 (max_v v)
+ x1 : nat
+ H0 : forall v : t nat m, v_apply (evalPrimRec m x) v <=
+                                  Ack x1 (max_v v)
+  ============================
+  forall v : t nat n,
+  v_apply (evalPrimRec n (composeFunc n m g x)) v <=
+  Ack (2 + Nat.max x0 x1) (max_v v)
 
+\end{Coqanswer}
+
+\input{movies/snippets/AckNotPR/majorAnyPRb}
+
+\begin{Coqanswer}
+  n : nat
+  x1 : PrimRec n
+  x2 : PrimRec (S (S n))
+  r : nat
+  Hg : forall v : t nat n,
+     v_apply (evalPrimRec n x1) v <= Ack r (max_v v)
+  s : nat
+  Hh : forall v : t nat (S (S n)),
+       v_apply (evalPrimRec (S (S n)) x2) v <= Ack s (max_v v)
+  ============================
+  majorizedPR (primRecFunc n x1 x2) Ack
+\end{Coqanswer}
+
+The las two goals deal with vectors of functions.
+
+\begin{Coqanswer}
+1 subgoal (ID 289)
+  
+  n : nat
+  ============================
+  majorizedSPR (PRnil n) Ack
+
+\end{Coqanswer}
+
+\begin{Coqanswer}
+1 subgoal (ID 296)
+  
+  n, m : nat
+  x : PrimRec n
+  p : PrimRecs n m
+  IHx : majorizedPR x Ack
+  IHx0 : majorizedSPR p Ack
+  ============================
+  majorizedSPR (PRcons n m x p) Ack
+\end{Coqanswer}
+
+\begin{Coqsrc}
+Qed.
+\end{Coqsrc}
 
 \subsection{Looking for a contradiction}
 
@@ -767,7 +837,7 @@ $H'_{\omega^\alpha}(k)\geq F_\alpha(k)$.
 \input{movies/snippets/F_alpha/HprimeF}
 
 
-Our proof of this lemma is not trivial at all, it uses some properties of the Ketonen-Solovay's toolkit. We advise the reader to explore this proof, with the help of an ide or softwre like alectryon.
+Our proof of this lemma is not trivial at all, it uses some properties of the Ketonen-Solovay's toolkit. We advise the reader to explore this proof, with the help of an ide or software like alectryon.
 %%
 %%% To move the path chapter
 %%%%
@@ -834,16 +904,18 @@ Our proof of this lemma is not trivial at all, it uses some properties of the Ke
 
 We finish the proof by comparing several fast growing functions.
 
+\vspace{4pt}
+
 \emph{From \href{../theories/html/hydras.Epsilon0.L_alpha.html}{Epsilon0.L\_alpha}}
 
 \input{movies/snippets/L_alpha/HprimeL}
 
+\vspace{4pt}
+
 \emph{From \href{../theories/html/hydras.Epsilon0.F_omega.html}{Epsilon0.F\_omega}}
-
-
 \input{movies/snippets/F_omega/FVsAck}
 
-
+\vspace{4pt}
 
 By transitivity, we get the inequality
 $F_\omega(k+1)\leq m(k+1)$, for any $k$.
@@ -856,6 +928,8 @@ We finish the proof by noting that the function $m$ (composed with \texttt{S}) d
 \input{movies/snippets/Hydra_Theorems/mDominatesAck}
 
 \input{movies/snippets/Hydra_Theorems/SmNotPR}
+
+\vspace{4pt}
 
 \input{movies/snippets/Hydra_Theorems/LNotPR}
 

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -209,99 +209,28 @@ the arity is fixed, these definitions behave well w.r.t.
 \vspace{4pt}
 \noindent
 \emph{From \href{../theories/html/hydras.MoreAck.PrimRecExamples.html}{MoreAck.PrimRecExamples}.}
-\begin{Coqsrc}
-Example Ex1 : evalPrimRec 0 zeroFunc = 0.
-Proof. reflexivity. Qed.
 
-Example Ex2 a : evalPrimRec 1 succFunc a = S a.
-Proof. reflexivity. Qed.
+\input{movies/snippets/PrimRecExamples/evalPrimRecEx}
 
-Example Ex3 a b c d e f: forall (H: 2 < 6),
-    evalPrimRec 6
-                (projFunc 6 2 H) a b c d e f = d.
-Proof. reflexivity. Qed.
-
-Example Ex4 (x y z : PrimRec 2) (t: PrimRec 3):
-  let u := composeFunc 2 3
-                       (PRcons 2 _ x
-                               (PRcons 2 _ y
-                                       (PRcons 2 _ z
-                                               (PRnil 2))))
-                       t in
-  let f := evalPrimRec 2 x in
-  let g := evalPrimRec 2 y in
-  let h := evalPrimRec 2 z in
-  let i := evalPrimRec 3 t in
-  let j := evalPrimRec 2 u in
-  forall a b, j a b = i (f a b) (g a b) (h a b).
-Proof. reflexivity. Qed.
-
-Example Ex5 (x : PrimRec 2)(y: PrimRec 4):
-  let g := evalPrimRec _ x in
-  let h := evalPrimRec _ y in
-  let f := evalPrimRec _ (primRecFunc _ x y) in
-  forall a b,  f 0 a b = g a b.
-Proof. reflexivity.   Qed.                          
-
-Example Ex6 (x : PrimRec 2)(y: PrimRec 4):
-  let g := evalPrimRec _ x in
-  let h := evalPrimRec _ y in
-  let f := evalPrimRec _ (primRecFunc _ x y) in
-  forall n a b,  f (S n) a b = h n (f n a b) a b.
-Proof. reflexivity.   Qed.                          
-\end{Coqsrc}
-
+\vspace{4pt}
+\noindent
 
 Another example?
 Let us consider the following term\footnote{Of course, we never typed this term \emph{verbatim}; we obtained it by an interactive proof the reader will be able to make after 
 reading Sect.\vref{sect:proofs-of-isPR}.}:
 
 \label{sect:bigfac}
-\begin{Coqsrc}
-Example bigPR : PrimRec 1 :=
-primRecFunc 0
-  (composeFunc 0 1 (PRcons 0 0 zeroFunc (PRnil 0)) succFunc)
-  (composeFunc 2 2
-    (PRcons 2 1
-      (composeFunc 2 1
-         (PRcons 2 0 (projFunc 2 1 (le_n 2))
-                 (PRnil 2))
-         succFunc)
-      (PRcons 2 0
-        (composeFunc 2 1
-          (PRcons 2 0
-             (projFunc 2 0
-                       (le_S 1 1 (le_n 1)))
-             (PRnil 2))
-          (projFunc 1 0 (le_n 1))) (PRnil 2)))
-    (primRecFunc 1 (composeFunc 1 0 (PRnil 1) zeroFunc)
-       (composeFunc 3 2
-         (PRcons 3 1
-            (projFunc 3 1 (le_S 2 2 (le_n 2)))
-            (PRcons 3 0 (projFunc 3 0
-                          (le_S 1 2
-                                (le_S 1 1 (le_n 1))))
-                    (PRnil 3)))
-         (primRecFunc 1 (projFunc 1 0 (le_n 1))
-                      (composeFunc 3 1
-                          (PRcons 3 0
-                                  (projFunc 3 1 (le_S 2 2 (le_n 2)))
-                                  (PRnil 3))
-                          succFunc))))). 
-\end{Coqsrc}
+
+\input{movies/snippets/PrimRecExamples/bigPRa}
+
 
 Let us now interpret this term as an arithmetic function.
 
-\begin{Coqsrc}
-Example  mystery_fun : nat -> nat := evalPrimRec 1 bigPR.
+\vspace{4pt}
+\noindent
 
-Compute map mystery_fun[0;1;2;3;4;5;6] : t nat _.
-\end{Coqsrc}
+\input{movies/snippets/PrimRecExamples/bigPRb}
 
-\begin{Coqanswer}
- = 1 :: 1 :: 2 :: 6 :: 24 :: 120 :: 720 :: nil
-     : t nat 7
-\end{Coqanswer}
 
 After this test, the term \texttt{bigPR} looks to be a primitive recursive definition of the factorial function, although we haven't proved this fact yet. Fortunately, we will see in the following sections simple ways to prove that a given function is primitive recursive, whithout building such an unreadable term.
 

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -92,14 +92,7 @@ Likewise, arbitrary boolean predicates may have an arbitrary number of arguments
 (\texttt{naryRel $n$}), defined in the same way as \texttt{naryFunc}, is the type of $n$-ary functions from
 \texttt{nat} into \texttt{bool}.
 
-\begin{Coqsrc}
-Compute naryRel 2.
-\end{Coqsrc}
-
-\begin{Coqanswer}
- = nat -> nat -> bool
-     : Set
-\end{Coqanswer}
+\input{movies/snippets/PrimRecExamples/naryRel2}
 
 The magic of dependent types makes it possible to define recursively extensional equality between functions of the same arity.
 
@@ -119,46 +112,14 @@ Fixpoint  extEqual (n : nat) : forall  (a b : naryFunc n), Prop :=
   end.
 \end{Coqsrc}
 
-\begin{Coqsrc}
-Compute extEqual 2.
-\end{Coqsrc}
+\input{movies/snippets/PrimRecExamples/extEqual2a}
 
-\begin{Coqanswer}
-     = fun a b : naryFunc 2 => forall x x0 : nat, a x x0 = b x x0
-     : naryFunc 2 -> naryFunc 2 -> Prop
- \end{Coqanswer}
- 
-\begin{Coqsrc}
-Example extEqual_ex1 : extEqual 2 mult (fun x y =>  y * x + x - x) .
-Proof.
-  intros x y.
-\end{Coqsrc}
+  Getting rid of the term \texttt{x-x}, we generate two easy-to-solve sub-goals.
 
-\begin{Coqanswer}
-  x, y : nat
-  ============================
-  extEqual 0 (x * y) (y * x)
-\end{Coqanswer}
-
-\begin{Coqsrc}
-  cbn.
-\end{Coqsrc}
-
-\begin{Coqanswer}
-1 subgoal (ID 10)
+\vspace{6pt}
+\noindent
+\input{movies/snippets/PrimRecExamples/extEqual2b}
   
-  x, y : nat
-  ============================
-  x * y = y * x + x - x
-\end{Coqanswer}
-
-\begin{Coqsrc}
-  rewrite <- Nat.add_sub_assoc, Nat.sub_diag.
-  - ring.
-  - apply le_n.  
-Qed.
-\end{Coqsrc}
-
 \subsection{A Data-type for Primitive Recursive Functions}
 
 O'Connor's formalization of primitive recursive functions takes the form of two mutually inductive dependent data types, each constructor of which is associated with one of these  rules.
@@ -515,21 +476,8 @@ a commented version of this proof,
 
 First, we look for lemmas which may help to prove that a given function obtained with the recursor \texttt{nat\_rec} is primitive recursive.
 
-\begin{Coqsrc}
-Search (is_PR 2 (fun _ _ => nat_rec _ _ _ _)).
-\end{Coqsrc}
+\input{movies/snippets/PrimRecExamples/PrimRecExamplesSearch}
 
-\begin{Coqanswer}
-ind1ParamIsPR:
-  forall f : nat -> nat -> nat -> nat,
-  isPR 3 f ->
-  forall g : nat -> nat,
-  isPR 1 g ->
-  isPR 2
-    (fun a b : nat =>
-     nat_rec (fun _ : nat => nat)
-                 (g b) (fun x y : nat => f x y b) a)
-\end{Coqanswer}
 
 We prove that the library function \texttt{plus} is extensionally equal to a function defined with
 \texttt{nat\_rec}.

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -288,35 +288,19 @@ Thus we would like to compose this constant function with the unary successor fu
 This is exactly the role of the instance \texttt{composeFunc 0 1} of the dependently typed
 function \texttt{composeFunc}, as shown by the following lemma.
 
-\begin{Coqsrc}
-Fact compose_01 :
-    forall (x:PrimRec 0) (t : PrimRec 1),
-    let c := evalPrimRec 0 x in
-    let f := evalPrimRec 1 t in
-    evalPrimRec 0 (composeFunc 0 1
-                               (PRcons 0 0 x (PRnil 0))
-                               t)  =
-     f c.
-Proof. reflexivity. Qed.
-\end{Coqsrc}
+\vspace{4pt}
+\input{movies/snippets/PrimRecExamples/compose01}
 
+
+\vspace{4pt}
 Thus, we get a quite simple proof of \texttt{const1\_NIsPR}.
 
 
 \vspace{4pt}
 \noindent
 \emph{From \href{../theories/html/hydras.MoreAck.PrimRecExamples.html}{MoreAck.PrimRecExamples}}.
-\begin{Coqsrc}
-Lemma  const1_NIsPR n : isPR 0 n. 
-Proof.
-  induction n.
-  - apply zeroIsPR.
-  - destruct IHn as [x Hx].
-   exists (composeFunc 0 1 (PRcons 0 0 x (PRnil 0)) succFunc). 
-   cbn in *; intros; now rewrite Hx.
-Qed.
-\end{Coqsrc}
 
+\input{movies/snippets/PrimRecExamples/const0NIsPR}
 
 \subsubsection{Proving that \texttt{plus} is primitive recursive}
 
@@ -328,38 +312,23 @@ First, we look for lemmas which may help to prove that a given function obtained
 
 \input{movies/snippets/PrimRecExamples/PrimRecExamplesSearch}
 
-
-We prove that the library function \texttt{plus} is extensionally equal to a function defined with
+The following lemma shows it suffices to prove that
+Standard library's function \texttt{plus} is extensionally equal to a function defined with
 \texttt{nat\_rec}.
 
-\begin{Coqsrc}
-Definition plus_alt x y  :=
-              nat_rec  (fun n : nat => nat)
-                       y
-                       (fun z t =>  S t)
-                       x.
+\input{movies/snippets/PrimRecExamples/isPRExtEqualTrans}
 
-Lemma plus_alt_ok:
-  extEqual 2 plus_alt plus.
-Proof.
-  intro x; induction x; cbn; auto.
-  intros y; cbn; now rewrite <- (IHx y).
-Qed.
-\end{Coqsrc}
+Thus, let us define an helper and prove its equivalence with \texttt{plus}.
 
-A last lemma before the proof:
+\input{movies/snippets/PrimRecExamples/plusAlt}
 
-\begin{Coqsrc}
-Lemma isPR_extEqual_trans n : forall f g, isPR n f ->
-                                    extEqual n f g ->
-                                    isPR n g.
-Proof.
- intros f g [x Hx]; exists x.
- apply extEqualTrans with f; auto.
-Qed.
-\end{Coqsrc}
 
-Let us start now.
+\vspace{4pt}
+
+
+We are now able to complete the proof.
+
+\input{movies/snippets/PrimRecExamples/plusIsPRa}
 
 \begin{Coqsrc}
 Lemma plusIsPR : isPR 2 plus.
@@ -381,22 +350,17 @@ subgoal 2 (ID 127) is:
 We already proved that \texttt{S} is \texttt{PR 1}, but we need to consider a function of three arguments, which ignores its first and third arguments.
 Fortunately, the library \texttt{primRec} already contains lemmas adapted to this kind of situation.
 
-\begin{Coqanswer}
-filter010IsPR :
-forall g : nat -> nat, isPR 1 g -> isPR 3 (fun _ b _ : nat => g b)
-\end{Coqanswer}
+\vspace{4pt}
+\input{movies/snippets/PrimRecExamples/checkFilter0101IsPR}
+\vspace{4pt}
+
 
 Thus, our first subgoal is solved easily. The rest of the proof 
 is just an application of already proven lemmas.
 
+\vspace{4pt}
 
-\begin{Coqsrc}
- - unfold plus_alt; apply ind1ParamIsPR.
-    + apply filter010IsPR, succIsPR.
-    + apply idIsPR.
-  - apply plus_alt_ok. 
-Qed.
-\end{Coqsrc}
+\input{movies/snippets/PrimRecExamples/plusIsPRb}
 
 
 \begin{todo}
@@ -419,26 +383,9 @@ Multiplication of natural number is already proven in the \texttt{primRec} libra
 The following proof decomposes the \texttt{double} function as the composition of 
 multiplication with the identity and the constant function which returns $2$.
 \emph{Note that the lemma \texttt{const1\_NIsPR} considers this function as an unary function (unlike \texttt{const0\_NIsPR})}. 
+\input{movies/snippets/PrimRecExamples/doubleIsPRa}
+\input{movies/snippets/PrimRecExamples/doubleIsPRb}
 
-\begin{Coqsrc}
-Lemma doubleIsPR : isPR 1 double.
-Proof.
-  unfold double; apply compose1_2IsPR.
-  - apply idIsPR.
-\end{Coqsrc}
-
-\begin{Coqanswer}
-subgoal 1 (ID 110) is:
- isPR 1 (fun _ : nat => 2)
-subgoal 2 (ID 111) is:
- isPR 2 Init.Nat.mul
-\end{Coqanswer}
-
- \begin{Coqsrc}
-  - apply const1_NIsPR.
-  - apply multIsPR.
-Qed.
-\end{Coqsrc}
 
 \index{primrec}{Exercises}
 \begin{exercise}

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -330,22 +330,6 @@ We are now able to complete the proof.
 
 \input{movies/snippets/PrimRecExamples/plusIsPRa}
 
-\begin{Coqsrc}
-Lemma plusIsPR : isPR 2 plus.
-Proof.
-  apply isPR_extEqual_trans with plus_alt.
-  - unfold plus_alt; apply ind1ParamIsPR.
-\end{Coqsrc}
-
-\begin{Coqanswer}
-2 subgoals (ID 126)
-  
-  ============================
-  isPR 3 (fun _ y _ : nat => S y)
-
-subgoal 2 (ID 127) is:
- isPR 1 (fun b : nat => b)
-\end{Coqanswer}
 
 We already proved that \texttt{S} is \texttt{PR 1}, but we need to consider a function of three arguments, which ignores its first and third arguments.
 Fortunately, the library \texttt{primRec} already contains lemmas adapted to this kind of situation.
@@ -378,39 +362,26 @@ Thus, the reader may look at them, and invent simple examples of application for
 Multiplication of natural number is already proven in the \texttt{primRec} library. Write a proof of your own, then compare to the library's version.
 \end{exercise}
 
+%\input{movies/snippets/PrimRecExamples/justATest}
+
 \subsubsection{More examples}
 
 The following proof decomposes the \texttt{double} function as the composition of 
 multiplication with the identity and the constant function which returns $2$.
 \emph{Note that the lemma \texttt{const1\_NIsPR} considers this function as an unary function (unlike \texttt{const0\_NIsPR})}. 
 \input{movies/snippets/PrimRecExamples/doubleIsPRa}
-\input{movies/snippets/PrimRecExamples/doubleIsPRb}
+
 
 
 \index{primrec}{Exercises}
 \begin{exercise}
 Prove that the following functions are primitive recursive. 
 
-\begin{Coqsrc}
-Fixpoint fact n :=
-  match n with 
-          | 0 => 1
-          | S p  => n * fact p
-  end.
+\input{movies/snippets/MorePRExamples/factDef}
 
-Fixpoint exp n p :=
-  match p with
-  | 0 => 1
-  | S m =>  exp n m * n
-  end.
+\input{movies/snippets/MorePRExamples/expDef}
 
-Fixpoint tower2 n :=
-  match n with
-  | 0 => 1
-  | S p => exp 2 (tower2 p)
-  end.
-\end{Coqsrc}
-
+\input{movies/snippets/MorePRExamples/tower2Def}
 
 
 \textbf{Hint:} You may have to look again at the lemmas of the library
@@ -436,15 +407,8 @@ recursive.
 \begin{exercise}
 Write a simple and readable proof that the Fibonacci function is primitive recursive.
 
+\input{movies/snippets/FibonacciPR/fibDef}
 
-\begin{Coqsrc}
-Fixpoint fib (n:nat) : nat :=
-  match n with
-  | 0 => 1
-  | 1 => 1
-  | S ((S p) as q) => fib q + fib p
-  end.
-\end{Coqsrc}
 
 \textbf{Hint:}  You may use as a helper the function which computes the pair \linebreak
 $(\texttt{fib}(n+1),\texttt{fib}(n))$. 
@@ -458,15 +422,14 @@ the associated constructor and projections are primitive recursive.
 
 \index{primrec}{Exercises}
 \begin{exercise}
+
 Prove the following lemmas (which may help to solve the next  exercise).
 
-\begin{Coqsrc}
-Lemma boundedSearch3 (P: naryRel 2) (b  : nat), 
-    boundedSearch P b <= b. 
+\input{movies/snippets/isqrt/boundedSearch3}
+\input{movies/snippets/isqrt/boundedSearch4}
 
-Lemma boundedSearch4 (P: naryRel 2) (b  : nat):
-  P b b = true -> P b (boundedSearch P b) = true.
-\end{Coqsrc}
+\textbf{Note:}  The function \texttt{boundedSearch} is defined
+in Library \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}. 
 \end{exercise}
 
 \index{primrec}{Exercises}

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -483,23 +483,10 @@ is the $n$-th iteration of $f$\,\footnote{Please not confuse with \texttt{primRe
 \noindent
 \emph{From \href{../theories/html/hydras.Prelude.Iterates.html}{Prelude.Iterates}}.
 \index{hydras}{Library Prelude!iterate}
-\begin{Coqsrc}
-Fixpoint iterate {A:Type}(f : A -> A) (n: nat)(x:A) :=
-  match n with
-  | 0 => x
-  | S p => f (iterate  f p x)
-  end.
-\end{Coqsrc}
 
-\begin{Coqsrc}
-Lemma iterate_le_n_Sn:
-forall f : nat -> nat,
-(forall x : nat, x <= f x) ->
-forall n x : nat, iterate f n x <= iterate f (S n) x.
-\end{Coqsrc}
+\input{movies/snippets/Iterates/iterateDef}
 
-
-
+\input{movies/snippets/Iterates/iterateLeNSN}
 
 
 Thus, our definition of the Ackermann function is as follows:
@@ -516,7 +503,7 @@ Thus, our definition of the Ackermann function is as follows:
 \index{hydras}{Exercises}
 
 \begin{exercise}
-The file \href{../theories/html/hydras.MoreAck.Ack.html}{MoreAck.Ack} presents two other definitions\footnote{post on \href{https://stackoverflow.com/questions/10292421/error-in-defining-ackermann-in-coq} by Anton Trunov.} of the Ackermann functions based on the lexicographic ordering on $\mathbb{N}\times\mathbb{N}$.
+The file \href{../theories/html/hydras.MoreAck.Ack.html}{MoreAck.Ack} presents two other definitions of the Ackermann functions based on the lexicographic ordering on $\mathbb{N}\times\mathbb{N}$.
 Prove that the four functions are extensionnally equal.
 \end{exercise}
 
@@ -526,29 +513,17 @@ Prove that the four functions are extensionnally equal.
 The three first lemmas make us sure that our function 
 \texttt{Ack} satifies the ``usual'' equations.
 
-\begin{Coqsrc}
-Lemma Ack_0 : Ack 0 = S.
-Proof refl_equal.
+\input{movies/snippets/Ack/AckRewrite}
 
-Lemma Ack_S_0 m : Ack (S m) 0 = Ack m 1. 
-Proof. reflexivity. Qed.
 
-Lemma Ack_S_S : forall m p,
-    Ack (S m) (S p) = Ack m (Ack (S m) p).
-Proof. reflexivity. Qed.
-\end{Coqsrc}
+\vspace{4pt}
 
 The order of growth of the Ackermann function w.r.t. its first argument is illustrated by the following equalities.
 
-\begin{Coqsrc}
-Lemma Ack_1_n n: Ack 1 n = S  (S n).
-
-Lemma Ack_2_n n: Ack 2 n = 2 * n + 3.
-
-Lemma Ack_3_n n: Ack 3 n = exp2 (S (S (S n))) - 3.
-
-Lemma Ack_4_n n: Ack 4 n = hyper_exp2 (S (S (S n))) - 3.
-\end{Coqsrc}
+\input{movies/snippets/Ack/Ack1N}
+\input{movies/snippets/Ack/Ack2N}
+\input{movies/snippets/Ack/Ack3N}
+\input{movies/snippets/Ack/Ack4N}
 
 
 \begin{remark}
@@ -572,10 +547,8 @@ to overcome the difficulty raised by nested recursion, by climbing up the hierar
 
 \noindent
 \emph{From \href{../theories/html/hydras.MoreAck.Ack.html}{MoreAck.Ack}}.
-\begin{Coqsrc}
-Lemma nested_Ack_bound : forall k m n, 
-    Ack k (Ack m n) <= Ack (2 + max k m) n.
-\end{Coqsrc}
+
+\input{movies/snippets/Ack/nestedAckBound}
 
 
 
@@ -585,10 +558,12 @@ Please note also that for any given $n$, the unary function
 \vspace{4pt}
 
 \noindent
+
 \emph{From \href{../theories/html/hydras.MoreAck.AckNotPR.html}{MoreAck.AckNotPR}}.
-\begin{Coqsrc}
-Theorem Ackn_IsPR (n: nat) : isPR 1 (Ack n).
-\end{Coqsrc}
+
+\input{movies/snippets/AckNotPR/AckNIsPR}
+
+
 
 
 
@@ -613,53 +588,12 @@ The following scheme allows us to write proofs by induction on the class of prim
 \emph{From \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}.}
 
 \index{coq}{Commands!Scheme}
-\begin{Coqsrc}
-Scheme PrimRec_PrimRecs_ind := Induction for PrimRec
-  Sort Prop
-  with PrimRecs_PrimRec_ind := Induction for PrimRecs 
-  Sort Prop.
-\end{Coqsrc}
 
-\begin{Coqanswer}
-PrimRec_PrimRecs_ind :
-forall (P : forall n : nat, PrimRec n -> Prop)
-  (P0 : forall n n0 : nat, PrimRecs n n0 -> Prop),
-(* successor *)
-P 1 succFunc ->
+\input{movies/snippets/primRec/SchemePrimRecInd}
 
-(* zero *)
-P 0 zeroFunc ->
 
-(* projections *)
-(forall (n m : nat) (l : m < n), P n (projFunc n m l)) ->
 
-(* composition *) 
-(forall (n m : nat) (g : PrimRecs n m),
-      P0 n m g -> forall h : PrimRec m, P m h -> 
-      P n (composeFunc n m g h)) ->
-
-(* primitive recursion *)
-(forall (n : nat) (g : PrimRec n),
- P n g ->
-    forall h : PrimRec (S (S n)), P (S (S n)) h -> 
-     P (S n) (primRecFunc n g h)) ->
-
-(* empty list of functions *)
-(forall n : nat, P0 n 0 (PRnil n)) ->
-
-(* add a function to a list *)
-(forall (n m : nat) (p : PrimRec n),
-   P n p -> 
-   forall p0 : PrimRecs n m, P0 n m p0 -> 
-   P0 n (S m) (PRcons n m p p0)) ->
-
-(* conclusion ! *)
-forall (n : nat) (p : PrimRec n), P n p
-\end{Coqanswer}
-
-For instance, proving a property shared by any primitive recursive function of arity 2 leads to consider the case where that function is obtained by composition with a function of any 
-arity $m$. The same problem happens with primitive 
-recursion, where a function of arity $n$ is built out of a function of arity $n+1$ and a function of arity $n-1$.
+Please note that, in order to prove a property shared by any primitive recursive function of, say, arity 2, this induction scheme  leads you to consider an expension of the considered property to primitive recursive function of any arity.
 
 Thus the lemma we will have to prove is the following one:
 
@@ -680,22 +614,14 @@ First, we extend \texttt{max} to vectors of natural numbers (using the notations
 \texttt{VectorDef.cons x \_ v}.
 
 \index{coq}{Dependently typed functions}
-\begin{Coqsrc}
-Fixpoint max_v {n:nat} : forall (v: Vector.t nat n) , nat :=
-  match n as n0 return (Vector.t nat n0 -> nat)
-  with
-    0 => fun v => 0
-  | S p => fun (v : Vector.t nat (S p)) =>
-             max (Vector.hd v) (max_v  (Vector.tl v))
-  end. 
 
-Lemma max_v_2 : forall x y,  max_v (x::y::nil) = max x y.
+\input{movies/snippets/MoreVectors/maxvDef}
 
-Lemma max_v_lub : forall n (v: t nat n) y,
-    (Forall (fun x =>  x <= y) v) -> max_v v <= y.
+\input{movies/snippets/MoreVectors/maxvLemmasa}
 
-Lemma max_v_ge : forall n (v: t nat n) y,  In  y  v -> y <= max_v v.
-\end{Coqsrc}
+\input{movies/snippets/MoreVectors/maxvLemmasb}
+
+\input{movies/snippets/MoreVectors/maxvLemmasc}
 
 
 We have also to convert any application
@@ -705,59 +631,24 @@ This is already defined in
 Library~\href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}.
 
 
-\begin{Coqsrc}
-Fixpoint evalList (m : nat) (l : Vector.t nat m) {struct l} :
- naryFunc m -> nat :=
-  match l in (Vector.t _ m) return (naryFunc m -> nat) with
-  | Vector.nil => fun x : naryFunc 0 => x
-  | Vector.cons a n l' => fun x : naryFunc (S n) => evalList n l' (x a)
-  end.
-\end{Coqsrc}
+\input{movies/snippets/primRec/evalListDef}
 
 Indeed, (\texttt{evalList $m$ $v$ $f$}) is the application to the vector $v$ of
 an uncurried version of $f$.
 In Library\href{../theories/html/hydras.MoreAck.AckNotPR.html}{MoreAck.AckNotPR}, we introduce a lighter notation.
 
 \index{coq}{Dependently typed functions}
-\begin{Coqsrc}
-(**  uncurried apply:
- 
-[v_apply f (x1::x2:: ... ::xn::nil)]  is [f x1 x2 ... xn] 
- *)
 
-Notation "'v_apply' f v" := (evalList _ v f) 
-     (at level 10, f at level 9).
+\input{movies/snippets/AckNotPR/vApply}
 
-Example Ex2: forall (f: naryFunc 2) x y,
-    v_apply f (x::y::nil) = f x y.
-Proof.   intros; now cbn. Qed.
 
-Example Ex4: forall (f: naryFunc 4) x y z t,
-    v_apply f (x::y::z::t::nil) = f x y z t.
-Proof.  intros; now cbn. Qed.
-\end{Coqsrc}
 
 We are now able to translate in \gallina{} the notion of ``majorization'':
 
 \index{coq}{Dependently typed functions}
-\begin{Coqsrc}
-Definition majorized {n} (f: naryFunc n) (A: naryFunc 2) : Prop :=
-  exists (q:nat), forall (v: t nat n),
-      v_apply f v <= A q  (max_v v).
 
-Definition majorizedPR {n} (x: PrimRec n) A := 
-           majorized (evalPrimRec n x) A.
+\input{movies/snippets/AckNotPR/majorizedDefs}
 
-(** For vectors of functions *)
-
-Definition majorizedS {n m} (fs : Vector.t (naryFunc n) m)
-           (A : naryFunc 2):=
-  exists N, forall (v: t nat n),
-      max_v (map (fun f => v_apply f v) fs) <= A N (max_v v).
-
-Definition majorizedSPR {n m} (x : PrimRecs n m) :=
-  majorizedS (evalPrimRecs _ _ x).
-\end{Coqsrc}
 
 Now, it remains to prove that any primitive function is majorized by \texttt{Ack}.
 The three base cases  are as follows:

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -653,129 +653,41 @@ We are now able to translate in \gallina{} the notion of ``majorization'':
 Now, it remains to prove that any primitive function is majorized by \texttt{Ack}.
 The three base cases  are as follows:
 
-\begin{Coqsrc}
-Lemma majorSucc : majorizedPR  succFunc Ack.
+\input{movies/snippets/AckNotPR/majorSucc}
 
-Lemma majorZero : majorizedPR  zeroFunc Ack.
+\input{movies/snippets/AckNotPR/majorZero}
 
-Lemma majorProjection (n m:nat)(H: m < n):
-  majorizedPR (projFunc n m H) Ack.
-\end{Coqsrc}
+\input{movies/snippets/AckNotPR/majorProjection}
 
 
-The rest of the cases are proved within a mutual  induction.
+
+The remaining cases are proved within a mutual  induction.
 
 \index{coq}{Mutual induction}
 
-\begin{Coqsrc}
-Lemma majorAnyPR:  forall n (x: PrimRec n),  majorizedPR  x Ack.
-Proof.
-  intros n x; induction x using PrimRec_PrimRecs_ind with
-                  (P0 := fun n m y => majorizedSPR  y Ack).
-  - apply majorSucc.
-  - apply majorZero.
-  - apply majorProjection. 
-  \end{Coqsrc}
+\input{movies/snippets/AckNotPR/majorAnyPR}
 
-  \begin{Coqsrc}
-  - (** function composition *)
-\end{Coqsrc}
-\begin{Coqanswer}
-1 subgoal (ID 265)
 
-  n, m : nat
-  g : PrimRecs n m
-  x : PrimRec m
-  IHx : majorizedSPR g Ack
-  IHx0 : majorizedPR x Ack
-  ============================
-  majorizedPR (composeFunc n m g x) Ack
-\end{Coqanswer}
-
-\begin{Coqsrc}
-  ...
- - (** primitive recursion *)
-\end{Coqsrc}
-
-\begin{Coqanswer}
-1 subgoal (ID 265)
-  
-  n : nat
-  x1 : PrimRec n
-  x2 : PrimRec (S (S n))
-  IHx1 : majorizedPR x1 Ack
-  IHx2 : majorizedPR x2 Ack
-  ============================
-  majorizedPR (primRecFunc n x1 x2) Ack
-\end{Coqanswer}
-
-\begin{Coqsrc}
- assert (L1 : forall i (v: t nat n) ,
-               v_apply f (i::v)  <= Ack q (i + max_v v)).
-    { induction i.
-      ...
-    }
-    ...
--  (** empty list of functions *)
-\end{Coqsrc}
-
-\begin{Coqanswer}
-1 subgoal (ID 266)
-  
-  n : nat
-  ============================
-  majorizedSPR (PRnil n) Ack
-\end{Coqanswer}
-
-\begin{Coqsrc}
-  ...
-- (** non-empty list of functions *)
-\end{Coqsrc}
-
-\begin{Coqanswer}
-1 subgoal (ID 273)
-  
-  n, m : nat
-  x : PrimRec n
-  p : PrimRecs n m
-  IHx : majorizedPR x Ack
-  IHx0 : majorizedSPR p Ack
-  ============================
-  majorizedSPR (PRcons n m x p) Ack
-\end{Coqanswer}
-  
-\begin{Coqsrc}
- ...
-Qed.
-\end{Coqsrc}
 
 \subsection{Looking for a contradiction}
 
 The following lemma is just a specialization of \texttt{majorAnyPR} to
 binary functions (forgetting vectors, coming back to usual notations).
 
-\begin{Coqsrc}
-Lemma majorPR2 (f: naryFunc 2)(Hf : isPR 2 f)
-  : exists (n:nat), forall x y,  f x y <= Ack n (max x  y).
-\end{Coqsrc}
+\input{movies/snippets/AckNotPR/majorPR2}
 
 We prove also a strict version of this lemma, thanks to the following property (proved in Library
 \href{../theories/html/hydras.MoreAck.Ack.html}{MoreAck.Ack}~).
 
-\begin{Coqsrc}
-Lemma Ack_strict_mono_l : forall n m p, n < m ->
-                                        Ack n (S p) < Ack m (S p).
-\end{Coqsrc}
+\input{movies/snippets/Ack/AckStrictMonoL}
+
 
 \vspace{4pt}
 \noindent
 \emph{From \href{../theories/html/hydras.MoreAck.AckNotPR.html}{MoreAck.AckNotPR}.}
 
-\begin{Coqsrc}
-Lemma majorPR2_strict (f: naryFunc 2)(Hf : isPR 2 f):
-    exists (n:nat),
-    forall x y, 2 <= x -> 2 <= y -> f x y < Ack n (max x  y).
-\end{Coqsrc}
+
+\input{movies/snippets/AckNotPR/majorPR2Strict}
 
 
 
@@ -783,58 +695,22 @@ If the Ackermann function were primitive recursive, then there would exist some 
 $\texttt{Ack}\,x\,y\leq \texttt{Ack}\,n\,(\texttt{max}\,x\,y)$ holds.
 Thus, our impossibility proof is just a sequence of easy small steps.
 
-\begin{Coqsrc}
-Section Impossibility_Proof.
-
-  Hypothesis HAck : isPR 2 Ack.
-  
-  Lemma Ack_not_PR : False.
-  Proof.
-    destruct (majorPR2_strict Ack HAck) as [m Hm];
-    pose (X := max 2 m); specialize (Hm X X).
-    rewrite max_idempotent in Hm; 
-    assert (Ack m X <= Ack X X) by (apply Ack_mono_l; lia).
-    lia.
-  Qed.
-
-End Impossibility_Proof.
-\end{Coqsrc}
-
+\input{movies/snippets/AckNotPR/AckNotPR}
 
 \begin{remark}
-It is easy to prove that any unary function which dominatates \texttt{fun n => Ack n n} fails to be primitive recursive. We use an instance of \texttt{majorAnyPR} for unary functions.
+It is easy to prove that any unary function which dominatates \texttt{fun n => Ack n n} fails to be primitive recursive. To this end, we use an instance of \texttt{majorAnyPR} dealing with unary functions.
 
 \vspace{4pt}
 \noindent
 
 \emph{From \href{../theories/html/hydras.MoreAck.AckNotPR.html}{MoreAck.AckNotPR}}.
-\begin{Coqsrc}
-Lemma majorPR1  (f: naryFunc 1)(Hf : isPR 1 f)
-  : exists (n:nat), forall x, f x <= Ack n x.
-(* ... *)
-\end{Coqsrc}
+
+\input{movies/snippets/AckNotPR/majorPR1}
 
 Then, we write  a short proof by contradiction.
 
-\begin{Coqsrc}
-Section dom_AckNotPR.
+\input{movies/snippets/AckNotPR/domAckNotPR}
 
-  Variable f : nat -> nat.
-  Hypothesis Hf : dominates f (fun n => Ack n n).
-
- Lemma dom_AckNotPR: isPR 1 f -> False.
-  Proof.
-    intros H;  destruct Hf as [N HN].
-    destruct  (majorPR1 _ H) as [M HM].
-    pose (X := Max.max N M).
-    specialize (HN X  (Max.le_max_l N M)).
-    specialize (HM X);
-      assert (Ack M X <= Ack X X) by (apply Ack_mono_l; subst; lia).
-    lia.
-  Qed.
-
-End dom_AckNotPR.
-\end{Coqsrc}
 \end{remark}
 
 \begin{remark}
@@ -858,16 +734,7 @@ This proof is  a little more complex than the preceding one.
 The function we consider is defined and proven correct in
 Module~\href{../theories/html/hydras.Hydra.Battle_length.html}{Hydra.Battle\_length}.
 
-\begin{Coqsrc}
-Definition l_std alpha k := (L_ alpha (S k) - k)%nat.
-
-Lemma l_std_ok : forall alpha : E0,
-    alpha <> Zero ->
-    forall k : nat,
-      1 <= k -> battle_length standard k (iota (cnf alpha))
-                              (l_std alpha k).
-(* ... *)
-\end{Coqsrc}
+\input{movies/snippets/Battle_length/BattleLength}
 
 \subsection{Proof steps}
 
@@ -876,109 +743,92 @@ Now, let us assume that the function \texttt{l\_std} is primitive recursive.
 
 \emph{From \href{../theories/html/hydras.Hydra.Hydra_Theorems.html}{Hydra.Hydra\_Theorems}}.
 
-\begin{Coqsrc}
-Section battle_lenght_notPR.
-
-  (** We assume that the function with computes the length 
-      of standard battles is primitive recursive *)
-  
-  Hypothesis H: forall alpha, isPR 1 (l_std alpha). 
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Theorems/battleLengthNotPRa}
 
 Let us consider the hydra represented by the ordinal $\omega^\omega$.
 
-\begin{Coqsrc}
-Let alpha := Phi0 omega%e0.
-Let h := iota (cnf alpha).
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Theorems/battleLengthNotPRb}
+
 
 In order to get rid of the substraction in the definition of \texttt{l\_std}, we work with a helper function.
 
-\begin{Coqsrc}
-Let m k := L_ alpha (S k).
-
-Remark m_eqn : forall k, m k = (l_std alpha k + k)%nat.
-(* ... *)
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Theorems/battleLengthNotPRc}
 
 Under the hypothesis \texttt{H}, $m$ is also primitive recursive.
 
-\begin{Coqsrc}
-Remark mIsPR : isPR 1 m.
-(* ... *)
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Theorems/battleLengthNotPRd}
 
 
 \subsubsection{Comparison between $F$ and $H'$}
 
-In \href{../theories/html/hydras.Epsilon0.F_alpha.html}{Epsilon0.F\_alpha}, we prove a relation between the $F$ and $H'$ functional. For any $\alpha$ and $k>0$,
+In \href{../theories/html/hydras.Epsilon0.F_alpha.html}{Epsilon0.F\_alpha}, we prove a relation between the $F$ and $H'$ functionals. For any $\alpha$ and $k>0$,
 $H'_{\omega^\alpha}(k)\geq F_\alpha(k)$.
 
-\begin{Coqsrc}
-H'_F : forall (alpha : E0) (n : nat), 
-     F_ alpha (S n) <= H'_ (Phi0 alpha) (S n) 
-\end{Coqsrc}
+\input{movies/snippets/F_alpha/HprimeF}
 
 
-Our proof of this lemma is not trivial at all. One of it sub-goals is the following one:
+Our proof of this lemma is not trivial at all, it uses some properties of the Ketonen-Solovay's toolkit. We advise the reader to explore this proof, with the help of an ide or softwre like alectryon.
+%%
+%%% To move the path chapter
+%%%%
 
-\begin{Coqsrc}
-  alpha : E0
-  IHalpha : forall beta : E0, beta o< alpha -> P beta
-  Halpha : Limitb alpha
-  n : nat
-  ============================
-  H'_ (Phi0 (CanonS alpha n)) (S n) <= 
-  H'_ (Phi0 (CanonS alpha (S n))) (S n)
-\end{Coqsrc}
+% \begin{Coqsrc}
+%   alpha : E0
+%   IHalpha : forall beta : E0, beta o< alpha -> P beta
+%   Halpha : Limitb alpha
+%   n : nat
+%   ============================
+%   H'_ (Phi0 (CanonS alpha n)) (S n) <= 
+%   H'_ (Phi0 (CanonS alpha (S n))) (S n)
+% \end{Coqsrc}
 
-In mathematical notation: $H'_{\omega^{\canonseq{\alpha}{n}}}(n+1) \leq
-H'_{\omega^{\canonseq{\alpha}{n+1}}}(n+1)$.
+% In mathematical notation: $H'_{\omega^{\canonseq{\alpha}{n}}}(n+1) \leq
+% H'_{\omega^{\canonseq{\alpha}{n+1}}}(n+1)$.
 
-\vspace{4pt}
+% \vspace{4pt}
 
-But there exists no lemma saying that, if 
-$\beta\leq \alpha$, then $H'_\beta(k)\leq H'_\alpha(k)$, for any $\alpha$ and $\beta$. For instance, 
-$H'_{42}(3)=45> H'_\omega(3)=7$.
-
-
-Looking for lemmas of the form $H'_\beta(k)\leq H'_\alpha(k)$, we find this one (from our library
-\href{../theories/html/hydras.Epsilon0.Hprime.html}{Epsilon0.Hprime}):
-
-\begin{Coqanswer}
-H'_restricted_mono_l : 
-    forall (alpha beta : E0) (n : nat), 
-      Canon_plus n alpha beta -> 
-      H'_ beta n <= H'_ alpha n.
-\end{Coqanswer}
-
-Thus, it remains to prove that 
-there exists a path from ${\omega^{\canonseq{\alpha}{n+1}}}$
-to ${\omega^{\canonseq{\alpha}{n}}}$ composed of 
-$n+1$-steps.
-
-Fortunately, the Ketonen-Solovay machinery contains three lemmas which help us to build such a path.
+% But there exists no lemma saying that, if 
+% $\beta\leq \alpha$, then $H'_\beta(k)\leq H'_\alpha(k)$, for any $\alpha$ and $\beta$. For instance, 
+% $H'_{42}(3)=45> H'_\omega(3)=7$.
 
 
-\begin{Coqanswer}
-KS_thm_2_4_lemma5 :
-  forall [i : nat] [alpha beta : T1],
-  const_pathS i alpha beta ->
-  nf alpha -> alpha <> zero -> 
-  const_pathS i (phi0 alpha) (phi0 beta)
+% Looking for lemmas of the form $H'_\beta(k)\leq H'_\alpha(k)$, we find this one (from our library
+% \href{../theories/html/hydras.Epsilon0.Hprime.html}{Epsilon0.Hprime}):
 
-KS_thm_2_4 :
-  forall [lambda : T1], nf lambda ->limitb lambda ->
-  forall i j : nat, i < j -> 
-   const_pathS 0 (canonS lambda j) (canonS lambda i)
+% \begin{Coqanswer}
+% H'_restricted_mono_l : 
+%     forall (alpha beta : E0) (n : nat), 
+%       Canon_plus n alpha beta -> 
+%       H'_ beta n <= H'_ alpha n.
+% \end{Coqanswer}
 
-Cor12_1 :
-forall [alpha : T1], nf alpha ->
-      forall (beta : T1) (i n : nat),
-      beta t1< alpha ->
-     i <= n -> const_pathS i alpha beta -> 
-     const_pathS n alpha beta
-\end{Coqanswer}
+% Thus, it remains to prove that 
+% there exists a path from ${\omega^{\canonseq{\alpha}{n+1}}}$
+% to ${\omega^{\canonseq{\alpha}{n}}}$ composed of 
+% $n+1$-steps.
+
+% Fortunately, the Ketonen-Solovay machinery contains three lemmas which help us to build such a path.
+
+
+% \begin{Coqanswer}
+% KS_thm_2_4_lemma5 :
+%   forall [i : nat] [alpha beta : T1],
+%   const_pathS i alpha beta ->
+%   nf alpha -> alpha <> zero -> 
+%   const_pathS i (phi0 alpha) (phi0 beta)
+
+% KS_thm_2_4 :
+%   forall [lambda : T1], nf lambda ->limitb lambda ->
+%   forall i j : nat, i < j -> 
+%    const_pathS 0 (canonS lambda j) (canonS lambda i)
+
+% Cor12_1 :
+% forall [alpha : T1], nf alpha ->
+%       forall (beta : T1) (i n : nat),
+%       beta t1< alpha ->
+%      i <= n -> const_pathS i alpha beta -> 
+%      const_pathS n alpha beta
+% \end{Coqanswer}
   
 \subsubsection{End of the proof}
 
@@ -986,44 +836,28 @@ We finish the proof by comparing several fast growing functions.
 
 \emph{From \href{../theories/html/hydras.Epsilon0.L_alpha.html}{Epsilon0.L\_alpha}}
 
-\begin{Coqsrc}
-H'_L_ : forall (alpha : E0) (i : nat), H'_ alpha i <= L_ alpha (S i)
-\end{Coqsrc}
-
+\input{movies/snippets/L_alpha/HprimeL}
 
 \emph{From \href{../theories/html/hydras.Epsilon0.F_omega.html}{Epsilon0.F\_omega}}
 
-\begin{Coqsrc}
-F_vs_Ack : forall n : nat, 2 <= n -> Ack n n <= F_ omega n
-\end{Coqsrc}
+
+\input{movies/snippets/F_omega/FVsAck}
 
 
 
 By transitivity, we get the inequality
 $F_\omega(k+1)\leq m(k+1)$, for any $k$.
 
-\begin{Coqsrc}
-Remark m_ge_F_omega : forall k,  F_ omega (S k) <= m (S k).
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Theorems/mGeFOmega}
 
 
 We finish the proof by noting that the function $m$ (composed with \texttt{S}) dominates the Ackermann function, which leads to a contradiction.
 
-\begin{Coqsrc}
-Remark m_dominates_Ack : 
-     dominates (fun n =>  S (m n)) (fun n => Ack.Ack n n).
-(* ... *)
+\input{movies/snippets/Hydra_Theorems/mDominatesAck}
 
-Remark SmNotPR : isPR 1 (fun n => S (m n)) -> False.
-(* ... *)
+\input{movies/snippets/Hydra_Theorems/SmNotPR}
 
-Theorem LNotPR : False.
-  Proof.
-    apply SmNotPR,  compose1_1IsPR.
-    - apply mIsPR.
-    - apply succIsPR.
-  Qed.
+\input{movies/snippets/Hydra_Theorems/LNotPR}
 
-End battle_lenght_notPR.
-\end{Coqsrc}
+
 

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -104,13 +104,8 @@ The magic of dependent types makes it possible to define recursively extensional
 
 \index{primrec}{Predicates!extEqual}
 
-\begin{Coqsrc}
-Fixpoint  extEqual (n : nat) : forall  (a b : naryFunc n), Prop :=
-  match n with
-    0 => fun a b => a = b
-  | S p => fun a b => forall c, extEqual p (a c) (b c)
-  end.
-\end{Coqsrc}
+\input{movies/snippets/extEqualNat/extEqualDef}
+
 
 \input{movies/snippets/PrimRecExamples/extEqual2a}
 
@@ -136,21 +131,8 @@ These two types are (\texttt{PrimRec $n$}) (primitive recursive functions of $n$
 \vspace{4pt}
 \noindent
 \emph{From \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}.}
-\begin{Coqsrc}
-Inductive PrimRec : nat -> Set :=
-  | succFunc : PrimRec 1
-  | zeroFunc : PrimRec 0
-  | projFunc : forall n m : nat, m < n -> PrimRec n
-  | composeFunc :
-      forall (n m : nat) (g : PrimRecs n m) (h : PrimRec m), PrimRec n
-  | primRecFunc :
-      forall (n : nat) (g : PrimRec n) (h : PrimRec (S (S n))), 
-      PrimRec (S n)
-with PrimRecs : nat -> nat -> Set :=
-  | PRnil : forall n : nat, PrimRecs n 0
-  | PRcons : forall n m : nat, PrimRec n -> PrimRecs n m -> 
-                   PrimRecs n (S m).
-\end{Coqsrc}
+
+\input{movies/snippets/primRec/PrimRecDef}
 
 \begin{remark}
 \label{projFunc-order-of-args}
@@ -180,27 +162,11 @@ Both functions are mutually defined through dependent pattern matching. We advis
 would feel uneasy with dependent types to consult Adam Chlipala's \emph{cpdt}  book~\cite{chlipalacpdt2011}. We leave it to the reader  to look also at the helper functions in
 \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}.
 
+\vspace{4pt}
 
-\begin{Coqsrc}
-Fixpoint evalPrimRec (n : nat) (f : PrimRec n) {struct f} : 
- naryFunc n :=
-  match f in (PrimRec n) return (naryFunc n) with
-  | succFunc => S
-  | zeroFunc => 0
-  | projFunc n m pf => evalProjFunc n m pf
-  | composeFunc n m l f =>
-      evalComposeFunc n m (evalPrimRecs _ _ l) (evalPrimRec _ f)
-  | primRecFunc n g h =>
-      evalPrimRecFunc n (evalPrimRec _ g) (evalPrimRec _ h)
-  end
-with evalPrimRecs (n m : nat) (fs : PrimRecs n m) {struct fs} :
- Vector.t (naryFunc n) m :=
-  match fs in (PrimRecs n m) return (Vector.t (naryFunc n) m) with
-  | PRnil a => Vector.nil  (naryFunc a)
-  | PRcons a b g gs =>
-       Vector.cons _ (evalPrimRec _ g) _  (evalPrimRecs _ _ gs)
-  end.
-\end{Coqsrc}
+\input{movies/snippets/primRec/evalPrimRecDef}
+
+\vspace{4pt}
 
 Looks complicated? The following examples show that, when
 the arity is fixed, these definitions behave well w.r.t. 
@@ -258,10 +224,8 @@ equal to the interpretation of some term of type \texttt{PrimRec $n$}.
 \vspace{4pt}
 \noindent
 \emph{From \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}.}
-\begin{Coqsrc}
-Definition isPR (n : nat) (f : naryFunc n) : Set :=
-  {p : PrimRec n | extEqual n (evalPrimRec _ p) f}.  
-\end{Coqsrc}
+
+\input{movies/snippets/primRec/isPRDef}
 
 The library \texttt{primRec} contains a large catalogue of lemmas allowing to prove statements 
 of the form (\texttt{isPR $n$ $f$}). We won't list all these lemmas here, but give a few examples of
@@ -285,61 +249,24 @@ we wrote alternate proofs in
 \href{../theories/html/hydras.MoreAck.PrimRecExamples.html}%
 {Ackermann.MoreAck.PrimRecExamples.v}, in order to illustrate the main proof patterns.
 
-\begin{Coqsrc}
-Module Alt.
-  
-Lemma zeroIsPR : isPR 0 0.
-Proof.
-  exists zeroFunc.
-\end{Coqsrc}
-
-\begin{Coqanswer}
-1 subgoal (ID 90)
-  
-  ============================
-  extEqual 0 (evalPrimRec 0 zeroFunc) 0
-\end{Coqanswer}
-
-\begin{Coqsrc}
-  cbn.
-\end{Coqsrc}
-
-
-\begin{Coqanswer}
-1 subgoal (ID 91)
-  
-  ============================
-  0 = 0
-\end{Coqanswer}
-
-\begin{Coqsrc}
-  reflexivity.
-Qed.
-\end{Coqsrc}
+\input{movies/snippets/PrimRecExamples/zeroIsPR}
 
 
 Likewise, we prove that the successor function on \texttt{nat} is primitive recursive too.
 
-\begin{Coqsrc}
-Lemma SuccIsPR : isPR 1 S.
-Proof.
-  exists succFunc; cbn; reflexivity.
-Qed.
-\end{Coqsrc}
+\input{movies/snippets/PrimRecExamples/SuccIsPR}
+
+
 
 Projections are proved primitive recursive, case by case (many examples in 
 \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}).
 \emph{Please notice again that the name of the projection follows the mathematical tradition, 
 whilst the arguments of  \texttt{projFunc} use another convention (\emph{cf} remark~\vref{projFunc-order-of-args}).}
 
-\begin{Coqsrc}
-Lemma pi2_5IsPR : isPR 5 (fun a b c d e => b).
-Proof.
- assert (H: 3 < 5) by auto.
- exists (projFunc 5 3 H).
- cbn; reflexivity.
-Qed.
-\end{Coqsrc}
+
+\input{movies/snippets/PrimRecExamples/pi25IsPR}
+
+
 
 Please note that the projection $\pi_{1,1}$ is just the identity on \texttt{nat}, and is realized by 
 (\texttt{projFunc 1 0}).
@@ -349,13 +276,7 @@ Please note that the projection $\pi_{1,1}$ is just the identity on \texttt{nat}
 \noindent
 \emph{From \href{../theories/html/hydras.Ackermann.primRec.html}{Ackermann.primRec}.}
 
-\begin{Coqsrc}
-Lemma idIsPR : isPR 1 (fun x : nat => x).
-Proof.
-  assert (H: 0 < 1) by auto.
-  exists (projFunc 1 0 H); cbn; auto.
-Qed.
-\end{Coqsrc}
+\input{movies/snippets/primRec/idIsPR}
 
 \subsubsection{Using function composition}
 

--- a/doc/hydras.tex
+++ b/doc/hydras.tex
@@ -145,23 +145,24 @@ Let us underline the analogy between hydra battles and interactive theorem provi
 \item In the second part, we are interested in computing $x^n$ with the least number of multiplications as possible. We use the notion of \emph{addition chains}~\cite{brauer1939,DBLP:journals/ipl/BerstelB87}, to generate efficient certified exponentiation functions.
 \end{itemize}
 
-
-\subsection{Documenting theories with alectryon}
-
-Quotations of \coq{} source and answers are progressively replaced from copy-pasted \emph{verbatim} to automatically generated \emph{LaTeX} blocks, using Clément Pit-Claudel's \emph{Alectryon} tool~\cite{alectryonpaper, alectryongithub}.
-Many thanks to Jérémy Damour and Théo Zimmermann who designed tools for maintaining consistency between the always evolving \coq{} modules and their documentation written in \emph{LaTeX}.
-
-Besides the guarantee of consistency between theories and documentation, we hope to give a corpus for experimenting new ways of documenting the implementation of non-trivial mathematics on a proof assistant.
-
-
-At present, this document is a hybrid version: Chapter~\vref{chapter:primrec} is fully adapted to \emph{Alectryon}, and we just started to re-write Chapter~\vref{chapter:hydras}.
-
 \paragraph*{Warning:}
 
 This document is \emph{not} an introductory text for \coq{}, and there are many aspects of this proof assistant that are not covered. 
  The reader should already have some basic experience with the \coq{} system. The Reference Manual and several tutorials are available on \coq{} page~\cite{Coq}.  First chapters of textbooks like \emph{Interactive Theorem Proving and Program Development}~\cite{BC04}, \emph{Software Foundations}~\cite{SF} or  \emph{Certified Programming with Dependent Types} ~\cite{chlipalacpdt2011} will give you the right background. 
 
 %%%%% ICI
+
+ 
+\subsection{Documenting theories with alectryon}
+
+Quotations of \coq{} source and answers are progressively replaced from copy-pasted \emph{verbatim} to automatically generated \emph{LaTeX} blocks, using Clément Pit-Claudel's \emph{Alectryon} tool~\cite{alectryonpaper, alectryongithub}.
+Many thanks to Jérémy Damour and Théo Zimmermann who designed tools for maintaining consistency between the always evolving \coq{} modules and documentation written in \emph{LaTeX}.
+
+Besides the guarantee of consistency between theories and documentation, we hope to give a corpus for experimenting new ways of documenting the implementation of non-trivial mathematics on a proof assistant.
+
+
+At present, this document is a hybrid version: Chapter~\vref{chapter:primrec} is fully adapted to \emph{Alectryon}, and we just started to re-write Chapter~\vref{chapter:hydras}.
+
 
 
 

--- a/doc/hydras.tex
+++ b/doc/hydras.tex
@@ -247,6 +247,8 @@ Eqdep.Eq_rect_eq.eq_rect_eq
 
 \subsection{Typographical Conventions}
 
+\subsubsection{Verbatim quotations}
+
 Quotations from our  \coq{} source are displayed as follows:
 
 
@@ -289,7 +291,15 @@ Proof.
 
 The reader may consult the full proof scripts with Proof General or CoqIDE, for instance.
 
+\subsubsection{Using Alectryon}
 
+Alectryon's \emph{LaTeX} mode cannot be mistaken for our hand-made quotations, particularly if you read a color-print.
+Here is an example from Chapter~\ref{chapter:primrec}.
+
+\vspace{4pt}
+
+
+\input{movies/snippets/Ack/AckFixpointIterate.tex}
 \subsection{Active Links}
 The  links which appear in this pdf  document lead are of three possible kinds of destination:
 \begin{itemize}

--- a/doc/hydras.tex
+++ b/doc/hydras.tex
@@ -145,6 +145,17 @@ Let us underline the analogy between hydra battles and interactive theorem provi
 \item In the second part, we are interested in computing $x^n$ with the least number of multiplications as possible. We use the notion of \emph{addition chains}~\cite{brauer1939,DBLP:journals/ipl/BerstelB87}, to generate efficient certified exponentiation functions.
 \end{itemize}
 
+
+\subsection{Documenting theories with alectryon}
+
+Quotations of \coq{} source and answers are progressively replaced from copy-pasted \emph{verbatim} to automatically generated \emph{LaTeX} blocks, using Clément Pit-Claudel's \emph{Alectryon} tool~\cite{alectryonpaper, alectryongithub}.
+Many thanks to Jérémy Damour and Théo Zimmermann who designed tools for maintaining consistency between the always evolving \coq{} modules and their documentation written in \emph{LaTeX}.
+
+Besides the guarantee of consistency between theories and documentation, we hope to give a corpus for experimenting new ways of documenting the implementation of non-trivial mathematics on a proof assistant.
+
+
+At present, this document is a hybrid version: Chapter~\vref{chapter:primrec} is fully adapted to \emph{Alectryon}, and we just started to re-write Chapter~\vref{chapter:hydras}.
+
 \paragraph*{Warning:}
 
 This document is \emph{not} an introductory text for \coq{}, and there are many aspects of this proof assistant that are not covered. 

--- a/doc/movies/Makefile
+++ b/doc/movies/Makefile
@@ -25,6 +25,10 @@ COQ_FILES = Ack.v               \
 	    Hydra_Examples.v    \
 	    Hydra_Lemmas.v      \
 	    extEqualNat.v       \
+	    MorePRExamples.v       \
+	    FibonacciPR.v       \
+	    isqrt.v       \
+
 
 TEX_FILE = $(COQ_FILES:.v=.tex)
 

--- a/doc/movies/Makefile
+++ b/doc/movies/Makefile
@@ -28,6 +28,8 @@ COQ_FILES = Ack.v               \
 	    MorePRExamples.v       \
 	    FibonacciPR.v       \
 	    isqrt.v       \
+	    Iterates.v       \
+	    MoreVectors.v       \
 
 
 TEX_FILE = $(COQ_FILES:.v=.tex)

--- a/doc/movies/Makefile
+++ b/doc/movies/Makefile
@@ -19,11 +19,13 @@ COQ_FILES = Ack.v               \
 	    primRec.v           \
 	    PrimRecExamples.v   \
 	    F_alpha.v           \
+	    L_alpha.v           \
 	    F_omega.v           \
 	    Hydra_Definitions.v \
 	    Hydra_Theorems.v    \
 	    Hydra_Examples.v    \
 	    Hydra_Lemmas.v      \
+	    Battle_length.v      \
 	    extEqualNat.v       \
 	    MorePRExamples.v       \
 	    FibonacciPR.v       \

--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -4925,17 +4925,17 @@ Define on \texttt{Omega2} an addition compatible with the addition on \texttt{Ep
 
     \end{project}
 
-    \index{hydras}{Projects}
-    \begin{project}
-      Prove that ordinal multiplication is left-distributive over ordinal addition; that is:
-      $$\forall \alpha \, \beta \, \gamma < \epsilon_0, \alpha\times(\beta+\gamma) = \alpha\times\beta+ \alpha\times \gamma$$
-
-    \end{project}
+ 
 
     \section{A refinement of \texttt{E0} : an ordinal notation for \texorpdfstring{$\omega^\omega$}{omega\^omega}}
 
     In Module   \href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/OrdinalNotations/OmegaOmega.v}{theories/ordinals/OrdinalNotations/OmegaOmega.v},
-we represents ordinals below $\omega^\omega$ by list of pairs of natural numbers. we establish this representation as a \emph{refinement} of the data types we used to represent ordinals less than $\epsilon_0$. Thus, many properties like well-foundedness of $<$ and associativity of $+$,  of this ordinal notations have very short proofs.
+    we represent ordinals below $\omega^\omega$ by list of pairs of natural numbers (with the same coefficient shift as in \texttt{T1}).
+    For instance, the ordinal $\omega^4\times 10 + \omega^3 + \omega+ 5$ is represented by the list \texttt{(4,9)::(3,0)::(1,0)::(0,4)::nil}.
+
+  The usual operations : \texttt{succ}, \texttt{+}, \texttt{*} are simple variants of the same operations in \texttt{T1}.
+
+    We establish this representation as a \emph{refinement} of the data types we used to represent ordinals less than $\epsilon_0$. Thus, many properties like well-foundedness of $<$ and associativity of $+$,  of this ordinal notations have very short proofs.
     
 %ici
     \section{A variant for hydra battles}

--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -4931,6 +4931,13 @@ Define on \texttt{Omega2} an addition compatible with the addition on \texttt{Ep
       $$\forall \alpha \, \beta \, \gamma < \epsilon_0, \alpha\times(\beta+\gamma) = \alpha\times\beta+ \alpha\times \gamma$$
 
     \end{project}
+
+    \section{A refinement of \texttt{E0} : an ordinal notation for \texorpdfstring{$\omega^\omega$}{omega\^omega}}
+
+    In Module   \href{https://github.com/coq-community/hydra-battles/blob/master/theories/ordinals/OrdinalNotations/OmegaOmega.v}{theories/ordinals/OrdinalNotations/OmegaOmega.v},
+we represents ordinals below $\omega^\omega$ by list of pairs of natural numbers. we establish this representation as a \emph{refinement} of the data types we used to represent ordinals less than $\epsilon_0$. Thus, many properties like well-foundedness of $<$ and associativity of $+$,  of this ordinal notations have very short proofs.
+    
+%ici
     \section{A variant for hydra battles}
 
     In order to prove the termination of any hydra battle, we try to define a variant mapping hydras to ordinals strictly less than $\epsilon_0$.

--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -73,7 +73,7 @@ we found in the following articles.
 \chapter{Hydras and hydra games}
 
 \label{sec:orgheadline91}
-
+\label{chapter:hydras}
 
 
 
@@ -639,26 +639,10 @@ In order to get an appropriate induction scheme for the types
 \index{coq}{Mutually inductive types}
 \index{coq}{Commands!Scheme}
 
-\begin{Coqsrc}
-Scheme Hydra_rect2 := Induction for Hydra Sort Type
-with Hydrae_rect2 := Induction for Hydrae Sort Type.
-\end{Coqsrc}  
+\input{movies/snippets/Hydra_Definitions/HydraRect2}
 
+\input{movies/snippets/Hydra_Examples/HydraRect2Check}
 
-\begin{Coqsrc}
-Check Hydra_rect2.
-\end{Coqsrc}
-
-
-\begin{Coqanswer}
-Hydra_rect2
- : forall (P : Hydra -> Type) (P0 : Hydrae -> Type),
-   (forall h : Hydrae, P0 h -> P (node h)) ->
-    P0 hnil ->
-    (forall h : Hydra, P h -> 
-             forall h0 : Hydrae, P0 h0 -> P0 (hcons h h0)) ->
-    forall h : Hydra, P h
-\end{Coqanswer}  
 
 
 
@@ -670,25 +654,15 @@ Using this scheme requires an auxiliary predicate, called \texttt{P0} in \texttt
 
 \vspace{4pt}
 \noindent
+\emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Definitions.html}{Hydra.Hydra\_Definitions}}
+
+\input{movies/snippets/Hydra_Definitions/hForall}
+
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Examples.html}{Hydra.Hydra\_Examples}}
 
-\begin{Coqsrc}
-(** All elements of s satisfy P *)
+\input{movies/snippets/Hydra_Examples/heightLtSizea}
 
-Fixpoint h_forall (P: Hydra -> Prop) (s: Hydrae) :=
-  match s with
-      hnil => True
-    | hcons h s' => P h /\ h_forall P s'
-  end.
- \end{Coqsrc}
 
- \begin{Coqsrc}
-Lemma height_lt_size (h:Hydra) :
- height h < hsize h.
-Proof.
-  induction h using Hydra_rect2  with 
-  (P0 :=  h_forall (fun h =>  height h < hsize h)).
- \end{Coqsrc}
 
 \begin{enumerate}
 \item The first subgoal is as follows:

--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -465,13 +465,8 @@ For this purpose, we define two mutual \emph{ad-hoc}  inductive types, where \te
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Definitions.html\#Hydra}{Hydra.Hydra\_Definitions}}
 
-\begin{Coqsrc}
-Inductive Hydra : Set :=
-| node :  Hydrae -> Hydra
-with Hydrae : Set :=
-| hnil : Hydrae
-| hcons : Hydra -> Hydrae -> Hydrae.
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Definitions/HydraDef}
+
 
 %\index{To do}
 \index{hydras}{Projects}
@@ -489,14 +484,7 @@ Look for an existing library on trees with nodes of arbitrary arity, in order to
 type \texttt{Hydrae}:
 
 
-\begin{Coqalt}
-Module Alt.
-
-Inductive Hydra: Set :=
-  hnode (daughters : list Hydra).
-
-End Alt.
-\end{Coqalt}
+\input{movies/snippets/Hydra_Definitions/HydraAlt}
 
 Using this representation, re-define all the constructions of this chapter.
 You will probably have to use patterns described for instance in~\cite{BC04} or the archives of the Coq-club~\cite{Coq}.
@@ -522,17 +510,8 @@ We provide several notations for hydra patterns  which occur often in our develo
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Definitions.html\#head}{Hydra.Hydra\_Definitions}}
 
-\begin{Coqsrc}
-(** heads *)
-Notation head := (node hnil).
- 
-(** nodes  with 1, 2 or 3 daughters *)
-Notation hyd1 h := (node (hcons h hnil)).
-Notation hyd2 h h' := (node (hcons h (hcons h' hnil))).
-Notation hyd3 h h' h'' := 
-                   (node (hcons h (hcons h' (hcons h'' hnil)))).
-\end{Coqsrc}
 
+\input{movies/snippets/Hydra_Definitions/headsEtc}
 
 For instance, the hydra \texttt{Hy}  of Figure~\vref{fig:Hy} is defined in \emph{Gallina} as follows:
 
@@ -540,14 +519,7 @@ For instance, the hydra \texttt{Hy}  of Figure~\vref{fig:Hy} is defined in \emph
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Examples.html\#Hy}{Hydra.Hydra\_Examples}}
 
-\begin{Coqsrc}
-Example Hy := hyd3 head
-                   (hyd2
-                      (hyd1 
-                         (hyd2 head head))
-                      head) 
-                   head.
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Examples/Hy}
 
 
 
@@ -558,18 +530,9 @@ will help us to describe and reason about replications in hydra battles.
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Definitions.html\#hcons_mult}{Hydra.Hydra\_Definitions}}
 
-\begin{Coqsrc}
-Fixpoint hcons_mult (h:Hydra)(n:nat)(s:Hydrae):Hydrae :=
-  match n with 
-  | O => s
-  | S p => hcons h (hcons_mult h p s)
-  end.
+\input{movies/snippets/Hydra_Definitions/hconsMult}
 
-(** A node with n clones of the same daughter *)
 
-Definition hyd_mult h n :=
-  node (hcons_mult h n hnil).
-\end{Coqsrc}
 
 \vspace{4mm}
 
@@ -581,12 +544,9 @@ For instance, the hydra $Hy''$ of Fig~\vref{fig:Hy3}  can be defined in \coq{} a
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Examples.html}{Hydra.Hydra\_Examples}}
 
-\begin{Coqsrc}
-Example Hy'' := 
-     hyd2 head
-          (hyd2 (hyd_mult (hyd1 head) 5)
-                head).
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Examples/HySecond}
+
+
 
 
 
@@ -606,47 +566,19 @@ Let us define for instance the function which  computes the number of nodes of a
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Definitions.html}{Hydra.Hydra\_Definitions}}
 
+\input{movies/snippets/Hydra_Definitions/hsize}
 
-\begin{Coqsrc}
-Fixpoint hsize (h:Hydra) : nat :=
-  match h with node l => S (lhsize l)
-  end
-with lhsize l : nat :=
-  match l with hnil => 0
-            | hcons h hs => hsize h + lhsize hs 
-  end.
-
- Compute hsize Hy.
-\end{Coqsrc}
-
-\begin{Coqanswer}
- = 9
-     : nat 
-\end{Coqanswer}
+\input{movies/snippets/Hydra_Examples/HySize}
 
 
 Likewise, the \emph{height} (maximum distance between the foot and a head) 
 is defined by mutual recursion:
 
-\begin{Coqsrc}
-Fixpoint height  (h:Hydra) : nat :=
-  match h with node l => lheight l
-  end
-with lheight l : nat :=
-  match l with 
-  | hnil => 0
-  | hcons h hs => Max.max (S (height h)) (lheight hs)
-  end.
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Definitions/height}
 
-\begin{Coqsrc}
-Compute height Hy.
-\end{Coqsrc}
+\input{movies/snippets/Hydra_Examples/HyHeight}
 
-\begin{Coqanswer}
- = 4
-     : nat  
-\end{Coqanswer}
+
 
 \index{hydras}{Exercises}
 
@@ -670,64 +602,34 @@ In this section, we show how induction principles are used to prove properties o
 
 One may try to use the default tactic of proof by induction, which corresponds to an application of the automatically  generated  induction principle for  type \texttt{Hydra}:
 
-\begin{Coqanswer}
-Hydra_ind :
-forall P : Hydra -> Prop,
-(forall h : Hydrae, P (node h)) -> forall h : Hydra, P h
-\end{Coqanswer}
+\input{movies/snippets/Hydra_Examples/HydraInd}
 
-Ler us start a simple proof by induction.
+Let us start a simple proof by induction.
 
 \vspace{4pt}
 \noindent
 \emph{From Module~\href{../theories/html/hydras.Hydra.Hydra_Examples.html}{Hydra.Hydra\_Examples}}
 
-\begin{Coqbad}
-Module Bad.
+\input{movies/snippets/Hydra_Examples/BadInductiona}
 
-Lemma height_lt_size (h:Hydra) :
-  height h <= hsize h.
-Proof.
-  induction h as [s].
-\end{Coqbad}
 
-\begin{Coqanswer}
-1 subgoal, subgoal 1 (ID 11)
-  
-  s : Hydrae
-  ============================
-   height (node s) <= hsize (node s)
-\end{Coqanswer}
 
 We might be tempted to do an induction on the sequence \texttt{s}:
 
-% \begin{Coqbad}
-% induction  s as [ | h s'].
-%   -   cbn; auto with arith.
-%   - 
-% \end{Coqbad}
+\input{movies/snippets/Hydra_Examples/BadInductionb}
 
+The first subgoal is trivial.
 
-\begin{Coqanswer}
- 1 focused subgoal
-(unfocused: 0), subgoal 1 (ID 19)
-  
-  h : Hydra
-  s' : Hydrae
-  IHs' : height (node s') <= hsize (node s')
-  ============================
-   height (node (hcons h s')) <= hsize (node (hcons h s'))
+\input{movies/snippets/Hydra_Examples/BadInductionc}
 
-\end{Coqanswer}
+Let us look at the second sub-goal of the induction.
 
-Note that the displayed subgoal does not contain any assumption on \texttt{h}, thus there is no way to 
-infer any property about the height and size of the hydra \texttt{(hcons h t)}.
+\input{movies/snippets/Hydra_Examples/BadInductiond}
 
-\begin{Coqbad}
-Abort.
+We notice that this subgoal does not contain any hypothesis
+on the height and size of the hydra \texttt{h}. So, it looks hard to prove the conclusion. Let's stop.
 
-End Bad.
-\end{Coqbad}
+\input{movies/snippets/Hydra_Examples/BadInductione}
 
 \subsubsection{A Principle of mutual induction}
 In order to get an appropriate induction scheme for the types 

--- a/doc/thebib.bib
+++ b/doc/thebib.bib
@@ -882,4 +882,46 @@ author = "Nachum Dershowitz",
   howpublished = {https://planetmath.org/ackermannfunctionisnotprimitiverecursive}
 }
 
+@inproceedings{alectryonpaper,
+author = {Pit-Claudel, Cl\'{e}ment},
+title = {Untangling Mechanized Proofs},
+year = {2020},
+isbn = {9781450381765},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+url = {https://doi.org/10.1145/3426425.3426940},
+doi = {10.1145/3426425.3426940},
+abstract = {Proof assistants like Coq, Lean, or HOL4 rely heavily on stateful meta-programs called
+scripts to assemble proofs. Unlike pen-and-paper proofs, proof scripts only describe
+the steps to take (induct on x, apply a theorem, …), not the states that these steps
+lead to; as a result, plain proof scripts are essentially incomprehensible without
+the assistance of an interactive user interface able to run the script and show the
+corresponding proof states. Until now, the standard process to communicate a proof
+without forcing readers to execute its script was to manually copy-paste intermediate
+proof states into the script, as source code comments — a tedious and error-prone
+exercise. Additional prose (such as for a book or tutorial) was likewise embedded
+in comments, preserving executability at the cost of a mediocre text-editing experience.
+This paper describes a new approach to the development and dissemination of literate
+proof scripts, with a focus on the Coq proof assistant. Specifically, we describe
+two contributions: a compiler that interleaves Coq’s output with the original proof
+script to produce interactive webpages that are complete, self-contained presentations
+of Coq proofs; and a new literate programming toolkit that allows authors to switch
+seamlessly between prose- and code-oriented views of the same sources, by translating
+back and forth between reStructuredText documents and literate Coq source files. In
+combination, these tools offer a new way to write, communicate, and preserve proofs,
+combining the flexibility of procedural proof scripts and the intelligibility of declarative
+proofs.},
+booktitle = {Proceedings of the 13th ACM SIGPLAN International Conference on Software Language Engineering},
+pages = {155–174},
+numpages = {20},
+keywords = {literate programming, proof presentation, formal verification, proof browsing},
+location = {Virtual, USA},
+series = {SLE 2020}
+}
 
+  
+@Misc{alectryongithub,
+  author = {Pit-Claudel, Cl\'{e}ment},
+  title = 	 {Alectryon},
+  howpublished = {https://github.com/cpitclaudel/alectryon}
+}

--- a/theories/ordinals/Ackermann/extEqualNat.v
+++ b/theories/ordinals/Ackermann/extEqualNat.v
@@ -16,12 +16,15 @@ Fixpoint naryRel (n : nat) : Set :=
   | S n => nat -> naryRel n
   end.
 
+(* begin snippet extEqualDef *)
+
 Fixpoint  extEqual (n : nat) : forall  (a b : naryFunc n), Prop :=
   match n with
     0 => fun a b => a = b
   | S p => fun a b => forall c, extEqual p (a c) (b c)
   end.
 
+(* end snippet extEqualDef *)
 
 
 Fixpoint charFunction (n : nat) : naryRel n -> naryFunc n :=

--- a/theories/ordinals/Ackermann/primRec.v
+++ b/theories/ordinals/Ackermann/primRec.v
@@ -19,23 +19,30 @@ Require Import Max.
 (** [PrimRec n] : data type of primitive recursive functions of arity [n] 
     [PrimRec n m] : m-tuples of [PrimRec n] *)
 
+(* begin snippet PrimRecDef *)
+
 Inductive PrimRec : nat -> Set :=
   | succFunc : PrimRec 1
   | zeroFunc : PrimRec 0
   | projFunc : forall n m : nat, m < n -> PrimRec n
   | composeFunc :
-      forall (n m : nat) (g : PrimRecs n m) (h : PrimRec m), PrimRec n
+      forall (n m : nat) (g : PrimRecs n m) (h : PrimRec m),
+        PrimRec n
   | primRecFunc :
-      forall (n : nat) (g : PrimRec n) (h : PrimRec (S (S n))), PrimRec (S n)
+      forall (n : nat) (g : PrimRec n) (h : PrimRec (S (S n))),
+        PrimRec (S n)
 with PrimRecs : nat -> nat -> Set :=
   | PRnil : forall n : nat, PrimRecs n 0
-  | PRcons : forall n m : nat, PrimRec n -> PrimRecs n m -> PrimRecs n (S m).
+  | PRcons : forall n m : nat, PrimRec n -> PrimRecs n m ->
+                               PrimRecs n (S m).
 
 Scheme PrimRec_PrimRecs_rec := Induction for PrimRec Sort Set
   with PrimRecs_PrimRec_rec := Induction for PrimRecs  Sort Set.
 
 Scheme PrimRec_PrimRecs_ind := Induction for PrimRec Sort Prop
   with PrimRecs_PrimRec_ind := Induction for PrimRecs  Sort Prop.
+
+(* end snippet PrimRecDef *)
 
 (** ** Semantics *)
 
@@ -142,6 +149,8 @@ Fixpoint evalPrimRecFunc (n : nat) (g : naryFunc n)
 
 (**  The interpretation function *)
 
+(* begin snippet evalPrimRecDef *)
+
 Fixpoint evalPrimRec (n : nat) (f : PrimRec n) {struct f} : 
  naryFunc n :=
   match f in (PrimRec n) return (naryFunc n) with
@@ -158,8 +167,11 @@ Fixpoint evalPrimRec (n : nat) (f : PrimRec n) {struct f} :
  Vector.t (naryFunc n) m :=
   match fs in (PrimRecs n m) return (Vector.t (naryFunc n) m) with
   | PRnil a => Vector.nil  (naryFunc a)
-  | PRcons a b g gs => Vector.cons _ (evalPrimRec _ g) _ (evalPrimRecs _ _ gs)
+  | PRcons a b g gs =>
+    Vector.cons _ (evalPrimRec _ g) _ (evalPrimRecs _ _ gs)
   end.
+
+(* end snippet evalPrimRecDef *)
 
 Definition extEqualVectorGeneral (n m : nat) (l : Vector.t (naryFunc n) m) :
   forall (m' : nat) (l' : Vector.t (naryFunc n) m'), Prop.
@@ -257,8 +269,12 @@ Qed.
 
 (** ** Predicates "to be primitive recursive"  *)
 
+(* begin snippet isPRDef *)
+
 Definition isPR (n : nat) (f : naryFunc n) : Set :=
   {p : PrimRec n | extEqual n (evalPrimRec _ p) f}.
+
+(* end snippet isPRDef *)
 
 Definition isPRrel (n : nat) (R : naryRel n) : Set :=
   isPR n (charFunction n R).
@@ -288,11 +304,21 @@ Qed.
 
 (** ** Usual projections (in curried form) are primitive recursive *)
 
+(*| 
+.. coq:: no-out 
+|*)
+
+(* begin snippet idIsPR *)
+
 Lemma idIsPR : isPR 1 (fun x : nat => x).
 Proof.
   assert (H: 0 < 1) by auto.
   exists (projFunc 1 0 H); cbn; auto.
 Qed.
+
+(* end snippet idIsPR *)
+
+(*||*)
 
 Lemma pi1_2IsPR : isPR 2 (fun a b : nat => a).
 Proof.

--- a/theories/ordinals/Ackermann/primRec.v
+++ b/theories/ordinals/Ackermann/primRec.v
@@ -36,13 +36,21 @@ with PrimRecs : nat -> nat -> Set :=
   | PRcons : forall n m : nat, PrimRec n -> PrimRecs n m ->
                                PrimRecs n (S m).
 
+
+(* end snippet PrimRecDef *)
+
+
 Scheme PrimRec_PrimRecs_rec := Induction for PrimRec Sort Set
   with PrimRecs_PrimRec_rec := Induction for PrimRecs  Sort Set.
+
+(* begin snippet SchemePrimRecInd *)
 
 Scheme PrimRec_PrimRecs_ind := Induction for PrimRec Sort Prop
   with PrimRecs_PrimRec_ind := Induction for PrimRecs  Sort Prop.
 
-(* end snippet PrimRecDef *)
+Check PrimRec_PrimRecs_ind.
+(* end snippet SchemePrimRecInd *)
+
 
 (** ** Semantics *)
 
@@ -100,12 +108,18 @@ Qed.
 
 (**  Applies an m-ary function to the vector l *)
 
+(* begin snippet evalListDef *)
+
 Fixpoint evalList (m : nat) (l : Vector.t nat m) {struct l} :
- naryFunc m -> nat :=
+  naryFunc m -> nat :=
   match l  in (Vector.t _ m) return (naryFunc m -> nat) with
   | Vector.nil => fun x : naryFunc 0 => x
-  | Vector.cons a n l' => fun x : naryFunc (S n) => evalList n l' (x a)
+  | Vector.cons a n l' =>
+    fun x : naryFunc (S n) => evalList n l' (x a)
   end.
+
+(* end snippet evalListDef *)
+
 
 Fixpoint evalOneParamList (n m a : nat) (l : Vector.t (naryFunc (S n)) m)
  {struct l} : Vector.t (naryFunc n) m :=

--- a/theories/ordinals/Epsilon0/E0.v
+++ b/theories/ordinals/Epsilon0/E0.v
@@ -108,7 +108,7 @@ Coercion Fin : nat >-> E0.
 
 Instance Mult (alpha beta : E0) : E0.
 Proof.
-  refine (@mkord (cnf alpha * cnf beta)%t1 _); apply nf_mult; apply cnf_ok.
+  refine (@mkord (cnf alpha * cnf beta)%t1 _); apply mult_nf; apply cnf_ok.
 Defined.
 
 
@@ -117,7 +117,7 @@ Infix "*" := Mult : E0_scope.
 Instance Mult_i  (alpha: E0) (n: nat) : E0.
 Proof.
   refine (@mkord (cnf alpha * n)%t1  _).
-  apply nf_mult_fin, cnf_ok.
+  apply mult_nf_fin, cnf_ok.
 Defined.
 
 (** ** Lemmas *)

--- a/theories/ordinals/Epsilon0/E0.v
+++ b/theories/ordinals/Epsilon0/E0.v
@@ -85,6 +85,8 @@ Proof.
   apply nf_phi0; apply cnf_ok.
 Defined.
 
+Notation "'omega^'" := phi0 (only parsing) : E0_scope.
+
 Instance Omega_term (alpha: E0) (n: nat) : E0.
 Proof.
   refine (@mkord (ocons (cnf alpha) n zero) _).
@@ -785,7 +787,7 @@ Proof.
 Qed.
 
 
-Example Ex42: (omega + 42 + phi0 2 = phi0 2)%e0.
+Example Ex42: (omega + 42 + omega^ 2 = omega^  2)%e0.
 Proof. 
   now rewrite <-  Comparable.compare_eq_iff.
 Qed.

--- a/theories/ordinals/Epsilon0/F_alpha.v
+++ b/theories/ordinals/Epsilon0/F_alpha.v
@@ -758,11 +758,19 @@ Qed.
 
 End H'_F.
 
-(** Proof using transfinite induction (prepared in the previous section) *)
+(* begin snippet HprimeF *)
 
-Lemma H'_F alpha : forall n,  (F_ alpha (S n) <= H'_ (phi0 alpha) (S n))%nat.
+(*|
+.. coq:: no-out 
+|*)
+
+Lemma H'_F alpha : forall n,  F_ alpha (S n) <= H'_ (phi0 alpha) (S n).
 Proof.
   pattern alpha; apply well_founded_induction with Lt.
+
+  (*||*)
+(* end snippet HprimeF *)
+  
   - apply Lt_wf.  
   -  clear alpha; intros alpha IHalpha.
      destruct (Zero_Limit_Succ_dec alpha) as [[Hzero | Hlim] | Hsucc].

--- a/theories/ordinals/Epsilon0/F_omega.v
+++ b/theories/ordinals/Epsilon0/F_omega.v
@@ -61,7 +61,11 @@ Proof.
   - intros; apply L; auto.
 Qed.
 
-Lemma F_vs_Ack n : 2 <= n -> Ack n n <= F_ omega n.
+(* begin snippet FVsAck *)
+
+Lemma F_vs_Ack n : 2 <= n -> Ack n n <= F_ omega n. (* .no-out *)
+(* end snippet FVsAck *)
+
 Proof.
   intros; rewrite F_lim_eqn.
   - rewrite Canon.Canon_Omega; apply L2; auto.

--- a/theories/ordinals/Epsilon0/L_alpha.v
+++ b/theories/ordinals/Epsilon0/L_alpha.v
@@ -196,8 +196,12 @@ Proof. apply L_ok. Qed.
 
 (** Comparison with Hardy's function H  *)
 
+(* begin snippet HprimeL *)
+
 Theorem H'_L_ alpha :
-  forall i:nat,  (H'_ alpha i <= L_ alpha (S i))%nat.
+  forall i:nat,  (H'_ alpha i <= L_ alpha (S i))%nat. (* .no-out *)
+(* end snippet HprimeL *)
+
 Proof with auto with E0.
   pattern alpha ; apply well_founded_induction with Lt ...
   clear alpha; intros alpha IHalpha i.

--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -2491,7 +2491,7 @@ Lemma cases_for_mult (alpha : T1) :
   nf alpha -> 
   alpha = zero \/
   (exists n : nat, alpha = FS n) \/
-  (exists a n, a<> zero /\ alpha = ocons a n zero) \/
+  (exists a n, a <> zero /\ alpha = ocons a n zero) \/
   (exists a n b,  a <> zero /\ b <> zero /\ alpha = ocons a n b).
 Proof.
   destruct alpha.

--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -2225,7 +2225,7 @@ Proof.
     intros; subst a1; now  rewrite mult_1_r.
 Qed.
 
-Lemma nf_mult_fin alpha n:
+Lemma mult_nf_fin alpha n:
   nf alpha -> nf (alpha * fin n).
 Proof.
   revert n; induction n.
@@ -2651,7 +2651,7 @@ Qed.
 
 
 
-Section Proof_of_nf_mult.
+Section Proof_of_mult_nf.
 
   Variable alpha : T1.
   Hypothesis Halpha : nf alpha.
@@ -2686,7 +2686,7 @@ Section Proof_of_nf_mult.
     Lemma L3 n p : alpha = FS n -> beta = FS p -> P beta.
     Proof.
       intros; subst; red; intros; split.
-      - apply (nf_mult_fin  (S p) H).
+      - apply (mult_nf_fin  (S p) H).
       - intros _ gamma H1; destruct (LT_of_finite H1 ).
         + subst; rewrite mult_a_0; eauto with T1.
         +  destruct H0 as [p0 [H2 H3]]; subst; simpl.
@@ -3058,11 +3058,11 @@ Section Proof_of_nf_mult.
   Qed.
 
 
-End Proof_of_nf_mult.
+End Proof_of_mult_nf.
 
 
 
-Theorem nf_mult alpha beta : nf alpha -> nf beta ->
+Theorem mult_nf alpha beta : nf alpha -> nf beta ->
                              nf (alpha * beta).
 Proof.
   intros.
@@ -3082,7 +3082,7 @@ Lemma nf_exp_F alpha n : nf alpha -> nf (exp_F alpha n).
 Proof.
   induction n; cbn.
   - eauto with T1.
-  - intro; apply nf_mult; auto.
+  - intro; apply mult_nf; auto.
 Qed.
 
 

--- a/theories/ordinals/Gamma0/Gamma0.v
+++ b/theories/ordinals/Gamma0/Gamma0.v
@@ -3668,7 +3668,7 @@ Proof.
   - unfold compare; rewrite compare_rw_gt; auto.
 Qed. 
 
-Instance Zero : G0.
+Instance zero : G0.
 Proof.
   refine (@mkg0 T2.zero _);  now compute. 
 Defined.
@@ -3718,13 +3718,16 @@ Proof.
   red in vnf_ok0, vnf_ok1. red. 
   rewrite nfb_equiv in *.
   now apply phi_nf.
-Defined. 
+Defined.
+
+Notation phi := Phi.
+Notation phi0 := (Phi zero).
 
 Coercion Finite : nat >-> G0.
 
 Local Open Scope g0_scope.
 
-Example ex42 : omega + 42 + Phi Zero 2 = Phi Zero 2.
+Example Ex42 : omega + 42 + phi zero 2 = phi zero 2.
 Proof.
   now rewrite <- Comparable.compare_eq_iff.
 Qed.

--- a/theories/ordinals/Gamma0/Gamma0.v
+++ b/theories/ordinals/Gamma0/Gamma0.v
@@ -3722,12 +3722,13 @@ Defined.
 
 Notation phi := Phi.
 Notation phi0 := (Phi zero).
+Notation "'omega^'" := phi0 (only parsing) : g0_scope.
 
 Coercion Finite : nat >-> G0.
 
 Local Open Scope g0_scope.
 
-Example Ex42 : omega + 42 + phi zero 2 = phi zero 2.
+Example Ex42 : omega + 42 + omega^ 2 = omega^ 2.
 Proof.
   now rewrite <- Comparable.compare_eq_iff.
 Qed.

--- a/theories/ordinals/Hydra/Battle_length.v
+++ b/theories/ordinals/Hydra/Battle_length.v
@@ -13,6 +13,8 @@ From hydras  Require Import Hydra_Lemmas  Epsilon0_Needed_Free
      Epsilon0_Needed_Std Hydra_Termination O2H.
 Import E0 Large_Sets Hprime Paths MoreLists.
 
+
+
 Section Battle_length.
 
   Variable alpha : E0.
@@ -85,13 +87,17 @@ Section Battle_length.
   
 End Battle_length.
 
+(* begin snippet BattleLength  *)
+
 Definition l_std alpha k := (L_ alpha (S k) - k)%nat.
 
 Lemma l_std_ok : forall alpha : E0,
     alpha <> Zero ->
     forall k : nat,
       1 <= k -> battle_length standard k (iota (cnf alpha))
-                              (l_std alpha k).
+                              (l_std alpha k). (* .no-out *)
+(* end snippet BattleLength  *)
+
 Proof. apply battle_length_std. Qed.
 
 

--- a/theories/ordinals/Hydra/Hydra_Definitions.v
+++ b/theories/ordinals/Hydra/Hydra_Definitions.v
@@ -36,9 +36,25 @@ End Alt.
 (**   Mutual induction scheme for types Hydra and Hydrae 
  *)
 
+
+(* begin snippet HydraRect2 *)
+
 Scheme Hydra_rect2 := Induction for Hydra Sort Type
 with   Hydrae_rect2 := Induction for Hydrae Sort Type.
 
+(* end snippet HydraRect2 *)
+
+(* begin snippet hForall *)
+
+(** All elements of s satisfy P *)
+
+Fixpoint h_forall (P: Hydra -> Prop) (s: Hydrae) :=
+  match s with
+    hnil => True
+  | hcons h s' => P h /\ h_forall P s'
+  end.
+
+(* end snippet hForall *)
 
 Lemma h_eq_dec : forall h h':Hydra, {h = h'}+{h <> h'}
 with hs_eq_dec : forall l l':Hydrae, {l = l'}+{l <> l'}.

--- a/theories/ordinals/Hydra/Hydra_Definitions.v
+++ b/theories/ordinals/Hydra/Hydra_Definitions.v
@@ -10,13 +10,19 @@
 From Coq Require Export Relations Max.
 From hydras Require Import T1 Epsilon0.
 
+(* begin snippet HydraDef *)
+
 Inductive Hydra : Set :=
 |  node :  Hydrae -> Hydra
 with Hydrae : Set :=
 | hnil : Hydrae
 | hcons : Hydra -> Hydrae -> Hydrae.
 
+(* end snippet HydraDef *)
+
 (** Alternative representation (discarded) *)
+
+(* begin snippet HydraAlt *)
 
 Module Alt.
 
@@ -25,6 +31,7 @@ Module Alt.
 
 End Alt.
 
+(* end snippet HydraAlt *)
 
 (**   Mutual induction scheme for types Hydra and Hydrae 
  *)
@@ -44,6 +51,8 @@ Defined.
 (**   Number of nodes (a.k.a. size)
  *)
 
+(* begin snippet hsize *)
+
 Fixpoint hsize (h:Hydra) : nat :=
   match h with node l => S (lhsize l)
   end
@@ -53,10 +62,12 @@ with lhsize l : nat :=
          | hcons h hs => hsize h + lhsize hs
   end.
 
-
+(* end snippet hsize *)
 
 (** ***  height (length of longest branch) 
  *)
+
+(* begin snippet height *)
 
 Fixpoint height  (h:Hydra) : nat :=
   match h with node l => lheight l
@@ -64,9 +75,10 @@ Fixpoint height  (h:Hydra) : nat :=
 with
 lheight l : nat :=
   match l with hnil => 0
-            | hcons h hs => Max.max (S (height h)) (lheight hs)
+          | hcons h hs => Max.max (S (height h)) (lheight hs)
   end.
 
+(* end snippet height *)
 
 (** ** Abbreviations 
  *)
@@ -74,18 +86,23 @@ lheight l : nat :=
 (** *** Heads : A head is just a node without daughters
 *)
 
+(* begin snippet headsEtc *)
+
 Notation head := (node hnil).
 
 (** *** Hydra with 1, 2 or 3 daughters 
  *)
 
-
 Notation hyd1 h := (node (hcons h hnil)).
 Notation hyd2 h h' := (node (hcons h (hcons h' hnil))).
 Notation hyd3 h h' h'' := (node (hcons h (hcons h' (hcons h'' hnil)))).
 
+(* end snippet headsEtc *)
+
 (** *** Adds n copies of the same hydra h at the right of  s 
 *)
+
+(* begin snippet hconsMult *)
 
 Fixpoint hcons_mult (h:Hydra)(n:nat)(s:Hydrae):Hydrae :=
   match n with 
@@ -100,7 +117,7 @@ Fixpoint hcons_mult (h:Hydra)(n:nat)(s:Hydrae):Hydrae :=
 Definition hyd_mult h n :=
   node (hcons_mult h n hnil).
 
-
+(* end snippet hconsMult *)
 
 (** ** Managing sequences of hydras
  *)

--- a/theories/ordinals/Hydra/Hydra_Examples.v
+++ b/theories/ordinals/Hydra/Hydra_Examples.v
@@ -9,13 +9,28 @@ Module Examples.
   Example ex1 : forall h h', R1 (hyd3 h head h') (hyd2 h h').
   Proof. split.  right; left. Qed.
 
-
+  (* begin snippet Hy *)
+  
   Example Hy := hyd3 head
                      (hyd2
                         (hyd1 
                            (hyd2 head head))
                         head) 
                      head.
+  (* end snippet Hy *)
+
+  (* begin snippet HySize *)
+
+  Compute hsize Hy.
+
+  (* end snippet HySize *)
+
+
+  (* begin snippet HyHeight *)
+
+  Compute height Hy.
+
+  (* end snippet HyHeight *)
   
   Example Hy' := hyd2 head
                       (hyd2
@@ -27,12 +42,15 @@ Module Examples.
   Example ex4:  round Hy Hy'.
   Proof.  chop_off 2. Qed.
 
+  (* begin snippet HySecond *)
   
   Example Hy'' := 
     hyd2 head
          (hyd2
             (hyd_mult (hyd1 head) 5)
             head).
+
+  (* end snippet HySecond *)
   
   Example Hy'H'' : round Hy' Hy''.
   Proof.
@@ -126,19 +144,48 @@ Module Examples.
 
 End Examples.
 
+(* begin snippet HydraInd *)
+
+Check Hydra_ind.
+
+(* end snippet HydraInd *)
+
+(* begin snippet BadInductiona *)
 
 Module Bad.
 
   Lemma  height_lt_size (h:Hydra) :
-    height h < hsize h.
-  Proof.
+    height h < hsize h. (* .no-out *)
+  Proof. (* .no-out *)
     induction h as [s].
-    induction s as [| h s'].
-    - simpl.  auto with arith.
-    - cbn.
+
+    (* end snippet BadInductiona *)
+
+    (* begin snippet BadInductionb *)
+    
+    induction s as [| h s']. (* .no-out *)
+
+    (* end snippet BadInductionb *)
+
+    (* begin snippet BadInductionc *)
+    
+    -  (* .no-in  .unfold *) simpl; auto with arith. (* .no-out *)
+
+    (* end snippet BadInductionc *)
+
+    (* begin snippet BadInductiond *)
+       
+    -  (* .no-in .unfold *)
+      (* end snippet BadInductiond *)
+      
+      (* begin snippet BadInductione *)
+      
   Abort.  
 
 End Bad.
+(* end snippet BadInductione *)
+  
+
 
 
 Fixpoint h_forall (P: Hydra -> Prop) (s: Hydrae) :=

--- a/theories/ordinals/Hydra/Hydra_Examples.v
+++ b/theories/ordinals/Hydra/Hydra_Examples.v
@@ -2,6 +2,12 @@ From Coq Require Import  Lia  Max.
 From hydras Require Import Hydra_Lemmas More_Arith.
 Open Scope nat_scope.
 
+(* begin snippet HydraRect2Check *)
+
+Check Hydra_rect2.
+
+(* end snippet HydraRect2Check *)
+
 
 Module Examples.
 
@@ -184,21 +190,22 @@ Module Bad.
 
 End Bad.
 (* end snippet BadInductione *)
-  
 
+(* begin snippet heightLtSizea *)
 
+(*|
+.. coq:: no-out
+|*)
 
-Fixpoint h_forall (P: Hydra -> Prop) (s: Hydrae) :=
-  match s with
-    hnil => True
-  | hcons h s' => P h /\ h_forall P s'
-  end.
-
-Lemma  height_lt_size (h:Hydra) :  height h < hsize h.
-Proof.
+Lemma  height_lt_size (h:Hydra) :  height h < hsize h. 
+Proof. 
   induction h using Hydra_rect2  with 
       (P0 :=  h_forall (fun h =>  height h < hsize h)).
-  -  destruct h as [ | h s'].
+(*||*)
+
+(* end snippet heightLtSizea *)
+  
+  -  destruct h as [ | h s']. 
      + cbn; auto with arith.
      +  simpl.  destruct IHh; assert (lheight s' <= lhsize s').
         { clear H; induction s'. 
@@ -218,7 +225,6 @@ Proof.
         *   lia. 
         *   specialize (max_le_plus (height h) n); lia.
   -  easy.   
-  -  split;auto. 
+  -  split;auto.
 Qed. 
-
 

--- a/theories/ordinals/Hydra/Hydra_Theorems.v
+++ b/theories/ordinals/Hydra/Hydra_Theorems.v
@@ -109,23 +109,33 @@ Require Import primRec F_alpha  AckNotPR PrimRecExamples.
 Require Import F_omega.
 Import E0.
 
+(* begin snippet battleLengthNotPRa *)
+
 Section battle_lenght_notPR.
 
-  (** We assume that the function with computes the length 
-      of standard battles is primitive recursive *)
-  
   Hypothesis H: forall alpha, isPR 1 (l_std alpha).
 
+  (* end snippet battleLengthNotPRa *)
+  
+
   (** A counter example *)
+
+  (* begin snippet battleLengthNotPRb *)
 
   Let alpha := phi0 omega%e0.
   Let h := iota (cnf alpha).
 
+   (* end snippet battleLengthNotPRb *)
+
   (** let us get rid of the substraction ... *)
+
+  (* begin snippet battleLengthNotPRc *)
   
   Let m k := L_ alpha (S k).
 
-  Remark m_eqn : forall k, m k = (l_std alpha k + k)%nat.
+  Remark m_eqn : forall k, m k = (l_std alpha k + k)%nat. (* .no-out *)
+  (* end snippet battleLengthNotPRc *)
+  
   Proof.
     intro k; assert (k <= L_ alpha (S k)).
     { assert (S k < L_ alpha (S k)).
@@ -137,7 +147,11 @@ Section battle_lenght_notPR.
     unfold m,l_std ; lia.   
   Qed.
 
-   Remark mIsPR : isPR 1 m.
+  (* begin snippet battleLengthNotPRd *)
+  
+  Remark mIsPR : isPR 1 m. (* .no-out *)
+
+   (* end snippet battleLengthNotPRd *)
   Proof.
     destruct (H alpha) as [x Hx].
     apply isPR_extEqual_trans with (fun k => (l_std alpha  k + k)%nat).
@@ -154,7 +168,11 @@ Section battle_lenght_notPR.
         now red.
   Qed.
 
-  Remark m_ge_F_omega : forall k,  F_ omega (S k) <= m (S k).
+  (* begin snippet mGeFOmega *)
+  
+  Remark m_ge_F_omega : forall k,  F_ omega (S k) <= m (S k). (* .no-out *)
+  (* end snippet mGeFOmega *)
+  
   Proof.
     intro k; rewrite m_eqn.
     transitivity (H'_ alpha (S k)).
@@ -179,8 +197,13 @@ Section battle_lenght_notPR.
     - intro; apply m_ge_Ack; auto with arith.
   Qed.
 
+  (* begin snippet mDominatesAck *)
+  
+  Remark m_dominates_Ack :
+    dominates (fun n =>  S (m n)) (fun n => Ack.Ack n n). (* .no-out *)
 
-  Remark m_dominates_Ack : dominates (fun n =>  S (m n)) (fun n => Ack.Ack n n).
+    (* end snippet mDominatesAck *)
+
   Proof.     
     exists 3; red; intros.
     apply Lt.le_lt_trans with (m p).
@@ -188,13 +211,24 @@ Section battle_lenght_notPR.
     - auto with arith.
   Qed.
 
-  Remark SmNotPR : isPR 1 (fun n => S (m n)) -> False.
+  (* begin snippet SmNotPR *)
+  
+  Remark SmNotPR : isPR 1 (fun n => S (m n)) -> False. (* .no-out *)
+ (* end snippet SmNotPR *)
+
+  
   Proof.
     intro; eapply dom_AckNotPR; eauto.
     apply m_dominates_Ack; auto.
   Qed.
  
 
+  (* begin snippet LNotPR *)
+  
+  (*| 
+.. coq:: no-out 
+|*)
+  
   Theorem LNotPR : False.
   Proof.
     apply SmNotPR,  compose1_1IsPR.
@@ -204,5 +238,7 @@ Section battle_lenght_notPR.
 
 End battle_lenght_notPR.
 
+(*||*)
 
+(* end snippet LNotPR *)
 

--- a/theories/ordinals/MoreAck/Ack.v
+++ b/theories/ordinals/MoreAck/Ack.v
@@ -478,8 +478,13 @@ Proof.
   - apply Ack_Sn_plus.
 Qed.
 
+(* begin snippet AckStrictMonoL *)
+
 Lemma Ack_strict_mono_l : forall n m p, n < m ->
-                                        Ack n (S p) < Ack m (S p).
+                                        Ack n (S p) < Ack m (S p). (* .no-out *)
+(* end snippet AckStrictMonoL *)
+
+
 Proof.
   induction 1.
   -  apply R5.

--- a/theories/ordinals/MoreAck/Ack.v
+++ b/theories/ordinals/MoreAck/Ack.v
@@ -168,6 +168,13 @@ End Alt3.
 
 (** *** Usual equations *)
 
+(* begin snippet AckRewrite *)
+
+(*|
+.. coq:: no-out 
+|*)
+
+
 Lemma Ack_0 : Ack 0 = S.
 Proof refl_equal.
 
@@ -178,26 +185,42 @@ Lemma Ack_S_S : forall m p,
     Ack (S m) (S p) = Ack m (Ack (S m) p).
 Proof. reflexivity. Qed.
 
+(*||*)
+
+(* end snippet AckRewrite *)
+
 (** *** First values *)
 
-Lemma Ack_1_n n : Ack 1 n = S (S n).
+(* begin snippet Ack1N *)
+
+Lemma Ack_1_n n : Ack 1 n = S (S n). (* .no-out *)
+
+(* end snippet Ack1N *)
+
 Proof.
   f_equal; induction n as [| p <-]; trivial.
 Qed.  
 
-Lemma Ack_2_n n: Ack 2  n = 2 * n + 3.
+(* begin snippet Ack2N *)
+
+Lemma Ack_2_n n: Ack 2  n = 2 * n + 3. (* .no-out *)
+
+(* end snippet Ack2N *)
+
 Proof.
   induction  n.
   - reflexivity. 
   - rewrite Ack_S_S, IHn, Ack_1_n; lia.
 Qed.
 
+(* begin snippet Ack3N *)
 
-Lemma Ack_3_n n: Ack 3 n = exp2 (S (S (S n))) - 3.
-  (* begin details *)
+Lemma Ack_3_n n: Ack 3 n = exp2 (S (S (S n))) - 3. (* .no-out *)
+
+(* end snippet Ack3N *)
+
 Proof.
   induction n.
-  (* begin details *)
   -  reflexivity.
   - rewrite Ack_S_S, Ack_2_n, IHn.
     change (exp2 (S (S (S (S n)))))
@@ -208,12 +231,14 @@ Proof.
       - cbn in IHn; lia.
     }
     lia.
-    (* end details *)
 Qed.
-(* end details *)
 
+(* begin snippet Ack4N *)
 
-Lemma Ack_4_n n : Ack 4 n = hyper_exp2 (S (S (S n))) - 3.
+Lemma Ack_4_n n : Ack 4 n = hyper_exp2 (S (S (S n))) - 3. (* .no-out *)
+
+(* end snippet Ack4N *)
+
 Proof.
   induction n.
   - reflexivity. 
@@ -399,7 +424,14 @@ Section Proof_of_nested_Ack_bound.
     - apply R1.
   Qed.
 
-  Lemma nested_Ack_bound k m n :  Ack k (Ack m n) <= Ack (2 + max k m) n.
+  (* begin snippet nestedAckBound *)
+  
+  Lemma nested_Ack_bound k m n :
+    Ack k (Ack m n) <= Ack (2 + max k m) n. (* .no-out *)
+  
+
+  (* end snippet nestedAckBound *)
+  
   Proof.
       pose (x:= Nat.max k m).
     (* begin details *)

--- a/theories/ordinals/MoreAck/AckNotPR.v
+++ b/theories/ordinals/MoreAck/AckNotPR.v
@@ -19,6 +19,12 @@ Import extEqualNat  VectorNotations.
 
  *)
 
+(*|
+.. coq:: no-out
+|*)
+
+(* begin snippet vApply *)
+
 Notation "'v_apply' f v" := (evalList _ v f) (at level 10, f at level 9).
 
 
@@ -34,12 +40,20 @@ Proof.
   intros; now cbn.
 Qed.
 
+(* end snippet vApply *)
+
+(*||*)
+
+(*  begin snippet majorizedDefs *)
+
 (** ** Comparing an n-ary and a binary functions *)
 
-Definition majorized {n} (f: naryFunc n) (A: naryFunc 2) : Prop :=
-  exists (q:nat), forall (v: t nat n), v_apply f v <= A q (max_v v).
+Definition majorized {n} (f: naryFunc n) (A: naryFunc 2) :=
+  exists (q:nat),
+    forall (v: t nat n), v_apply f v <= A q (max_v v).
 
-Definition majorizedPR {n} (x: PrimRec n) A := majorized (evalPrimRec n x) A.
+Definition majorizedPR {n} (x: PrimRec n) A :=
+  majorized (evalPrimRec n x) A.
 
 (** For vectors of functions *)
 
@@ -50,6 +64,8 @@ Definition majorizedS {n m} (fs : Vector.t (naryFunc n) m)
 
 Definition majorizedSPR {n m} (x : PrimRecs n m) :=
   majorizedS (evalPrimRecs _ _ x).
+
+(*  end snippet majorizedDefs *)
 
 Section evalList.
   
@@ -468,10 +484,21 @@ Section Proof_of_Ackn_PR.
     Qed.
 
   End S_step.
+  
   (* begin show *)
+
+  (* begin snippet AcknIsPR *)
+
+(*|
+.. coq:: no-out 
+|*)
+  
   Theorem Ackn_IsPR (n: nat) : isPR 1 (Ack n).
   Proof.
     induction n.
+
+ (* end snippet AcknIsPR *)
+  
     - cbn; apply succIsPR.
     - apply iSPR_Ack_Sn; auto.  
   Qed.

--- a/theories/ordinals/MoreAck/AckNotPR.v
+++ b/theories/ordinals/MoreAck/AckNotPR.v
@@ -219,7 +219,7 @@ Qed.
 
 (** *** The general case is proved by  induction on x *)
 
-(* begin snippet majorAnyPR *)
+(* begin snippet majorAnyPRa *)
 
 (*|
 .. coq:: no-out 
@@ -234,10 +234,10 @@ Proof.
   - apply majorProjection.
 (*||*)
     
-  - (* .no-out *)  destruct IHx, IHx0; red; exists (2 + max x0 x1).
-(*|
-.. coq:: none 
-|*)               
+  - (* .no-out *) destruct IHx, IHx0; red; exists (2 + max x0 x1). (* .no-out *)
+
+    (* end snippet majorAnyPRa *)
+    
     intro v; simpl evalPrimRec; rewrite evalListComp.
     (* begin details *)
     generalize 
@@ -254,8 +254,9 @@ Proof.
       * rewrite max_comm; apply nested_Ack_bound.
  
   (*||*)
+  (* begin snippet majorAnyPRb *)
         
-  -  (* .no-out *)  destruct IHx1 as [r Hg]; destruct IHx2 as [s Hh].
+  -  (* .no-out *)  destruct IHx1 as [r Hg]; destruct IHx2 as [s Hh]. (* .no-out *)
 
 (*|
 .. coq:: none
@@ -325,10 +326,11 @@ Proof.
         -- simpl max_v; fold z; transitivity (Ack (2 + max 2 q) z).
            ++ rewrite max_comm; apply nested_Ack_bound.
            ++ apply Ack_mono_l;  lia.
-    (*  Lists of PR functions *)
+
   (*||*)
+  (* end snippet majorAnyPRb *)
               
-  - (* .no-out *) red;cbn;  red; exists 0. (* .none *)
+   -  (* .no-out *) red;cbn;  red; exists 0. (* .none *)
     intro; rewrite Ack_0;  cbn; auto with arith. (* .none *)
   - (* .no-out *) red; cbn; red; destruct IHx, IHx0; exists (max x0 x1).
 (*|
@@ -348,7 +350,7 @@ Proof.
 (*||*)
 Qed. 
 
-(* end snippet majorAnyPR *)
+
 
 
 (** Let us specialize Lemma [majorAnyPR] to unary and binary  functions 
@@ -374,7 +376,7 @@ Qed.
 (* begin snippet majorPR2 *)
 
 Lemma majorPR2 (f: naryFunc 2)(Hf : isPR 2 f)
-  : exists (n:nat), forall x y,  f x y <= Ack n (max x  y). (* no-out *)
+  : exists (n:nat), forall x y,  f x y <= Ack n (max x  y). (* .no-out *)
 
 (* end snippet majorPR2 *)
 
@@ -412,18 +414,19 @@ Section Impossibility_Proof.
 
   Hypothesis HAck : isPR 2 Ack.
 
-  Lemma Ack_not_PR : False. (* .no-out *)
-  Proof. (* no-out *)
-    destruct (majorPR2_strict Ack HAck) as [m Hm].
-    (*|
+  Lemma Ack_not_PR : False.
+  (*|
 .. coq:: no-out
-|*)      
+|*)    
+  Proof. 
+    destruct (majorPR2_strict Ack HAck) as [m Hm].
     pose (X := max 2 m); specialize (Hm X X).
     rewrite max_idempotent in Hm;
       assert (H0: Ack m X <= Ack X X) by (apply Ack_mono_l; lia).
     lia.
-(*||*)
   Qed.
+  (*||*)
+
   
 End Impossibility_Proof.
 

--- a/theories/ordinals/MoreAck/AckNotPR.v
+++ b/theories/ordinals/MoreAck/AckNotPR.v
@@ -180,21 +180,35 @@ End evalList.
 
 (** *** Base cases *)
 
-Lemma majorSucc : majorizedPR  succFunc Ack.
+(* begin snippet majorSucc *)
+
+Lemma majorSucc : majorizedPR  succFunc Ack. (* .no-out *)
+
+(* end snippet majorSucc *)
+
 Proof.
   exists 1; intro v; rewrite (decomp1 v).
   simpl evalList; simpl max_v; rewrite max_0_r.
   rewrite Ack_1_n; auto with arith.
 Qed.
 
+(* begin snippet majorZero *)
 
-Lemma majorZero : majorizedPR  zeroFunc Ack.
+Lemma majorZero : majorizedPR  zeroFunc Ack. (* .no-out *)
+
+(* end snippet majorZero *)
+
 Proof.
   exists 0; intro v; rewrite (t_0_nil _ v), Ack_0; cbn; auto with arith.
 Qed.
 
+(* begin snippet majorProjection *)
+
 Lemma majorProjection (n m:nat)(H: m < n):
-  majorizedPR (projFunc n m H) Ack.
+  majorizedPR (projFunc n m H) Ack. (* .no-out *)
+
+(* end snippet majorProjection *)
+
 Proof. 
   red; cbn; red; exists 0.
     rewrite Ack_0; intro v; transitivity (max_v v).
@@ -202,18 +216,28 @@ Proof.
     + auto with arith.
 Qed.
 
+
 (** *** The general case is proved by  induction on x *)
 
-Lemma majorAnyPR: forall n (x: PrimRec n), majorizedPR  x Ack.
-(* begin details : A long proof ... *)
-Proof.
+(* begin snippet majorAnyPR *)
+
+(*|
+.. coq:: no-out 
+|*)
+
+Lemma majorAnyPR: forall n (x: PrimRec n), majorizedPR  x Ack. (* .no-out *)
+Proof. 
   intros n x; induction x using PrimRec_PrimRecs_ind with
                   (P0 := fun n m y => majorizedSPR  y Ack).
   - apply majorSucc.
   - apply majorZero.
-  - apply majorProjection. 
-  -  (** function composition *)
-    destruct IHx, IHx0; red; exists (2 + max x0 x1). 
+  - apply majorProjection.
+(*||*)
+    
+  - (* .no-out *)  destruct IHx, IHx0; red; exists (2 + max x0 x1).
+(*|
+.. coq:: none 
+|*)               
     intro v; simpl evalPrimRec; rewrite evalListComp.
     (* begin details *)
     generalize 
@@ -228,13 +252,18 @@ Proof.
                                      (evalPrimRecs n m g)) a H1).
         intro H2;lia.
       * rewrite max_comm; apply nested_Ack_bound.
-  (* end details *)
-  - (** Primitive recursion *)
-    destruct IHx1 as [r Hg]; destruct IHx2 as [s Hh].
+ 
+  (*||*)
+        
+  -  (* .no-out *)  destruct IHx1 as [r Hg]; destruct IHx2 as [s Hh].
+
+(*|
+.. coq:: none
+|*)
+    
     remember  (evalPrimRec n x1) as g.
     remember (evalPrimRec _ x2) as h.
     pose(q := S  (max r s)); red.
-    (* begin details *)
     remember  (evalPrimRecFunc _ (evalPrimRec _ x1)
                                (evalPrimRec _ x2)) as f.
     assert (L1 : forall i (v: t nat n) ,
@@ -296,13 +325,15 @@ Proof.
         -- simpl max_v; fold z; transitivity (Ack (2 + max 2 q) z).
            ++ rewrite max_comm; apply nested_Ack_bound.
            ++ apply Ack_mono_l;  lia.
-  (* end details *)
-   (*  Lists of PR functions *)
-    
-  - red;cbn;  red; exists 0.
-    intro; rewrite Ack_0;  cbn; auto with arith.
-  - red; cbn; red; destruct IHx, IHx0; exists (max x0 x1).
-    (* begin details *)
+    (*  Lists of PR functions *)
+  (*||*)
+              
+  - (* .no-out *) red;cbn;  red; exists 0. (* .none *)
+    intro; rewrite Ack_0;  cbn; auto with arith. (* .none *)
+  - (* .no-out *) red; cbn; red; destruct IHx, IHx0; exists (max x0 x1).
+(*|
+.. coq:: none
+|*)
     intros v;  cbn; specialize (H0 v).
     pose (X :=
             (max_v (map (fun f : naryFunc n => v_apply f v)
@@ -314,19 +345,22 @@ Proof.
       *  apply Ack_mono_l; apply le_max_l.
     + transitivity (Ack x1 (max_v v)); auto.
       * apply Ack_mono_l; apply le_max_r.
-        (* end details *)
+(*||*)
 Qed. 
-(* end details *)
 
-
-
+(* end snippet majorAnyPR *)
 
 
 (** Let us specialize Lemma [majorAnyPR] to unary and binary  functions 
  *)
 
+(* begin snippet majorPR1 *)
+
 Lemma majorPR1  (f: naryFunc 1)(Hf : isPR 1 f)
-  : exists (n:nat), forall x,  f x  <= Ack n x.
+  : exists (n:nat), forall x,  f x  <= Ack n x. (* .no-out *)
+
+(* end snippet majorPR1 *)
+
 Proof.
   destruct Hf as [x Hx].
   generalize (majorAnyPR 1 x). intros.
@@ -337,10 +371,14 @@ Proof.
   symmetry; apply Hx.  
 Qed.
 
+(* begin snippet majorPR2 *)
 
 Lemma majorPR2 (f: naryFunc 2)(Hf : isPR 2 f)
-  : exists (n:nat), forall x y,  f x y <= Ack n (max x  y).
-Proof.
+  : exists (n:nat), forall x y,  f x y <= Ack n (max x  y). (* no-out *)
+
+(* end snippet majorPR2 *)
+
+Proof. 
   destruct Hf as [x Hx]; generalize (majorAnyPR 2 x).
   intros.
   red in H;red in H.  destruct H as [N HN];  exists N.
@@ -350,9 +388,13 @@ Proof.
   - symmetry; apply Hx.
 Qed.
 
+(* begin snippet majorPR2Strict *)
+
 Lemma majorPR2_strict (f: naryFunc 2)(Hf : isPR 2 f):
     exists n:nat,
-    forall x y, 2 <= x -> 2 <= y -> f x y < Ack n (max x y).
+      forall x y, 2 <= x -> 2 <= y -> f x y < Ack n (max x y). (* .no-out *)
+(* end snippet majorPR2Strict *)
+
 Proof.
    destruct (majorPR2 _ Hf) as [m Hm].
    exists (S (max 2 m)); intros x y; destruct x, y; try lia.
@@ -364,41 +406,38 @@ Proof.
 
 (** *** Now, let us assume that [Ack] is PR *)
 
+(* begin snippet AckNotPR *)
+
 Section Impossibility_Proof.
 
   Hypothesis HAck : isPR 2 Ack.
 
-
-  Lemma Ack_not_PR : False.
-  (* begin show *)
-  Proof.
+  Lemma Ack_not_PR : False. (* .no-out *)
+  Proof. (* no-out *)
     destruct (majorPR2_strict Ack HAck) as [m Hm].
-  (* end show *)
-    (* begin details *)
-    (**
-<<
-1 subgoal (ID 333)
-  
-  HAck : isPR 2 Ack
-  m : nat
-  Hm : forall x y : nat, 2 <= x -> 2 <= y -> Ack x y < Ack m (Nat.max x y)
-  ============================
-  False
->>
-     **)
+    (*|
+.. coq:: no-out
+|*)      
     pose (X := max 2 m); specialize (Hm X X).
     rewrite max_idempotent in Hm;
       assert (H0: Ack m X <= Ack X X) by (apply Ack_mono_l; lia).
     lia.
-    (* end details *)
-   
- (* begin show *)
+(*||*)
   Qed.
- (* end show *)  
   
 End Impossibility_Proof.
 
+(* end snippet AckNotPR *)
+
+
 (** ***  Any function which dominates (diagonalized) [Ack] fails to be PR *)
+
+(* begin snippet domAckNotPR *)
+
+(*|
+.. coq:: no-out
+|*)
+
 
 Section dom_AckNotPR.
 
@@ -406,7 +445,6 @@ Section dom_AckNotPR.
   Hypothesis Hf : dominates f (fun n => Ack n n).
 
   Lemma dom_AckNotPR: isPR 1 f -> False.
-  (* begin details *)
   Proof.
     intros H;  destruct Hf as [N HN].
     destruct  (majorPR1 _ H) as [M HM].
@@ -417,10 +455,12 @@ Section dom_AckNotPR.
       assert (Ack M X <= Ack X X) by (apply Ack_mono_l; subst; lia).
     lia.    
   Qed.
-  (* end details *)
+
 End dom_AckNotPR.
 
+(*||*)
 
+(* end snippet domAckNotPR *)
  
   (** ** Nevertheless, for any [n], [Ack n] is primitive recursive. *)
 

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -218,13 +218,24 @@ Proof. reflexivity. Qed.
 
 *)
 
-Lemma isPR_extEqual_trans n : forall f g, isPR n f ->
-                                    extEqual n f g ->
-                                    isPR n g.
+(* begin snippet isPRExtEqualTrans *)
+
+(*|
+.. coq:: no-out
+|*)
+
+Lemma isPR_extEqual_trans n f g :
+  isPR n f -> extEqual n f g -> isPR n g.
 Proof.
- intros f g [x Hx]; exists x.
+ intros [x Hx]; exists x.
  apply extEqualTrans with f; auto.
 Qed.
+
+(*||*)
+
+(* end snippet isPRExtEqualTrans *)
+
+
 
 Module Alt.
   
@@ -267,6 +278,12 @@ Qed.
 
 Check composeFunc 0 1.
 
+(* begin snippet compose01 *)
+
+(*| 
+.. coq:: no-out 
+|*)
+
 Fact compose_01 :
     forall (x:PrimRec 0) (t : PrimRec 1),
     let c := evalPrimRec 0 x in
@@ -274,8 +291,17 @@ Fact compose_01 :
     evalPrimRec 0 (composeFunc 0 1
                                (PRcons 0 0 x (PRnil 0))
                                t)  =
-     f c.
+     f c. 
 Proof. reflexivity. Qed.
+(*||*)
+
+(* end snippet compose01 *)
+
+(* begin snippet const0NIsPR  *)
+
+(*| 
+.. coq:: no-out 
+|*)
 
 
 Lemma  const0_NIsPR n : isPR 0 n. 
@@ -287,6 +313,15 @@ Proof.
    cbn in *; intros; now rewrite Hx.
 Qed.
 
+(*||*)
+
+(* end snippet const0NIsPR  *)
+
+(* begin snippet plusAlt  *)
+
+(*| 
+.. coq:: no-out 
+|*)
 
 Definition plus_alt x y  :=
               nat_rec  (fun n : nat => nat)
@@ -301,21 +336,54 @@ Proof.
   intros y; cbn; now rewrite <- (IHx y).
 Qed.
 
+(*||*)
+
+(* end snippet plusAlt *)
+
+
 (* begin snippet PrimRecExamplesSearch *)
 
 Search (isPR 2 (fun _ _ => nat_rec _ _ _ _)).
 
 (* end snippet PrimRecExamplesSearch *)
 
+(* begin snippet checkFilter0101IsPR *)
 
-Lemma plusIsPR : isPR 2 plus.
-Proof.
+(*|
+.. coq:: unfold no-in 
+|*)
+
+Check filter010IsPR.
+
+(*||*)
+
+(* end snippet checkFilter0101IsPR *)
+
+(* begin snippet plusIsPRa *)
+
+Lemma plusIsPR : isPR 2 plus. (* .no-out *)
+Proof. (* .no-out *)
   apply isPR_extEqual_trans with plus_alt.
-  - unfold plus_alt; apply ind1ParamIsPR.
+  - (* .no-out *)  unfold plus_alt; apply ind1ParamIsPR.
+    
+(* end snippet plusIsPRa *)
+
+(* begin snippet plusIsPRb *)
+    
+(*|
+.. coq:: no-out 
+|*)
+
     + apply filter010IsPR, succIsPR.
     + apply idIsPR.
   - apply plus_alt_ok. 
 Qed.
+
+(*||*)
+
+(* end snippet plusIsPRb *)
+
+
 
 Remark R02 : 1 < 2.
 Proof. auto. Qed.
@@ -332,4 +400,30 @@ Qed.
 
 
 End Alt.
+
+(* begin snippet doubleIsPRa *)
+
+Definition double (n:nat) := 2 * n.
+
+Lemma doubleIsPR : isPR 1 double. (* .no-out *)
+Proof. (* .no-out *)
+  unfold double; apply compose1_2IsPR.
+
+(* end snippet doubleIsPRa *)
+
+(* begin snippet doubleIsPRb *)
+(*|
+.. coq:: no-out 
+|*)
+
+  - apply const1_NIsPR.
+  - apply idIsPR.
+  - apply multIsPR.
+Qed.
+
+(*||*)
+
+(* end snippet doubleIsPRb *)
+
+
 

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -1,4 +1,6 @@
 Require Import Arith ArithRing List.
+Require Import Vector.
+Import VectorNotations.
 
 (* begin snippet naryFunc3 *)
 
@@ -9,16 +11,13 @@ Compute naryFunc 3.
 
 (* end snippet naryFunc3 *)
 
-Require Import Vector.
-Import VectorNotations.
-(**
+
+
+(* begin snippet naryRel2 *)
 
 Compute naryRel 2.
 
-  = nat -> nat -> bool
-     : Set
-
- *)
+(* end snippet naryRel2 *)
 
 (* begin snippet checknaryFunc *)
 
@@ -30,26 +29,22 @@ Check (fun n p q : nat =>  n * p + q): naryFunc 3. (* .no-out *)
 
 (* end snippet checknaryFunc *)
 
+(* begin snippet extEqual2a *)
 Compute extEqual 2.
-(*
-    = fun a b : naryFunc 3 => forall x x0 x1 : nat, a x x0 x1 = b x x0 x1
-     : naryFunc 3 -> naryFunc 3 -> Prop
- *)
 
-Example extEqual_ex1 : extEqual 2 mult (fun x y =>  y * x + x - x).
-Proof.
-  intros x y.
-(*
-  x, y : nat
-  ============================
-  extEqual 0 (x * y) (y * x)
- *)
-  cbn. 
+
+Example extEqual_ex1: extEqual 2 mult (fun x y =>  y * x + x - x).
+Proof. (* .no-out *)
+  intros x y; cbn.
+(* end snippet extEqual2a *)
+
+  
+(* begin snippet extEqual2b *)  
   rewrite <- Nat.add_sub_assoc, Nat.sub_diag.
-  - ring.
-  - apply le_n.  
+  - (* .no-out *) ring.
+  - (* .no-out *) apply le_n.  
 Qed.
-
+(* end snippet extEqual2b *)
 
 (** ** Examples of terms of type [PrimRec n] and their interpretation *)
 
@@ -270,6 +265,11 @@ Proof.
   intros y; cbn; now rewrite <- (IHx y).
 Qed.
 
+(* begin snippet PrimRecExamplesSearch *)
+
+Search (isPR 2 (fun _ _ => nat_rec _ _ _ _)).
+
+(* end snippet PrimRecExamplesSearch *)
 
 
 Lemma plusIsPR : isPR 2 plus.

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -407,23 +407,13 @@ Definition double (n:nat) := 2 * n.
 
 Lemma doubleIsPR : isPR 1 double. (* .no-out *)
 Proof. (* .no-out *)
-  unfold double; apply compose1_2IsPR.
-
-(* end snippet doubleIsPRa *)
-
-(* begin snippet doubleIsPRb *)
-(*|
-.. coq:: no-out 
-|*)
-
-  - apply const1_NIsPR.
-  - apply idIsPR.
-  - apply multIsPR.
+  unfold double; apply compose1_2IsPR. 
+  - (* .no-out *) apply const1_NIsPR.
+  - (* .no-out *) apply idIsPR.
+  - (* .no-out *) apply multIsPR.
 Qed.
 
-(*||*)
-
-(* end snippet doubleIsPRb *)
+(* end snippet doubleIsPRa *)
 
 
 

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -21,11 +21,17 @@ Compute naryRel 2.
 
 (* begin snippet checknaryFunc *)
 
-Check plus: naryFunc 2. (* .no-out *)
+(*|
+.. coq:: .no-out
+|*)
 
-Check 42: naryFunc 0. (* .no-out *)
+Check plus: naryFunc 2.
 
-Check (fun n p q : nat =>  n * p + q): naryFunc 3. (* .no-out *)
+Check 42: naryFunc 0.
+
+Check (fun n p q : nat =>  n * p + q): naryFunc 3.
+
+(*||*)
 
 (* end snippet checknaryFunc *)
 
@@ -33,7 +39,7 @@ Check (fun n p q : nat =>  n * p + q): naryFunc 3. (* .no-out *)
 Compute extEqual 2.
 
 
-Example extEqual_ex1: extEqual 2 mult (fun x y =>  y * x + x - x).
+Example extEqual_ex1: extEqual 2 mult (fun x y =>  y * x + x - x). (* .no-out *)
 Proof. (* .no-out *)
   intros x y; cbn.
 (* end snippet extEqual2a *)
@@ -47,17 +53,21 @@ Qed.
 
 (** ** Examples of terms of type [PrimRec n] and their interpretation *)
 
+(*|
+.. coq:: .no-out
+|*)
+
 (* begin snippet evalPrimRecEx  *)
 
-Example Ex1 : evalPrimRec 0 zeroFunc = 0. (* .no-out *)
+Example Ex1 : evalPrimRec 0 zeroFunc = 0.
 Proof. reflexivity. Qed.
 
-Example Ex2 a : evalPrimRec 1 succFunc a = S a. (* .no-out *)
+Example Ex2 a : evalPrimRec 1 succFunc a = S a.
 Proof. reflexivity. Qed.
 
 Example Ex3 a b c d e f: forall (H: 2 < 6),
     evalPrimRec 6
-                (projFunc 6 2 H) a b c d e f = d. (* .no-out *)
+                (projFunc 6 2 H) a b c d e f = d.
 Proof. reflexivity. Qed.
 
 
@@ -73,22 +83,22 @@ Example Ex4 (x y z : PrimRec 2) (t: PrimRec 3):
   let h := evalPrimRec 2 z in
   let i := evalPrimRec 3 t in
   let j := evalPrimRec 2 u in
-  forall a b, j a b = i (f a b) (g a b) (h a b). (* .no-out *)
-Proof. (* .no-out *) reflexivity. Qed.
+  forall a b, j a b = i (f a b) (g a b) (h a b).
+Proof. reflexivity. Qed.
 
 Example Ex5 (x : PrimRec 2)(y: PrimRec 4):
   let g := evalPrimRec _ x in
   let h := evalPrimRec _ y in
   let f := evalPrimRec _ (primRecFunc _ x y) in
-  forall a b,  f 0 a b = g a b. (* .no-out *)
-Proof. (* .no-out *) reflexivity.   Qed.                          
+  forall a b,  f 0 a b = g a b.
+Proof. reflexivity.   Qed.                          
 
 Example Ex6 (x : PrimRec 2)(y: PrimRec 4):
   let g := evalPrimRec _ x in
   let h := evalPrimRec _ y in
   let f := evalPrimRec _ (primRecFunc _ x y) in
-  forall n a b, f (S n) a b = h n (f n a b) a b. (* .no-out *)
-Proof. (* .no-out *) reflexivity.   Qed.                          
+  forall n a b, f (S n) a b = h n (f n a b) a b.
+Proof. reflexivity.   Qed.                          
 (* end snippet evalPrimRecEx  *)  
 
 
@@ -126,6 +136,8 @@ primRecFunc 0
                           succFunc))))).
 
 (* end snippet bigPRa  *)
+
+(*||*)
 
 (* begin snippet bigPRb  *)
 Example  mystery_fun : nat -> nat := evalPrimRec 1 bigPR.

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -226,20 +226,33 @@ Proof.
  apply extEqualTrans with f; auto.
 Qed.
 
-
 Module Alt.
   
-Lemma zeroIsPR : isPR 0 0.
-Proof.
+(* begin snippet zeroIsPR *)
+
+Lemma zeroIsPR : isPR 0 0. (* .no-out *)
+Proof. (* .no-out *)
   exists zeroFunc.
   cbn.
   reflexivity.
 Qed.  
 
+(* end snippet zeroIsPR *)
+
+(*|
+.. coq:: no-out
+|*)
+
+(* begin snippet SuccIsPR *)
+
 Lemma SuccIsPR : isPR 1 S.
 Proof.
   exists succFunc; cbn; reflexivity.
 Qed.
+
+(* end snippet SuccIsPR *)
+
+(* begin snippet pi25IsPR *)
 
 Lemma pi2_5IsPR : isPR 5 (fun a b c d e => b).
 Proof.
@@ -247,6 +260,10 @@ Proof.
  exists (projFunc 5 3 H).
  cbn; reflexivity.
 Qed.
+
+(* end snippet pi25IsPR *)
+
+(*||*)
 
 Check composeFunc 0 1.
 

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -407,13 +407,16 @@ Definition double (n:nat) := 2 * n.
 
 Lemma doubleIsPR : isPR 1 double. (* .no-out *)
 Proof. (* .no-out *)
-  unfold double; apply compose1_2IsPR. 
+  unfold double; apply compose1_2IsPR. (* .no-out *)
+  (* end snippet doubleIsPRa *)
+  
+(* begin snippet doubleIsPRb *)  
   - (* .no-out *) apply const1_NIsPR.
   - (* .no-out *) apply idIsPR.
   - (* .no-out *) apply multIsPR.
 Qed.
 
-(* end snippet doubleIsPRa *)
+(* end snippet doubleIsPRb *)
 
 
 

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -37,7 +37,6 @@ Example extEqual_ex1: extEqual 2 mult (fun x y =>  y * x + x - x).
 Proof. (* .no-out *)
   intros x y; cbn.
 (* end snippet extEqual2a *)
-
   
 (* begin snippet extEqual2b *)  
   rewrite <- Nat.add_sub_assoc, Nat.sub_diag.
@@ -48,15 +47,17 @@ Qed.
 
 (** ** Examples of terms of type [PrimRec n] and their interpretation *)
 
-Example Ex1 : evalPrimRec 0 zeroFunc = 0.
+(* begin snippet evalPrimRecEx  *)
+
+Example Ex1 : evalPrimRec 0 zeroFunc = 0. (* .no-out *)
 Proof. reflexivity. Qed.
 
-Example Ex2 a : evalPrimRec 1 succFunc a = S a.
+Example Ex2 a : evalPrimRec 1 succFunc a = S a. (* .no-out *)
 Proof. reflexivity. Qed.
 
 Example Ex3 a b c d e f: forall (H: 2 < 6),
     evalPrimRec 6
-                (projFunc 6 2 H) a b c d e f = d.
+                (projFunc 6 2 H) a b c d e f = d. (* .no-out *)
 Proof. reflexivity. Qed.
 
 
@@ -72,24 +73,26 @@ Example Ex4 (x y z : PrimRec 2) (t: PrimRec 3):
   let h := evalPrimRec 2 z in
   let i := evalPrimRec 3 t in
   let j := evalPrimRec 2 u in
-  forall a b, j a b = i (f a b) (g a b) (h a b).
-Proof. reflexivity. Qed.
+  forall a b, j a b = i (f a b) (g a b) (h a b). (* .no-out *)
+Proof. (* .no-out *) reflexivity. Qed.
 
 Example Ex5 (x : PrimRec 2)(y: PrimRec 4):
   let g := evalPrimRec _ x in
   let h := evalPrimRec _ y in
   let f := evalPrimRec _ (primRecFunc _ x y) in
-  forall a b,  f 0 a b = g a b.
-Proof. reflexivity.   Qed.                          
+  forall a b,  f 0 a b = g a b. (* .no-out *)
+Proof. (* .no-out *) reflexivity.   Qed.                          
 
 Example Ex6 (x : PrimRec 2)(y: PrimRec 4):
   let g := evalPrimRec _ x in
   let h := evalPrimRec _ y in
   let f := evalPrimRec _ (primRecFunc _ x y) in
-  forall n a b,  f (S n) a b = h n (f n a b) a b.
-Proof. reflexivity.   Qed.                          
+  forall n a b, f (S n) a b = h n (f n a b) a b. (* .no-out *)
+Proof. (* .no-out *) reflexivity.   Qed.                          
+(* end snippet evalPrimRecEx  *)  
 
 
+(* begin snippet bigPRa  *)
 
 Example bigPR : PrimRec 1 :=
 primRecFunc 0
@@ -120,13 +123,16 @@ primRecFunc 0
                           (PRcons 3 0
                                   (projFunc 3 1 (le_S 2 2 (le_n 2)))
                                   (PRnil 3))
-                          succFunc))))). 
+                          succFunc))))).
 
+(* end snippet bigPRa  *)
+
+(* begin snippet bigPRb  *)
 Example  mystery_fun : nat -> nat := evalPrimRec 1 bigPR.
-
 
 Compute map mystery_fun [0;1;2;3;4;5;6] : t nat _.
 
+(* end snippet bigPRb  *)
 
 (** ** Understanding some constructions ...
 

--- a/theories/ordinals/OrdinalNotations/Example_3PlusOmega.v
+++ b/theories/ordinals/OrdinalNotations/Example_3PlusOmega.v
@@ -32,20 +32,18 @@ Defined.
 Instance L_3_plus_omega :  ON_Iso _ _ f g.
 Proof.
   split.
-  - destruct x, y.   cbn.
+  - destruct x, y; cbn.
     +  destruct t0; unfold compare; cbn; destruct t; reflexivity.
     + cbn; destruct t.
-      red in i. assert (x < 3). {
-        now rewrite PeanoNat.Nat.ltb_lt in i. }
-      rewrite PeanoNat.Nat.compare_lt_iff.
-      simpl; lia.
+      red in i; assert (x < 3) by (now rewrite PeanoNat.Nat.ltb_lt in i).
+      rewrite PeanoNat.Nat.compare_lt_iff; simpl; lia.
     + cbn; destruct t.
       destruct x; auto.
       destruct x; auto.
       destruct x; auto.
-      assert (S (S (S x)) < 3).
-      { red in i; rewrite PeanoNat.Nat.ltb_lt in i. lia. }
-      cbn; lia.
+      assert (S (S (S x)) < 3) by
+       (red in i; rewrite PeanoNat.Nat.ltb_lt in i; lia);
+        cbn; lia.
   +  reflexivity.
   - destruct a.
     + destruct t; cbn; unfold g;  destruct (le_lt_dec 3 x).

--- a/theories/ordinals/OrdinalNotations/OmegaOmega.v
+++ b/theories/ordinals/OrdinalNotations/OmegaOmega.v
@@ -589,7 +589,7 @@ Check phi0  7.
 #[local] Coercion Fin : nat >-> OO.
 
 
-Goal   omega * 5 + omega^  2 = omega^ 2.
+Example Ex42: omega + 42 + omega^ 2 = omega^ 2.
   now rewrite <- Comparable.compare_eq_iff.
 Qed.
 

--- a/theories/ordinals/OrdinalNotations/OmegaOmega.v
+++ b/theories/ordinals/OrdinalNotations/OmegaOmega.v
@@ -58,7 +58,7 @@ Module LO.
   Compute T1.pp (refine (fin 42)).
   Compute T1.pp (refine omega).
   Compute T1.pp (refine (phi0 33)).
-  *)
+   *)
 
 
   Inductive ap : t -> Prop :=
@@ -72,7 +72,6 @@ Module LO.
     | ocons 0 _ _ => true
     | ocons i n beta => succb beta
     end.
-
   
   Fixpoint limitb (alpha:t) :=
     match alpha with
@@ -81,6 +80,7 @@ Module LO.
     | ocons i n nil => true
     | ocons i n beta => limitb beta
     end.
+
 
   Lemma succb_ref (a:t): succb a -> T1.succb (refine a).
   Proof.
@@ -98,7 +98,7 @@ Module LO.
        + discriminate.
        + simpl T1.limitb; destruct l. 
          * trivial.
-         * intro H ; rewrite IHl; case (refine (p::l)); auto.
+         * intro H; rewrite IHl; case (refine (p::l)); auto.
   Qed.
 
 
@@ -117,7 +117,7 @@ Module LO.
                 end)
        end)
     end.
- 
+  
   Lemma compare_ref (alpha beta:t) :
     compare alpha beta = T1.compare (refine alpha) (refine beta).
   Proof.
@@ -147,7 +147,7 @@ Module LO.
     - cbn; destruct p; cbn; trivial. 
     - cbn; destruct a; reflexivity. 
     - cbn; rewrite IHalpha. destruct p, a;  rewrite Nat.compare_antisym.
-      destruct  (Nat.compare n1 n) eqn:? ; cbn; trivial.
+      destruct (Nat.compare n1 n) eqn:? ; cbn; trivial.
       rewrite Nat.compare_antisym;
         destruct  (Nat.compare n2 n0) eqn:? ; now cbn.
   Qed.
@@ -196,7 +196,7 @@ Module LO.
     unfold lt, T1.lt; rewrite compare_ref; now split.
   Qed.
 
-  Lemma eq_ref  (a b : t) : a = b <->  refine a = refine b.
+  Lemma eq_ref  (a b : t) : a = b <-> refine a = refine b.
   Proof.
     destruct (compare_correct a b).
     - split.
@@ -214,7 +214,7 @@ Module LO.
 
   Lemma lt_irrefl (alpha: t): ~ lt alpha alpha.
   Proof.
-    rewrite lt_ref; now apply  T1.lt_irrefl.
+    rewrite lt_ref; now apply T1.lt_irrefl.
   Qed.
 
 
@@ -239,7 +239,6 @@ Module LO.
   Qed.
 
 
-
   Fixpoint nf_b (alpha : t) : bool :=
     match alpha with
     | nil => true
@@ -255,6 +254,12 @@ Module LO.
 
   Lemma zero_nf : nf zero.
   Proof. reflexivity. Qed.
+
+  Lemma fin_nf (i:nat) : nf (fin i).
+  Proof.
+    destruct i; red; now cbn.
+  Qed. 
+
 
   Lemma single_nf :
     forall i n, nf (ocons i n zero).
@@ -281,113 +286,160 @@ Module LO.
     destruct p; cbn; destruct b.
     - auto with bool. 
     - destruct p; auto with bool. 
-     rewrite andb_false_r; discriminate.
+      rewrite andb_false_r; discriminate.
     - destruct p; intro H; apply andb_prop in H; now destruct H. 
   Qed.
 
 
-Lemma nf_inv3 :
-  forall i n  j n' b',
-    nf (ocons i n (ocons j n' b')) -> Nat.lt j i.
-Proof.
-  unfold nf; cbn;
-    destruct  b'; try discriminate; auto with T1;
-      intro H; red in H; repeat rewrite andb_true_iff in H.
-  - destruct H as [_ H]; destruct i. 
-    + discriminate.
-    + rewrite  Nat.leb_le in H; lia.
-  - destruct p; destruct i.
-   + destruct j; destruct H; discriminate.
-   + destruct H; rewrite  Nat.leb_le in H0; lia.
-Qed.
+  Lemma nf_inv3 :
+    forall i n  j n' b',
+      nf (ocons i n (ocons j n' b')) -> Nat.lt j i.
+  Proof.
+    unfold nf; cbn;
+      destruct  b'; try discriminate; auto with T1;
+        intro H; red in H; repeat rewrite andb_true_iff in H.
+    - destruct H as [_ H]; destruct i. 
+      + discriminate.
+      + rewrite  Nat.leb_le in H; lia.
+    - destruct p; destruct i.
+      + destruct j; destruct H; discriminate.
+      + destruct H; rewrite  Nat.leb_le in H0; lia.
+  Qed.
 
 
-Lemma nf_ref: forall alpha, T1.nf (refine alpha) <-> nf alpha.
-Proof.
-  induction alpha.
-  - cbn; split; trivial.
-  - destruct a as [i n];  split.
-  + intro H;  destruct alpha.
-    * apply single_nf.
-    * destruct p.
-      apply ocons_nf.
-      -- cbn in H; apply T1.nf_inv3 in H; now apply T1.lt_fin_iff. 
-      -- cbn in H; apply IHalpha; apply T1.nf_inv2 in H; apply H.
-  + intro H; destruct alpha.
-   * apply T1.single_nf, T1.nf_fin.
-   * destruct p; cbn; apply T1.ocons_nf.
-     --  apply nf_inv3 in H; now apply T1.lt_fin_iff.
-     -- apply T1.nf_fin.
-     -- apply nf_inv2 in H; now rewrite IHalpha.
-Qed.
+  Lemma nf_ref: forall alpha, T1.nf (refine alpha) <-> nf alpha.
+  Proof.
+    induction alpha.
+    - cbn; split; trivial.
+    - destruct a as [i n];  split.
+      + intro H;  destruct alpha.
+        * apply single_nf.
+        * destruct p.
+          apply ocons_nf.
+          -- cbn in H; apply T1.nf_inv3 in H; now apply T1.lt_fin_iff. 
+          -- cbn in H; apply IHalpha; apply T1.nf_inv2 in H; apply H.
+      + intro H; destruct alpha.
+        * apply T1.single_nf, T1.nf_fin.
+        * destruct p; cbn; apply T1.ocons_nf.
+          --  apply nf_inv3 in H; now apply T1.lt_fin_iff.
+          -- apply T1.nf_fin.
+          -- apply nf_inv2 in H; now rewrite IHalpha.
+  Qed.
 
 
-Declare Scope lo_scope.
-Delimit Scope lo_scope with lo.
-Open Scope lo_scope.
+  Declare Scope lo_scope.
+  Delimit Scope lo_scope with lo.
+  Open Scope lo_scope.
 
-Fixpoint plus (alpha beta : t) :t :=
-  match alpha,beta with
-  |  nil, y  => y
-  |  x, nil  => x
-  |  ocons a n b, ocons a' n' b' =>
-      (match Nat.compare a a' with
-       | Lt => ocons a' n' b'
-       | Gt => (ocons a n (plus b (ocons a' n' b')))
-       | Eq  => (ocons a (S (n+n')) b')
-       end)
-  end
-where "alpha + beta" := (plus alpha beta) : lo_scope.
+  Fixpoint succ (alpha : t) : t :=
+    match alpha with
+      nil => fin 1
+    | ocons 0 n _  => ocons 0 (S n) nil
+    | ocons a n beta => ocons a n (succ beta)
+    end.
 
-Compute (omega + omega).
-(** *** multiplication *)
+  Fixpoint plus (alpha beta : t) :t :=
+    match alpha,beta with
+    |  nil, y  => y
+    |  x, nil  => x
+    |  ocons a n b, ocons a' n' b' =>
+       (match Nat.compare a a' with
+        | Lt => ocons a' n' b'
+        | Gt => (ocons a n (plus b (ocons a' n' b')))
+        | Eq  => (ocons a (S (n+n')) b')
+        end)
+    end
+  where "alpha + beta" := (plus alpha beta) : lo_scope.
 
-Fixpoint mult (alpha beta : t) : t :=
-  match alpha,beta with
-  |  nil, _  => zero
-  |  _, nil => zero
-  |  ocons 0 n _, ocons 0 n' _ =>
-      ocons 0 (Peano.pred((S n) * (S n'))) zero
-  |  ocons a n b, ocons 0 n' _ =>
-      ocons a (Peano.pred ((S n) * (S n'))) b
-  |  ocons a n b, ocons a' n' b' =>
-      ocons (a + a')%nat n' ((ocons a n b) * b')
-  end
-where "alpha * beta" := (mult alpha beta) : lo_scope.
+  Fixpoint mult (alpha beta : t) : t :=
+    match alpha,beta with
+    |  nil, _  => zero
+    |  _, nil => zero
+    |  ocons 0 n _, ocons 0 n' _ =>
+       ocons 0 (Peano.pred((S n) * (S n'))) zero
+    |  ocons a n b, ocons 0 n' _ =>
+       ocons a (Peano.pred ((S n) * (S n'))) b
+    |  ocons a n b, ocons a' n' b' =>
+       ocons (a + a')%nat n' ((ocons a n b) * b')
+    end
+  where "alpha * beta" := (mult alpha beta) : lo_scope.
 
 
-Compute omega * omega.
-Compute fin 1 * omega.
-Compute fin 42 * omega.
+  Compute omega * omega.
+  Compute fin 1 * omega.
+  Compute fin 42 * omega.
+
+  Lemma phi0_ref (i:nat) : refine (phi0 i) = T1.phi0 (T1.fin i).
+  Proof. reflexivity. Qed.
+
+  Lemma phi0_nf  (i:nat) : nf (phi0 i).
+  Proof. unfold nf;  now cbn. Qed.
+  
+  Lemma succ_ref (alpha : t) :
+    refine (succ alpha) = T1.succ (refine alpha).
+  Proof.  
+    induction alpha.
+    - now cbn.
+    - destruct alpha.
+      + destruct a;  cbn; destruct n; now cbn.
+      + destruct a; destruct n.
+        * now cbn.
+        * destruct p; destruct n1. 
+          -- now cbn.
+          -- cbn in *; now rewrite IHalpha.
+  Qed.
+
+  Lemma succ_nf alpha : nf alpha -> nf (succ alpha).
+  Proof.
+    intro H; rewrite <- nf_ref in *; rewrite succ_ref; now apply T1.succ_nf.
+  Qed.
+  
+  Lemma plus_ref : forall alpha beta: t,
+      refine (alpha + beta) = T1.plus (refine alpha) (refine beta).
+  Proof.
+    induction alpha, beta.
+    - now cbn.
+    - now cbn.
+    - cbn; destruct a. now cbn.
+    - destruct a, p; cbn;  destruct (n ?= n1) eqn:cn_n1.
+      1,2:   rewrite T1.compare_fin_rw in *; rewrite cn_n1; now cbn.
+      rewrite T1.compare_fin_rw in *; cbn;rewrite cn_n1, IHalpha; now cbn.
+  Qed.
 
 
-Lemma plus_ref : forall alpha beta: t,
-    refine (alpha + beta) = T1.plus (refine alpha) (refine beta).
-Proof.
-  induction alpha, beta.
-  - now cbn.
-  - now cbn.
-  - cbn; destruct a. now cbn.
-  - destruct a, p; cbn;  destruct (n ?= n1) eqn:cn_n1.
-  1,2:   rewrite T1.compare_fin_rw in *; rewrite cn_n1; now cbn.
-  rewrite T1.compare_fin_rw in *; cbn;rewrite cn_n1, IHalpha; now cbn.
-Qed.
+  Lemma plus_nf alpha beta : nf alpha -> nf beta -> nf (alpha + beta).
+  Proof.
+    intros Halpha Hbeta; rewrite <- nf_ref in *; rewrite plus_ref;
+      now   apply T1.plus_nf.
+  Qed.
 
-Lemma mult_ref : forall alpha beta: t,
-    refine (alpha * beta) = T1.mult (refine alpha) (refine beta).
-Proof.
-  induction alpha.  
-  -  cbn; destruct beta. 
-     + now cbn.
-     + cbn; destruct p; now cbn.
-  - induction beta.
-    +  destruct a; cbn. destruct n; now cbn.
-    +  destruct a, a0; cbn. destruct n; cbn. destruct n1; cbn; trivial.
-      * f_equal; rewrite IHbeta; f_equal.
-      * cbn. destruct n1. cbn. reflexivity.
-        cbn. f_equal. f_equal. lia.
-        rewrite IHbeta; f_equal.
-Qed.
+
+  Lemma mult_ref : forall alpha beta: t,
+      refine (alpha * beta) = T1.mult (refine alpha) (refine beta).
+  Proof.
+    induction alpha.  
+    -  cbn; destruct beta. 
+       + now cbn.
+       + cbn; destruct p; now cbn.
+    - induction beta.
+      +  destruct a; cbn. destruct n; now cbn.
+      +  destruct a, a0; cbn. destruct n; cbn. destruct n1; cbn; trivial.
+         * f_equal; rewrite IHbeta; f_equal.
+         * cbn. destruct n1. cbn. reflexivity.
+           cbn. f_equal. f_equal. lia.
+           rewrite IHbeta; f_equal.
+  Qed.
+
+
+  Lemma mult_nf alpha beta : nf alpha -> nf beta -> nf (alpha * beta).
+  Proof.
+    intros Halpha Hbeta; rewrite <- nf_ref in *; rewrite mult_ref;
+      now   apply T1.mult_nf.
+  Qed.
+
+
+ Lemma plus_assoc (a b c: t) : a + (b + c) = a + b + c.
+ Proof. apply eq_ref; rewrite !plus_ref; apply T1.plus_assoc. Qed.
 
 End LO.
 
@@ -410,7 +462,54 @@ Module OO.
   Definition le := leq lt.
   Definition compare (alpha beta: OO):= LO.compare (data alpha) (data beta).
 
+  Instance Zero : OO := @mkord nil refl_equal.
+
+  Instance _Omega : OO.
+  Proof.
+    now exists omega%lo.  
+  Defined. 
+
+
+  Instance Fin (i:nat) : OO.
+  Proof.
+    exists (LO.fin i); apply fin_nf.
+  Defined.
   
+  Notation omega  := _Omega.
+
+  Instance Succ (alpha : OO) : OO.
+  Proof.
+    refine (@mkord (LO.succ (@data alpha)) _); 
+      apply succ_nf,  data_ok.
+  Defined.
+
+
+  Instance plus (alpha beta : OO) : OO.
+  Proof.
+    refine (@mkord (LO.plus (@data alpha) (@data beta))_ );
+      apply plus_nf; apply data_ok.
+  Defined.
+
+  Infix "+" := plus : OO_scope.
+
+  Instance mult (alpha beta : OO) : OO.
+  Proof.
+    refine (@mkord (LO.mult (@data alpha) (@data beta))_ );
+      apply mult_nf; apply data_ok.
+  Defined.
+
+  Infix "*" := mult : OO_scope.
+
+  Instance phi0 (i : nat): OO.
+  Proof.
+    refine (@mkord (LO.phi0 i) _). 
+    apply phi0_nf; apply data_ok.
+  Defined.
+
+
+
+  Infix "*" := mult : OO_scope.
+
   Instance embed (alpha: OO) : E0.E0.
   Proof.
     destruct alpha as [data Hdata].
@@ -429,59 +528,59 @@ Module OO.
 
   Instance oo_str : StrictOrder lt.
   split.
-   - intros x H; destruct x.
-     unfold lt in H; cbn; destruct (LO.lt_irrefl _ H).
-   - intros x y z; destruct x, y, z.
+  - intros x H; destruct x.
+    unfold lt in H; cbn; destruct (LO.lt_irrefl _ H).
+  - intros x y z; destruct x, y, z.
     unfold lt ; cbn; intros; eapply LO.lt_trans; eauto.
   Qed.
 
   Lemma nf_proof_unicity :
-  forall (alpha:t) (H H': nf alpha), H = H'.
-Proof.
-  intros; red in H, H'; apply eq_proofs_unicity_on.
-  destruct y. 
-  - rewrite H; auto. 
-  - rewrite H; right; discriminate. 
-Qed.
-
-  Lemma OO_eq_intro : forall alpha beta : OO,
-    data alpha = data beta -> alpha = beta.
-Proof.
-  destruct alpha, beta; simpl; intros; subst; f_equal; auto; 
-    apply nf_proof_unicity.
-Qed.
-
-
-Instance OO_comp : Comparable lt compare.
-Proof.
-  split.
-  - apply oo_str.
-  - destruct a, b; unfold compare; cbn.
-    destruct (LO.compare_correct data0 data1).
-    + constructor; subst; apply OO_eq_intro; now cbn.
-    + constructor; red; now cbn.
-    + constructor; red; now cbn.
-Qed. 
-
-Lemma lt_wf : well_founded lt.
-Proof.
-  specialize  (ON_Generic.wf_measure (B:= OO) embed); intro Hm;
-  unfold ON_Generic.measure_lt in Hm; eapply wf_incl.
-  2: eassumption.
-  intros x y Hxy; red; now apply lt_embed.
+    forall (alpha:t) (H H': nf alpha), H = H'.
+  Proof.
+    intros; red in H, H'; apply eq_proofs_unicity_on.
+    destruct y. 
+    - rewrite H; auto. 
+    - rewrite H; right; discriminate. 
   Qed.
 
-Import ON_Generic.
-Instance ON_OO : ON lt compare.
-Proof.
-  split.  
-  - apply OO_comp.
-  - apply lt_wf.
-Qed.
+  Lemma OO_eq_intro : forall alpha beta : OO,
+      data alpha = data beta -> alpha = beta.
+  Proof.
+    destruct alpha, beta; simpl; intros; subst; f_equal; auto; 
+      apply nf_proof_unicity.
+  Qed.
+
+
+  Instance OO_comp : Comparable lt compare.
+  Proof.
+    split.
+    - apply oo_str.
+    - destruct a, b; unfold compare; cbn.
+      destruct (LO.compare_correct data0 data1).
+      + constructor; subst; apply OO_eq_intro; now cbn.
+      + constructor; red; now cbn.
+      + constructor; red; now cbn.
+  Qed. 
+
+  Lemma lt_wf : well_founded lt.
+  Proof.
+    specialize  (ON_Generic.wf_measure (B:= OO) embed); intro Hm;
+      unfold ON_Generic.measure_lt in Hm; eapply wf_incl.
+    2: eassumption.
+    intros x y Hxy; red; now apply lt_embed.
+  Qed.
+
+  Import ON_Generic.
+  Instance ON_OO : ON lt compare.
+  Proof.
+    split.  
+    - apply OO_comp.
+    - apply lt_wf.
+  Qed.
 
 End OO.
 
- 
+
 
 
 

--- a/theories/ordinals/OrdinalNotations/OmegaOmega.v
+++ b/theories/ordinals/OrdinalNotations/OmegaOmega.v
@@ -3,17 +3,12 @@
 (** New implementation as a refinement of epsilon0 *)
 
 Require T1 E0.
-Require Import Arith.
-Require Import Coq.Logic.Eqdep_dec.
-Require Import Coq.Arith.Peano_dec.
-Require Import List Bool.
-Require Import Recdef Lia.
-Require Import Coq.Wellfounded.Inverse_Image
-        Coq.Wellfounded.Inclusion RelationClasses.
+Require Import Arith  Coq.Logic.Eqdep_dec Coq.Arith.Peano_dec  List Bool
+        Recdef Lia  Coq.Wellfounded.Inverse_Image
+        Coq.Wellfounded.Inclusion RelationClasses  Logic.Eqdep_dec.
 
 Coercion is_true: bool >-> Sortclass.
 Require Import Comparable.
-Require Import Logic.Eqdep_dec.
 
 (** * Representation by lists of pairs of integers *)
 

--- a/theories/ordinals/OrdinalNotations/OmegaOmega.v
+++ b/theories/ordinals/OrdinalNotations/OmegaOmega.v
@@ -444,9 +444,8 @@ Module LO.
  Lemma mult_plus_distr_l (a b c: t) : nf a -> nf b -> nf c ->
                                       a * (b + c) = a * b + a * c.
  Proof.
-   intros Ha Hb Hc;  apply eq_ref; rewrite !mult_ref, !plus_ref,
-                                   T1.mult_plus_distr_l,
-                                   !mult_ref ; trivial.
+   intros Ha Hb Hc; apply eq_ref;
+     rewrite !mult_ref, !plus_ref, T1.mult_plus_distr_l, !mult_ref; trivial.
    all: now apply nf_ref.   
  Qed.
 
@@ -574,8 +573,7 @@ Module OO.
   Lemma lt_wf : well_founded lt.
   Proof.
     specialize  (ON_Generic.wf_measure (B:= OO) embed); intro Hm;
-      unfold ON_Generic.measure_lt in Hm; eapply wf_incl.
-    2: eassumption.
+      unfold ON_Generic.measure_lt in Hm; eapply wf_incl; [| eassumption].
     intros x y Hxy; red; now apply lt_embed.
   Qed.
 
@@ -590,10 +588,14 @@ Module OO.
 
 End OO.
 
+Import OO.
+#[local] Open Scope OO_scope.
+Check phi0  7.
+#[local] Coercion Fin : nat >-> OO.
 
 
-
-
-
+Goal   omega * 5 + phi0 2 = omega * omega.
+  now rewrite <- Comparable.compare_eq_iff.
+Qed.
 
 

--- a/theories/ordinals/OrdinalNotations/OmegaOmega.v
+++ b/theories/ordinals/OrdinalNotations/OmegaOmega.v
@@ -509,7 +509,7 @@ Module OO.
     apply phi0_nf; apply data_ok.
   Defined.
 
-
+  Notation "'omega^'" := phi0 (only parsing) : OO_scope.
 
   Infix "*" := mult : OO_scope.
 
@@ -589,7 +589,7 @@ Check phi0  7.
 #[local] Coercion Fin : nat >-> OO.
 
 
-Goal   omega * 5 + phi0 2 = omega * omega.
+Goal   omega * 5 + omega^  2 = omega^ 2.
   now rewrite <- Comparable.compare_eq_iff.
 Qed.
 

--- a/theories/ordinals/OrdinalNotations/OmegaOmega.v
+++ b/theories/ordinals/OrdinalNotations/OmegaOmega.v
@@ -441,6 +441,15 @@ Module LO.
  Lemma plus_assoc (a b c: t) : a + (b + c) = a + b + c.
  Proof. apply eq_ref; rewrite !plus_ref; apply T1.plus_assoc. Qed.
 
+ Lemma mult_plus_distr_l (a b c: t) : nf a -> nf b -> nf c ->
+                                      a * (b + c) = a * b + a * c.
+ Proof.
+   intros Ha Hb Hc;  apply eq_ref; rewrite !mult_ref, !plus_ref,
+                                   T1.mult_plus_distr_l,
+                                   !mult_ref ; trivial.
+   all: now apply nf_ref.   
+ Qed.
+
 End LO.
 
 Declare Scope OO_scope.
@@ -480,7 +489,7 @@ Module OO.
   Instance Succ (alpha : OO) : OO.
   Proof.
     refine (@mkord (LO.succ (@data alpha)) _); 
-      apply succ_nf,  data_ok.
+      apply succ_nf, data_ok.
   Defined.
 
 
@@ -571,6 +580,7 @@ Module OO.
   Qed.
 
   Import ON_Generic.
+  
   Instance ON_OO : ON lt compare.
   Proof.
     split.  

--- a/theories/ordinals/Prelude/Iterates.v
+++ b/theories/ordinals/Prelude/Iterates.v
@@ -8,11 +8,16 @@ Open Scope nat_scope.
 From Coq Require Import RelationClasses Relations Arith Max Lia.
 From hydras Require Import Exp2.
 
+(* begin snippet iterateDef *)
+
 Fixpoint iterate {A:Type}(f : A -> A) (n: nat)(x:A) :=
   match n with
   | 0 => x
   | S p => f (iterate  f p x)
-  end.
+  end. (* .no-out *)
+
+(* end snippet iterateDef *)
+
 
 (** Compatibility with Ackermann Library's definition *)
 
@@ -220,9 +225,14 @@ Proof.
 Qed. 
 
 
+(* begin snippet iterateLeNSN *)
+
 Lemma iterate_le_n_Sn (f: nat -> nat):
   (forall x,  x <= f x) ->
-  forall n x,  iterate f n x <= iterate f (S n)  x.
+  forall n x,  iterate f n x <= iterate f (S n)  x. (* .no-out *)
+
+(* end snippet iterateLeNSN *)
+
 Proof.
   induction n.
   - cbn; auto with arith.

--- a/theories/ordinals/Prelude/MoreVectors.v
+++ b/theories/ordinals/Prelude/MoreVectors.v
@@ -230,40 +230,57 @@ Qed.
 
   (** Maximum of a vector of nat *)
 
+  (* begin snippet maxvDef *)
+  
   Fixpoint max_v {n:nat} (v: Vector.t nat n) : nat :=
     match v  with
     | nil =>  0
     | cons x t => max x (max_v t)
     end.
 
+   (* end snippet maxvDef *)
 
+  (* begin snippet maxvLemmasa *)
 
-Lemma max_v_2 : forall x y,  max_v (x::y::nil) = max x y.
-Proof.
-  intros; cbn. now rewrite max_0_r.
-Qed.
+  Lemma max_v_2 : forall x y,  max_v (x::y::nil) = max x y. (* .no-out *)
 
-Lemma max_v_lub : forall n (v: t nat n) y,
-    (Forall (fun x =>  x <= y) v) ->
-    max_v v <= y.
-Proof.
-  induction n.  
-  -  intros v; rewrite (t_0_nil _ v); cbn.
-     intros; auto with arith.
-  -   intros v; rewrite (decomp _ _ v); cbn.
-      intros;  destruct (Forall_inv _ _ _  _ H). apply max_lub; auto. 
-Qed.
+   (* end snippet maxvLemmasa *)
 
+  Proof.
+    intros; cbn. now rewrite max_0_r.
+  Qed.
+ 
+  (* begin snippet maxvLemmasb *)
+  
+  Lemma max_v_lub : forall n (v: t nat n) y,
+      (Forall (fun x =>  x <= y) v) ->
+      max_v v <= y. (* .no-out *)
 
-Lemma max_v_ge : forall n (v: t nat n) y,
-    In  y  v -> y <= max_v v.
-Proof.
-  induction n.  
-  -  intros v; rewrite (t_0_nil _ v); cbn; inversion 1.
-  -  intros v; rewrite (decomp _ _ v); cbn; intros; destruct (In_cases _ _ H).
-     +  cbn in H0; subst; apply le_max_l. 
-     + cbn in H0; specialize (IHn _ _ H0); lia.
-Qed.
+  (* end snippet maxvLemmasb *)
+  
+  Proof.
+    induction n.  
+    -  intros v; rewrite (t_0_nil _ v); cbn.
+       intros; auto with arith.
+    -   intros v; rewrite (decomp _ _ v); cbn.
+        intros;  destruct (Forall_inv _ _ _  _ H). apply max_lub; auto. 
+  Qed.
+
+  (* begin snippet maxvLemmasc *)
+  
+  Lemma max_v_ge : forall n (v: t nat n) y,
+      In  y  v -> y <= max_v v. (* .no-out *)
+  
+    (* end snippet maxvLemmasc *)
+
+  Proof.
+    induction n.  
+    -  intros v; rewrite (t_0_nil _ v); cbn; inversion 1.
+    -  intros v; rewrite (decomp _ _ v); cbn; intros; destruct (In_cases _ _ H).
+       +  cbn in H0; subst; apply le_max_l. 
+       + cbn in H0; specialize (IHn _ _ H0); lia.
+  Qed.
+
 
 Lemma max_v_tl {n:nat}(v:  Vector.t nat (S n)) :
   max_v (Vector.tl v) <= max_v v.

--- a/theories/ordinals/Schutte/Schutte.v
+++ b/theories/ordinals/Schutte/Schutte.v
@@ -81,13 +81,15 @@ Axiom inh_Ord : inhabited Ord.
 
 
 Example Ex42: omega + 42 + phi0 2 = phi0 2.
-Proof. 
-  assert (HAP:= AP_phi0 2); elim  HAP; intros  _ H0.
-  assert (H: omega < phi0 2) by
-    (rewrite omega_eqn; apply phi0_mono, finite_mono; auto with arith).
-  apply H0, AP_plus_closed; trivial.
-  apply lt_trans with omega; trivial.
-  -  apply finite_lt_omega.
+Proof.
+  (** [phi0 2] is additive principal *)
+  assert (HAP:= AP_phi0 2); elim  HAP; intros  _ H0; apply H0.
+  assert (Hlt: omega < phi0 (F 2)) by
+      (rewrite omega_eqn; apply phi0_mono, finite_mono;
+      auto with arith).
+  (** [phi0 2] is closed under addition *)
+  apply (AP_plus_closed HAP Hlt).
+  apply lt_trans with omega; [apply finite_lt_omega | apply Hlt ].
 Qed. 
 
 

--- a/theories/ordinals/solutions_exercises/FibonacciPR.v
+++ b/theories/ordinals/solutions_exercises/FibonacciPR.v
@@ -2,6 +2,8 @@ Require Import primRec cPair extEqualNat.
 
 (** The famous Fibonacci function *)
 
+(* begin snippet fibDef *)
+
 Fixpoint fib (n:nat) : nat :=
   match n with
   | 0 => 1
@@ -9,6 +11,7 @@ Fixpoint fib (n:nat) : nat :=
   | S ((S p) as q) => fib q + fib p
   end.
 
+(* end snippet fibDef *)
 
 Section Proof_of_FibIsPR.
 

--- a/theories/ordinals/solutions_exercises/MorePRExamples.v
+++ b/theories/ordinals/solutions_exercises/MorePRExamples.v
@@ -14,11 +14,15 @@ Proof.
   - apply multIsPR.
 Qed.
 
+(* begin snippet expDef *)
+
 Fixpoint exp n p :=
   match p with
     0 => 1
   | S m =>  exp n m * n
   end.
+
+(* end snippet expDef *)
 
 Definition exp_alt := fun a b => nat_rec (fun _ => nat)
                                      1
@@ -51,11 +55,15 @@ Proof.
   apply exp_alt_ok.
 Qed.
 
+(* begin snippet tower2Def *)
+
 Fixpoint tower2 n :=
   match n with
     0 => 1
   | S p => exp 2 (tower2 p)
   end.
+
+(* end snippet tower2Def *)
 
 Definition tower2_alt h : nat :=  nat_rec (fun n => nat)
                                 1
@@ -82,12 +90,12 @@ Proof.
  apply extEqualTrans with tower2_alt; [auto | apply tower2_alt_ok].
 Qed.
 
-    
+(* begin snippet factDef *)    
 Fixpoint fact n :=
   match n with 0 => 1
           |   S p  => n * fact p
   end.
-
+(* end snippet factDef *)    
 
 Definition fact_alt
   : nat -> nat :=

--- a/theories/ordinals/solutions_exercises/isqrt.v
+++ b/theories/ordinals/solutions_exercises/isqrt.v
@@ -8,9 +8,13 @@ From hydras Require Import  primRec extEqualNat.
 From Coq Require Import Min ArithRing Lia Compare_dec Arith Lia.
 
 
+(* begin snippet boundedSearch3 *)
 
 Lemma boundedSearch3 :
-  forall (P : naryRel 2) (b  : nat), boundedSearch P b <= b. 
+  forall (P : naryRel 2) (b  : nat), boundedSearch P b <= b. (* .no-out *)
+
+(* end snippet boundedSearch3 *)
+
 Proof.
   unfold boundedSearch; intros P b; generalize b at 2 3.
   induction b0.
@@ -19,9 +23,15 @@ Proof.
     case_eq (P b b0); auto.
 Qed.
 
+(* begin snippet boundedSearch4 *)
+
 Lemma boundedSearch4 :
-  forall (P : naryRel 2) (b  : nat), P b b = true ->
-                                     P b (boundedSearch P b) = true.
+  forall (P : naryRel 2) (b  : nat),
+    P b b = true ->
+    P b (boundedSearch P b) = true. (* .no-out *)
+
+(* end snippet boundedSearch4 *)
+
 Proof.
   intros;  destruct (boundedSearch2 P b); auto. 
   now rewrite H0.


### PR DESCRIPTION
Start to add a few snippets to chapter9 (primitive recursive functions).

-  There is a quotation of a definition from the Ackermann library, and the same problem will happen with the Standard Library. It looks difficult to add snippets in such libraries. I chose (for the time being) to leave the Coqsrc blocks. 

- Just for trying, I put a commented proof of extEqual_ex1 (P. 165 of the pdf, library ordinals/MoreAck/PrimRecExamples.v)  with comments inside the proof. I put a few (* .no-outs *) comments because alectryon displays the sub-goal after the bullets.