### PR TITLE
Refactor bibliography

### DIFF
--- a/doc/chapter-powers.tex
+++ b/doc/chapter-powers.tex
@@ -333,7 +333,7 @@ In~\cite{BC04}, several exercices~\footnote{Exercises 9.8 (page 270), 9.10 (page
 present ways to compute Fibonacci numbers, with the less number of recursive calls  as possible. Please note that these optimizations and the formal proof of their correctness are \emph{ad-hoc}, \emph{i.e.} exclusively written for the 
 Fibonacci numbers.
 In contrast, the optimizations we present in this document apply, in their vast majority, \emph{generic} techniques of efficient computation of powers in a monoid. 
-This example of Fibonacci numbers has been developed with Yves Bertot, who wrote a first version with \texttt{SSreflect/Mathcomp}~\cite{MCB, SSR}. 
+This example of Fibonacci numbers has been developed with Yves Bertot, who wrote a first version with \texttt{SSreflect/Mathcomp}~\cite{MCB}.
 
 
 \subsubsection{Using 2x2 integer matrices}
@@ -1287,7 +1287,7 @@ forall (x:A) (n:N),   x ^b n  == x ^ N.to_nat n.
 The relationship between \texttt{power} and \texttt{N\_bpow} can be considered
 as a kind of \emph{refinement} as in the \texttt{B}-method~\cite{b-book}. Note
 that the two representations of natural numbers and the function \texttt{N.to\_nat}
-form a kind of  \emph{data refinement} \cite{Abrial:2010:MES:1855020, cohen:hal-01113453}.
+form a kind of  \emph{data refinement} \cite{Abrial:2010:MES:1855020, Cohen2013}.
 
 
 

--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -2557,7 +2557,7 @@ In our formalization, the interpretation of an ordinal as a set is realized by t
 \end{remark}
 
 \begin{remark}
-Finite ordinals are also formalized in MathComp~\cite{SSR}.  See also Adam Chlipala's \emph{CPDT}~\cite{chlipalacpdt2011} for a thorough study of the use of dependent types.  
+Finite ordinals are also formalized in MathComp~\cite{MCB}.  See also Adam Chlipala's \emph{CPDT}~\cite{chlipalacpdt2011} for a thorough study of the use of dependent types.  
 \end{remark}
 
 

--- a/doc/thebib.bib
+++ b/doc/thebib.bib
@@ -1,52 +1,50 @@
 @inproceedings{MS08,
- author = {M. Sozeau  and N. Oury},
+ author = {Sozeau, Matthieu and Oury, Nicolas},
  title = {First-Class Type Classes},
- booktitle = {TPHOLs '08: Proceedings of the 21st International Conference on Theorem Proving in Higher Order Logics},
+ booktitle = {International Conference on Theorem Proving in Higher Order Logics},
  year = {2008},
  isbn = {978-3-540-71065-3},
  pages = {278--293},
  location = {Montreal, P.Q., Canada},
- doi = {http://dx.doi.org/10.1007/978-3-540-71067-7_23},
- publisher = {Springer-Verlag},
+ doi = {10.1007/978-3-540-71067-7_23},
+ publisher = {Springer},
  address = {Berlin, Heidelberg},
- }
+ url = {https://sozeau.gitlabpages.inria.fr/www/research/publications/First-Class_Type_Classes.pdf},
+}
 
 @Misc{PCMS,
- author = 	 {Pierre Castéran and Matthieu Sozeau},
-  title = 	 {{A gentle Introduction to Type Classes and Relations in Coq}},
-  howpublished = {http://www.labri.fr/perso/casteran/CoqArt/TypeClassesTut/typeclassestut.pdf},
+ author = 	 {Pierre Cast{\'e}ran and Matthieu Sozeau},
+ title = 	 {{A gentle Introduction to Type Classes and Relations in Coq}},
+ howpublished = {http://www.labri.fr/perso/casteran/CoqArt/TypeClassesTut/typeclassestut.pdf},
 }
-
 
 @article{sozeau:hal-01671777,
-  TITLE = {{Equations reloaded}},
-  AUTHOR = {Sozeau, Matthieu and Mangin, Cyprien},
-  URL = {https://hal.inria.fr/hal-01671777},
-  JOURNAL = {{Proceedings of the ACM on Programming Languages}},
-  PUBLISHER = {{ACM}},
-  VOLUME = {3},
-  NUMBER = {ICFP},
-  PAGES = {1-29},
-  YEAR = {2019},
-  MONTH = Jul,
-  DOI = {10.1145/3341690},
-  KEYWORDS = {Coq ; Dependent pattern-matching ; Proof assistants ; Type theory ; Program verification ; Recursion},
-  PDF = {https://hal.inria.fr/hal-01671777/file/icfp19main-p204-p.pdf},
-  HAL_ID = {hal-01671777},
-  HAL_VERSION = {v3},
+author = {Sozeau, Matthieu and Mangin, Cyprien},
+title = {Equations Reloaded: High-Level Dependently-Typed Functional Programming and Proving in {Coq}},
+year = {2019},
+issue_date = {August 2019},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+volume = {3},
+number = {ICFP},
+url = {https://hal.inria.fr/hal-01671777},
+doi = {10.1145/3341690},
+journal = {Proceedings of the ACM on Programming Languages},
+month = jul,
+articleno = {86},
+numpages = {29},
 }
 
-
-@INPROCEEDINGS{Bertot_theoremproving,
-    author = {Yves Bertot},
-    title = {Theorem proving support in programming language semantics, in "From Semantics to Computer Science, essays in Honour of Gilles Kahn},
-    booktitle = {Proceedings Editing},
-    year = {},
-    publisher = {University Press}
+@inbook{Bertot_theoremproving,
+author = {Yves Bertot},
+title = {Theorem proving support in programming language semantics},
+editor = {Yves Bertot and G{\'e}rard Huet and Jean-Jacques L{\'e}vy and Gordon Plotkin},
+booktitle = {{From Semantics to Computer Science: Essays in Honour of Gilles Kahn}},
+publisher = {Cambridge University Press},
+year = {2009},
+pages = {337--361},
+url = {http://hal.inria.fr/inria-00160309},
 }
-
-
-
 
 @Misc{Coq,
   author = 	 {{Coq Development Team}},
@@ -55,25 +53,32 @@
 }
 
 @book{BC04,
-  author = {Bertot, Yves and Cast\'eran, Pierre},
-  title = {Interactive Theorem Proving and Program Development. Coq'Art: The Calculus of Inductive Constructions},
+  title = {Interactive Theorem Proving and Program Development: {Coq'Art}: The Calculus of Inductive Constructions},
   year = {2004},
+  doi = {10.1007/978-3-662-07964-5},
+  author = {Bertot, Yves and Cast\'eran, Pierre},
   publisher = {Springer},
-  note = {\url{http://www.labri.fr/perso/casteran/CoqArt/index.html}}
+  address = {Berlin, Heidelberg},
+  isbn = {978-3-662-07964-5},
+  url = {https://www.labri.fr/perso/casteran/CoqArt/},
 }
 
-@Misc{BS2011,
-  author = 	 {Bas Spitters and Eelis van der Weegen},
-  title = 	 {Type Classes for Mathematics in Type Theory},
-  howpublished = {http://arxiv.org/pdf/1102.1323.pdf},
-  year = 	 {2011},
+@article{BS2011,
+  title={Type classes for mathematics in type theory},
+  volume={21},
+  doi={10.1017/S0960129511000119},
+  number={4},
+  journal={Mathematical Structures in Computer Science},
+  publisher={Cambridge University Press},
+  author={Spitters, Bas and van der Weegen, Eelis},
+  year={2011},
+  pages={795--825},
+  url={https://arxiv.org/abs/1102.1323},
 }
-
-
 
 @book{b-book,
  author = {Abrial, J.-R.},
- title = {The B-book: Assigning Programs to Meanings},
+ title = {The {B-book}: Assigning Programs to Meanings},
  year = {1996},
  isbn = {0-521-49619-5},
  publisher = {Cambridge University Press},
@@ -82,21 +87,27 @@
 
 @book{Abrial:2010:MES:1855020,
  author = {Abrial, Jean-Raymond},
- title = {Modeling in Event-B: System and Software Engineering},
+ title = {Modeling in {Event-B}: System and Software Engineering},
  year = {2010},
  isbn = {0521895561, 9780521895569},
  edition = {1st},
  publisher = {Cambridge University Press},
  address = {New York, NY, USA},
-} 
+}
 
-
-
-@InProceedings{PHOAS,
-  author = 	 {Adam Chlipala},
-  title = 	 {Parametric Higher-Order Abstract Syntax for Mechanized Semantics},
-  booktitle = {Proceedings of the 13th ACM SIGPLAN International Conference on Functional Programming (ICFP'08)},
-  year = 	 {2008},
+@inproceedings{PHOAS,
+ author = {Chlipala, Adam},
+ title = {Parametric Higher-order Abstract Syntax for Mechanized Semantics},
+ booktitle = {International Conference on Functional Programming},
+ year = {2008},
+ isbn = {978-1-59593-919-7},
+ location = {Victoria, BC, Canada},
+ pages = {143--156},
+ numpages = {14},
+ url = {http://adam.chlipala.net/papers/PhoasICFP08/},
+ doi = {10.1145/1411204.1411226},
+ publisher = {ACM},
+ address = {New York, NY, USA},
 }
 
 @book{chlipalacpdt2011,
@@ -104,101 +115,87 @@
   title = {Certified Programming with Dependent Types},
   publisher = {MIT Press},
   year = 2011,
-  url = {{http://adam.chlipala.net/cpdt/}},
-  note = {\url{http://adam.chlipala.net/cpdt/}}
+  isbn = {978-0-262-31786-3},
+  url = {http://adam.chlipala.net/cpdt/},
 }
 
-@conference {Cohen2013,
-	title = {Refinements for Free!},
-	booktitle = {Certified Programs and Proofs - Third International Conference, CPP 2013, Melbourne, VIC, Australia, December 11-13, 2013, Proceedings},
-	year = {2013},
-	publisher = {Springer},
-	organization = {Springer},
-	doi = {10.1007/978-3-319-03545-1_10},
-	url = {http://dx.doi.org/10.1007/978-3-319-03545-1_10},
-	author = {Cyril Cohen and Maxime D{\'e}n{\`e}s and Anders M{\"o}rtberg},
-	editor = {Georges Gonthier and Michael Norrish}
+@InProceedings{Cohen2013,
+author={Cohen, Cyril and D{\'e}n{\`e}s, Maxime and M{\"o}rtberg, Anders},
+title={Refinements for Free!},
+booktitle={Certified Programs and Proofs},
+year={2013},
+publisher={Springer},
+address={Cham},
+pages={147--162},
+isbn={978-3-319-03545-1},
+doi={10.1007/978-3-319-03545-1_10},
+url={https://perso.crans.org/cohen/papers/refinements.pdf},
 }
-
 
 @inproceedings{Wadler1989,
  author = {Wadler, Philip},
  title = {Theorems for Free!},
- booktitle = {Proceedings of the Fourth International Conference on Functional Programming Languages and Computer Architecture},
- series = {FPCA '89},
+ booktitle = {International Conference on Functional Programming Languages and Computer Architecture},
  year = {1989},
  isbn = {0-89791-328-0},
- location = {Imperial College, London, United Kingdom},
+ location = {London, United Kingdom},
  pages = {347--359},
  numpages = {13},
- url = {http://doi.acm.org/10.1145/99370.99404},
+ url = {https://homepages.inf.ed.ac.uk/wadler/papers/free/free.ps},
  doi = {10.1145/99370.99404},
- acmid = {99404},
  publisher = {ACM},
  address = {New York, NY, USA},
-} 
-
-
-@article{DBLP:journals/ita/BrlekCHM95,
-  author    = {Srecko Brlek and
-               Pierre Cast{\'{e}}ran and
-               Laurent Habsieger and
-               Richard Mallette},
-  title     = {On-Line Evaluation of Powers Using Euclid's Algorithm},
-  journal   = {{ITA}},
-  volume    = {29},
-  number    = {5},
-  pages     = {431--450},
-  year      = {1995},
-  timestamp = {Thu, 03 Jan 2002 12:23:59 +0100},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/ita/BrlekCHM95},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
 }
 
+@article{DBLP:journals/ita/BrlekCHM95,
+  author = {Brlek, Sre\'cko and Cast\'eran, Pierre and Habsieger, Laurent and Mallette, Richard},
+  title = {On-line evaluation of powers using {Euclid's} algorithm},
+  journal = {RAIRO - Theoretical Informatics and Applications - Informatique Th\'eorique et Applications},
+  pages = {431--450},
+  publisher = {EDP-Sciences},
+  volume = {29},
+  number = {5},
+  year = {1995},
+  doi = {10.1051/ita/1995290504311},
+  url = {http://www.numdam.org/item/ITA_1995__29_5_431_0.pdf},
+}
 
 @article{brauer1939,
 author = "Brauer, Alfred",
-fjournal = "Bulletin of the American Mathematical Society",
-journal = "Bull. Amer. Math. Soc.",
+journal = "Bulletin of the American Mathematical Society",
 month = "10",
 number = "10",
 pages = "736--739",
 publisher = "American Mathematical Society",
 title = "On addition chains",
-url = "http://projecteuclid.org/euclid.bams/1183502136",
+doi = "10.1090/S0002-9904-1939-07068-7",
+url = "https://www.ams.org/journals/bull/1939-45-10/S0002-9904-1939-07068-7/S0002-9904-1939-07068-7.pdf",
 volume = "45",
 year = "1939"
 }
 
-
-@inproceedings{DBLP:conf/tapsoft/BrlekCS91,
-  author    = {Srecko Brlek and
-               Pierre Cast{\'{e}}ran and
-               Robert Strandh},
-  title     = {On Addition Schemes},
-  booktitle = {TAPSOFT'91: Proceedings of the International Joint Conference on Theory
-               and Practice of Software Development, Brighton, UK, April 8-12, 1991,
-               Volume 2: Advances in Distributed Computing {(ADC)} and Colloquium
-               on Combining Paradigms for Software Development {(CCPSD)}},
-  pages     = {379--393},
-  year      = {1991},
-  url       = {http://dx.doi.org/10.1007/3540539816_77},
-  doi       = {10.1007/3540539816_77},
-  timestamp = {Thu, 15 Oct 2009 16:38:19 +0200},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/conf/tapsoft/BrlekCS91},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
+@InProceedings{DBLP:conf/tapsoft/BrlekCS91,
+author="Brlek, Sre{\'{c}}ko and Cast{\'e}ran, Pierre and Strandh, Robert",
+title="On addition schemes",
+booktitle="International Joint Conference on Theory and Practice of Software Development",
+doi="10.1007/3540539816_77",
+year="1991",
+publisher="Springer",
+address="Berlin, Heidelberg",
+pages="379--393",
+isbn="978-3-540-46499-0",
+url="https://link.springer.com/content/pdf/10.1007%2F3540539816_77.pdf",
 }
 
-
 @Misc{CantorContribSlide,
- author = 	 {P. C. and \'Evelyne Contéjean},
+ author = 	 {Pierre Cast{\'e}ran and \'Evelyne Cont{\'e}jean},
   title = 	 {On Ordinal Notations},
   howpublished = {User Contributions to the Coq Proof Assistant},
    year= {2006}
 }
 
 @Misc{CantorContrib,
- author = 	 {Pierre  Castéran and \'Evelyne Contéjean},
+ author = 	 {Pierre Cast{\'e}ran and \'Evelyne Cont{\'e}jean},
   title = 	 {On Ordinal Notations},
   howpublished = {User Contributions to the Coq Proof Assistant},
    year= {2006}
@@ -212,19 +209,16 @@ year = "1939"
 }
 
 @article{DBLP:journals/ipl/BerstelB87,
-  author    = {Jean Berstel and
-               Srecko Brlek},
-  title     = {On the Length of Word Chains},
-  journal   = {Inf. Process. Lett.},
-  volume    = {26},
-  number    = {1},
-  pages     = {23--28},
-  year      = {1987},
-  url       = {http://dx.doi.org/10.1016/0020-0190(87)90031-7},
-  doi       = {10.1016/0020-0190(87)90031-7},
-  timestamp = {Fri, 08 Jul 2011 12:13:22 +0200},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/ipl/BerstelB87},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
+title = {On the length of word chains},
+journal = {Information Processing Letters},
+volume = {26},
+number = {1},
+pages = {23--28},
+year = {1987},
+issn = {0020-0190},
+doi = {10.1016/0020-0190(87)90031-7},
+url = {http://www-igm.univ-mlv.fr/~berstel/Articles/1987WordChains.pdf},
+author = {Berstel, Jean and Brlek, Sre{\'{c}}ko},
 }
 
 @inproceedings{REYNOLDS83,
@@ -235,7 +229,7 @@ booksubtitle = "Proceedings of the IFIP 9th World Computer Congress",
 place = "Paris, France",
 dates = "September 19--23, 1983",
 editor = "R. E. A. Mason",
-publisher = "Elsevier Science Publishers B. V. (North-Holland)",
+publisher = "Elsevier",
 address = "Amsterdam",
 year = "1983",
 pages = "513--523",
@@ -256,7 +250,7 @@ updated = "9 May 2001"}
 @article{Strachey:2000:FCP:609150.609208,
  author = {Strachey, Christopher},
  title = {Fundamental Concepts in Programming Languages},
- journal = {Higher Order Symbol. Comput.},
+ journal = {Higher-Order and Symbolic Computation},
  issue_date = {April 2000},
  volume = {13},
  number = {1-2},
@@ -265,20 +259,18 @@ updated = "9 May 2001"}
  issn = {1388-3690},
  pages = {11--49},
  numpages = {39},
- url = {http://dx.doi.org/10.1023/A:1010000313106},
+ url = {https://www.cs.cmu.edu/~crary/819-f09/Strachey67.pdf},
  doi = {10.1023/A:1010000313106},
- acmid = {609208},
  publisher = {Kluwer Academic Publishers},
  address = {Hingham, MA, USA},
- keywords = {CPL, L-values, R-values, ad hoc polymorphism, binding mechanisms, foundations of computing, functions as data, parameter passing, parametric polymorphism, programming languages, semantics, type completeness, variable binding},
 } 
 
 @Misc{DanBrown-survey,
   author = 	 {Daniel Brown},
   title = 	 {Parametricity},
-  howpublished = {http://www.ccs.neu.edu/home/matthias/369-s10/Transcript/parametricity.pdf},
+  howpublished = {https://web.archive.org/web/20190628092255/http://www.ccs.neu.edu/home/matthias/369-s10/Transcript/parametricity.pdf},
   year = 	 {2010},
-  note = 	 {Available on Matthias Felleisen page},
+  note = 	 {Transcript of a lecture by Matthias Felleisen},
 }
 
 @book{Tel:1994:IDA:203042,
@@ -288,49 +280,43 @@ updated = "9 May 2001"}
  isbn = {0-521-47096-2},
  publisher = {Cambridge University Press},
  address = {New York, NY, USA},
-} 
-
-
-
+}
 
 @book{HommageJPJ,
-   title = "Rewriting, computation and proof : essays dedicated to Jean-Pierre J ouannaud on the occasion of his 60th birthday",
-   editor = "Comon-Lundh, Hubert and Kirchner, Claude and Kirchner, Hélène",
-   series = "{Lecture Notes in Computer Science}",
-   publisher = "Springer",
-   address = "Berlin, New York",
-   url = "http://opac.inria.fr/record=b1125009",
-   isbn = "978-3-540-73146-7",
-   year = 2007
-} 
- 
-@incollection{Dershowitz2007,
-author="Dershowitz, Nachum
-and Moser, Georg",
-editor="Comon-Lundh, Hubert
-and Kirchner, Claude
-and Kirchner, H{\'e}l{\`e}ne",
-bookTitle="Rewriting, Computation and Proof: Essays Dedicated to Jean-Pierre Jouannaud on the Occasion of His 60th Birthday",
-year="2007",
-publisher="Springer Berlin Heidelberg",
+ editor="Comon-Lundh, Hubert and Kirchner, Claude and Kirchner, H{\'e}l{\`e}ne",
+ title="Rewriting, Computation and Proof: Essays Dedicated to {Jean-Pierre Jouannaud} on the Occasion of His 60th Birthday",
+ year="2007",
+ doi="10.1007/978-3-540-73147-4",
+ publisher="Springer",
+ address="Berlin, Heidelberg",
+ isbn="978-3-540-73146-7",
+ url="https://www.springer.com/gp/book/9783540731467",
+}
+
+@Inbook{Dershowitz2007,
+author="Dershowitz, Nachum and Moser, Georg",
 title="The Hydra Battle Revisited",
+bookTitle="Rewriting, Computation and Proof: Essays Dedicated to {Jean-Pierre Jouannaud} on the Occasion of His 60th Birthday",
+year="2007",
+publisher="Springer",
 address="Berlin, Heidelberg",
 pages="1--27",
 isbn="978-3-540-73147-4",
 doi="10.1007/978-3-540-73147-4_1",
-url="http://dx.doi.org/10.1007/978-3-540-73147-4_1",
+url="https://www.cs.tau.ac.il/~nachum/papers/LNCS/Hydra.pdf",
 \crossref={HommageJPJ},
 }
 
-
-
-@ARTICLE{KP82,
-    author = {Laurie Kirby and  Jeff Paris},
-    title = {Accessible independence results for {P}eano arithmetic},
-    journal = {Bulletin of the London Mathematical Society},
-    year = {1982},
-    volume = {14},
-    pages = {725--731}
+@article{KP82,
+author = {Kirby, Laurie and Paris, Jeff},
+title = {Accessible Independence Results for {Peano} Arithmetic},
+journal = {Bulletin of the London Mathematical Society},
+volume = {14},
+number = {4},
+pages = {285--293},
+doi = {10.1112/blms/14.4.285},
+url = {https://faculty.baruch.cuny.edu/lkirby/accessible_independence_results.pdf},
+year = {1982},
 }
 
 @article{KS81,
@@ -339,40 +325,68 @@ url="http://dx.doi.org/10.1007/978-3-540-73147-4_1",
  author = {Jussi Ketonen and Robert Solovay},
  journal = {Annals of Mathematics},
  number = {2},
- pages = {267-314},
+ pages = {267--314},
  publisher = {Annals of Mathematics},
  title = {Rapidly Growing {R}amsey Functions},
  volume = {113},
- year = {1981}
+ year = {1981},
+ doi = {10.2307/2006985},
 }
 
-
-@InBook{Promel2013,
-  author = 	 {Hans J{\"u}rgen Pr{\H o}mel},
-   title = 	 {Ramsey Theory for Discrete Structures},
-  chapter = 	 {Rapidly Growing Ramsey Functions},
-  publisher = 	 {Springer, Cham},
-  year = 	 {2013}
+@Inbook{Promel2013,
+author="Pr{\"o}mel, Hans J{\"u}rgen",
+title="Rapidly Growing Ramsey Functions",
+bookTitle="Ramsey Theory for Discrete Structures",
+year="2013",
+publisher="Springer",
+address="Cham",
+pages="97--103",
+isbn="978-3-319-01315-2",
+doi="10.1007/978-3-319-01315-2_8",
+url="https://link.springer.com/chapter/10.1007/978-3-319-01315-2_8"
 }
 
-
-
-@Article{fourcolors,
-  author = 	 {Georges Gonthier},
-  title = 	 {Formal Proof --- The Four-Color Theorem},
-  journal = 	 {Notices of the American Mathematical Society},
-  year = 	 {2008},
- volume = 	 {55},
-  number = 	 {11},
-  month = {December}
+@article{fourcolors,
+  author = {Gonthier, Georges},
+  title = {Formal proof---the four-color theorem},
+  journal = {Notices of the American Mathematical Society},
+  pages = {1382--1393},
+  year = {2008},
+  volume = {55},
+  number = {11},
+  url = {http://www.ams.org/notices/200811/tx081101382p.pdf},
 }
 
-
-@Misc{flyspeck2015,
-   author = 	 {Thomas Hales and others},
-   title = 	 {A formal proof of the {K}epler conjecture},
-  howpublished = {https://arxiv.org/abs/1501.02155},
-   year = 	 {2015}
+@article{flyspeck2015,
+  title={A Formal Proof of the {Kepler} Conjecture},
+  volume={5},
+  doi={10.1017/fmp.2017.1},
+  journal={Forum of Mathematics, Pi},
+  publisher={Cambridge University Press},
+  author = {Thomas Hales and
+            Mark Adams and
+            Gertrud Bauer and
+            Tat Dat Dang and
+            John Harrison and
+            Le Truong Hoang and
+            Cezary Kaliszyk and
+            Victor Magron and
+            Sean McLaughlin and
+            Tat Thang Nguyen and
+            Quang Truong Nguyen and
+            Tobias Nipkow and
+            Steven Obua and
+            Joseph Pleso and
+            Jason Rute and
+            Alexey Solovyev and
+            Thi Hoai An Ta and
+            Nam Trung Tran and
+            Thi Diep Trieu and
+            Josef Urban and
+            Ky Vu and
+            Roland Zumkeller},
+  year={2017},
+  url={https://arxiv.org/abs/1501.02155},
 }
 
 @Misc{bauer2008,
@@ -382,16 +396,26 @@ url="http://dx.doi.org/10.1007/978-3-540-73147-4_1",
  year = 	 {2008}
 }
 
-
 @TechReport{CG88,
   author = 	 {Eduardo Gimenez and Pierre Cast\'eran} ,
-  title = 	 {A Tutorial on [Co-]Inductive Types in Coq},
+  title = 	 {A Tutorial on [Co-]Inductive Types in {Coq}},
   institution =  {INRIA},
   year = 	 {1998},
-  annote = 	 {www.labri.fr/perso/casteran/RecTutorial.pdf}
+  url =          {https://hal.inria.fr/hal-00344325},
 }
 
-
+@article{Paulson84constructingrecursion,
+title = {Constructing recursion operators in intuitionistic type theory},
+journal = {Journal of Symbolic Computation},
+volume = {2},
+number = {4},
+pages = {325--355},
+year = {1986},
+issn = {0747-7171},
+doi = {10.1016/S0747-7171(86)80002-5},
+url = {https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-57.pdf},
+author = {Lawrence C. Paulson},
+}
 
 @ARTICLE{Paulson84constructingrecursion,
     author = {Lawrence C Paulson},
@@ -402,81 +426,64 @@ url="http://dx.doi.org/10.1007/978-3-540-73147-4_1",
     pages = {325--355}
 }
 
-
 @Misc{SF,
-  author = 	 {Benjamin  Pierce and others},
+  author = 	 {Benjamin Pierce and others},
   title = 	 {Software Foundations},
-  howpublished = {https://softwarefoundations.cis.upenn.edu/}
+  howpublished = {https://softwarefoundations.cis.upenn.edu}
 }
 
 @article{CF2011,
-  author    = {Pierre Cast{\'{e}}ran and
-               Vincent Filou},
+  author    = {Pierre Cast{\'{e}}ran and Vincent Filou},
   title     = {Tasks, Types and Tactics for Local Computation Systems},
-  journal   = {Stud. Inform. Univ.},
+  journal   = {Studia Informatica Universalis},
   volume    = {9},
   number    = {1},
   pages     = {39--86},
   year      = {2011},
-  url       = {http://studia.complexica.net/index.php?option=com_content&view=article&id=186%3Atasks-types-and-tactics-for-local-computation-systems-pp-39-86-},
-  timestamp = {Mon, 18 Mar 2013 13:53:39 +0100},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/siu/CasteranF11},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
+  url       = {https://hal.archives-ouvertes.fr/hal-00596712},
 }
 
-
-@inproceedings {
-	ABC13,
-	title	=	"{Certified Impossibility Results for Byzantine-Tolerant Mobile Robots}",
-	author	=	" C. Auger and Z. Bouzid and P. Courtieu and S. Tixeuil and X. Urbain ",
-	booktitle	=	"{International Symposium on Stabilization, Safety, and Security of Distributed Systems}",
-	year	=	2013,
-	month	=	"November",
-	series	=	"LNCS",
-	volume	=	8255,
-	pages	=	"15",
-	address	=	"Osaka, Japon",
+@InProceedings{ABC13,
+author="Auger, C{\'e}dric and Bouzid, Zohir and Courtieu, Pierre and Tixeuil, S{\'e}bastien and Urbain, Xavier",
+title="Certified Impossibility Results for Byzantine-Tolerant Mobile Robots",
+booktitle="Stabilization, Safety, and Security of Distributed Systems",
+year="2013",
+publisher="Springer",
+address="Cham",
+pages="178--190",
+isbn="978-3-319-03089-0",
+doi="10.1007/978-3-319-03089-0_13",
+url="https://arxiv.org/abs/1306.4242",
 }
-
-
 
 @article{DBLP:journals/ipl/CourtieuRTU15,
-  author    = {Pierre Courtieu and
-               Lionel Rieg and
-               S{\'{e}}bastien Tixeuil and
-               Xavier Urbain},
-  title     = {Impossibility of gathering, a certification},
-  journal   = {Inf. Process. Lett.},
-  volume    = {115},
-  number    = {3},
-  pages     = {447--452},
-  year      = {2015},
-  url       = {https://doi.org/10.1016/j.ipl.2014.11.001},
-  doi       = {10.1016/j.ipl.2014.11.001},
-  timestamp = {Tue, 06 Jun 2017 22:27:05 +0200},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/ipl/CourtieuRTU15},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
+title = {Impossibility of gathering, a certification},
+journal = {Information Processing Letters},
+volume = {115},
+number = {3},
+pages = {447--452},
+year = {2015},
+issn = {0020-0190},
+doi = {10.1016/j.ipl.2014.11.001},
+url = {https://arxiv.org/abs/1405.5902},
+author = {Pierre Courtieu and Lionel Rieg and S{\'{e}}bastien Tixeuil and Xavier Urbain},
 }
 
-
 @article{DBLP:journals/corr/RamosQMA15,
-  author    = {Marcus Vin{\'{\i}}cius Midena Ramos and
-               Ruy J. G. B. de Queiroz and
-               Nelma Moreira and
-               Jos{\'{e}} Carlos Bacelar Almeida},
-  title     = {Formalization of the pumping lemma for context-free languages},
-  journal   = {CoRR},
-  volume    = {abs/1510.04748},
-  year      = {2015},
-  url       = {http://arxiv.org/abs/1510.04748},
-  timestamp = {Wed, 07 Jun 2017 14:41:57 +0200},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/corr/RamosQMA15},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
+ title={Formalization of the pumping lemma for context-free languages},
+ volume={9},
+ url={https://jfr.unibo.it/article/view/5595},
+ DOI={10.6092/issn.1972-5787/5595},
+ number={2},
+ journal={Journal of Formalized Reasoning},
+ author={Ramos, Marcus Vin{\'{\i}}cius Midena and Almeida, Jos{\'{e}} Carlos Bacelar and Moreira, Nelma and de Queiroz, Ruy Jos{\'{e}} Guerra Barretto},
+ year={2016},
+ month={Jan.},
+ pages={53--68}
 }
 
 @Article{Manolios2005,
-author="Manolios, Panagiotis
-and Vroon, Daron",
+author="Manolios, Panagiotis and Vroon, Daron",
 title="Ordinal Arithmetic: Algorithms and Mechanization",
 journal="Journal of Automated Reasoning",
 year="2005",
@@ -488,13 +495,11 @@ pages="387--423",
 abstract="Termination proofs are of critical importance for establishing the correct behavior of both transformational and reactive computing systems. A general setting for establishing termination proofs involves the use of the ordinal numbers, an extension of the natural numbers into the transfinite that were introduced by Cantor in the nineteenth century and are at the core of modern set theory. We present the first comprehensive treatment of ordinal arithmetic on compact ordinal notations and give efficient algorithms for various operations, including addition, subtraction, multiplication, and exponentiation. Using the ACL2 theorem proving system, we implemented our ordinal arithmetic algorithms, mechanically verified their correctness, and developed a library of theorems that can be used to significantly automate reasoning involving the ordinals. To enable users of the ACL2 system to fully utilize our work required that we modify ACL2, e.g., we replaced the underlying representation of the ordinals and added a large library of definitions and theorems. Our modifications are available starting with ACL2 version 2.8.",
 issn="1573-0670",
 doi="10.1007/s10817-005-9023-9",
-url="https://doi.org/10.1007/s10817-005-9023-9"
+url="http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf",
 }
 
-
-
 @techreport{grimm:hal-00911710,
-  TITLE = {{Implementation of three types of ordinals in Coq}},
+  TITLE = {Implementation of three types of ordinals in {Coq}},
   AUTHOR = {Grimm, Jos{\'e}},
   URL = {https://hal.inria.fr/hal-00911710},
   TYPE = {Research Report},
@@ -502,91 +507,89 @@ url="https://doi.org/10.1007/s10817-005-9023-9"
   PAGES = {74},
   INSTITUTION = {{INRIA}},
   YEAR = {2013},
-  KEYWORDS = {Gaia ; Coq ; Bourbaki ; ordinals ; well-order},
-  PDF = {https://hal.inria.fr/hal-00911710/file/RR8407.pdf},
-  HAL_ID = {hal-00911710},
-  HAL_VERSION = {v1},
 }
-
-
 
 @InProceedings{PCiota,
-  author = 	 {Pierre Castéran},
-  title = 	 {Utilisation en {C}oq de l'opérateur de description},
-   booktitle = {Actes des Journées Francophones des Langages Applicatifs},
+  author = 	 {Pierre Cast{\'e}ran},
+  title = 	 {Utilisation en {C}oq de l'op{\'e}rateur de description},
+  booktitle = {Actes des Journ{\'e}es Francophones des Langages Applicatifs},
   year = 	 {2007},
-  note = 	 {http://jfla.inria.fr/2007/actes/index.html}
+  pages = {30--44},
+  url = {http://jfla.inria.fr/2007/actes/PDF/03_casteran.pdf},
 }
-
 
 @Misc{BauerHydra,
-   author = 	 {Andrej Bauer},
+  author = 	 {Andrej Bauer},
   title = 	 {The Hydra Game},
-  howpublished = {math.andrej.com/2008/02/02/the-hydra-game}
+  howpublished = {http://math.andrej.com/2008/02/02/the-hydra-game}
 }
 
-
 @Book{schutte,
-author = {Kurt  Schutte},
-title = { Proof theory / Translation from the German by J. N. Crossley },
-isbn = { 0387079114 },
-publisher = { Springer-Verlag Berlin ; New York },
-pages = { xii, 302 p. ; },
-year = { 1977 }, 
-type = { Book },
-language = { English },
-subjects = { Proof theory. },
-life-dates = { 1977 -  },
-catalogue-url = { http://nla.gov.au/nla.cat-vn2178762 }
+ author = {Kurt Sch\"utte},
+ title = {Proof Theory},
+ isbn = {978-3-642-66475-5},
+ publisher = {Springer},
+ year = {1977},
+ doi = {10.1007/978-3-642-66473-1},
+ url = {https://www.springer.com/gp/book/9783642664755},
 }
 
 @Misc{Sladek07thetermite,
-    author = {Will Sladek},
-    title = {The {T}ermite and the {T}ower: Goodstein sequences and provability in PA},
-    howpublished={\url{www.uio.no/studier/emner/matnat/ifi/INF5170/v08/undervisningsmateriale/sladekgoodstein.pdf}},
-   year = {2007}
+ author = {Will Sladek},
+ title = {The {T}ermite and the {T}ower: {Goodstein} sequences and provability in {PA}},
+ howpublished={\url{https://www.uio.no/studier/emner/matnat/ifi/INF5170/v08/undervisningsmateriale/sladekgoodstein.pdf}},
+ year = {2007}
 }
 
-
-
-@article{goodstein_1944, title={On the restricted ordinal theorem}, volume={9}, DOI={10.2307/2268019}, number={2}, journal={Journal of Symbolic Logic}, publisher={Cambridge University Press}, author={Goodstein, R. L.}, year={1944}, pages={33–41}}
-
+@article{goodstein_1944,
+ title={On the restricted ordinal theorem},
+ volume={9},
+ DOI={10.2307/2268019},
+ number={2},
+ journal={Journal of Symbolic Logic},
+ publisher={Cambridge University Press},
+ author={Goodstein, R. L.},
+ year={1944},
+ pages={33--41},
+ url={https://www.jstor.org/stable/2268019},
+}
 
 @Misc{Sladek07,
   author = 	{Will Sladek},
-  title = 	 {The {T}ermite and the {T}ower: Goodstein sequences and provability in {PA}},
-  howpublished = {http://citeseerx.ist.psu.edu/showciting?cid=337283},
- year = 	 {2007}
+  title = 	 {The {T}ermite and the {T}ower: {Goodstein} sequences and provability in {PA}},
+  howpublished = {\url{https://www.uio.no/studier/emner/matnat/ifi/INF5170/v08/undervisningsmateriale/sladekgoodstein.pdf}},
+  year = 	 {2007}
 }
 
 @article{DBLP:journals/corr/Schmitz13,
-  author    = {Sylvain Schmitz},
-  title     = {Complexity Hierarchies Beyond Elementary},
-  journal   = {CoRR},
-  volume    = {abs/1312.5686},
-  year      = {2013},
-  url       = {http://arxiv.org/abs/1312.5686},
-  timestamp = {Wed, 07 Jun 2017 14:40:59 +0200},
-  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/corr/Schmitz13},
-  bibsource = {dblp computer science bibliography, http://dblp.org}
+author = {Schmitz, Sylvain},
+title = {Complexity Hierarchies beyond Elementary},
+year = {2016},
+issue_date = {February 2016},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+volume = {8},
+number = {1},
+issn = {1942-3454},
+url = {https://arxiv.org/abs/1312.5686},
+doi = {10.1145/2858784},
+journal = {ACM Transactions on Computation Theory},
+month = feb,
+numpages = {36},
 }
 
-
-@inproceedings{Norrish_Huffman_13,
-    publisher        = {Springer},
-    author           = {Norrish, Michael and Huffman, Brian},
-    month            = jul,
-    slides           = {http://ts.data61.csiro.au/publications/nicta_slides/6676.pdf},
-    editor           = {{Sandrine Blazy and Christine Paulin-Mohring and David Pichardie}},
-    year             = {2013},
-    title            = {Ordinals in {HOL}: Transfinite Arithmetic up to (and beyond) $\omega_1$},
-    booktitle        = {International Conference on Interactive Theorem Proving},
-    pages            = {133-146},
-    address          = {Rennes, France}
-  }
-
-
-
+@InProceedings{Norrish_Huffman_13,
+author="Norrish, Michael and Huffman, Brian",
+title="Ordinals in {HOL}: Transfinite Arithmetic up to (and Beyond) $\omega_1$",
+booktitle="Interactive Theorem Proving",
+year="2013",
+publisher="Springer",
+address="Berlin, Heidelberg",
+doi="10.1007/978-3-642-39634-2_12",
+pages="133--146",
+isbn="978-3-642-39634-2",
+url="https://ts.data61.csiro.au/publications/nicta_full_text/6676.pdf",
+}
 
 @Manual{Jessie,
  author = 	 {Claude March\'e and Yannick Moy},
@@ -598,15 +601,13 @@ catalogue-url = { http://nla.gov.au/nla.cat-vn2178762 }
 @Misc{compcertsite,
   author = {{CompCert Development Team}},
   title = 	 {The {C}omp{C}ert compiler},
-  howpublished = {\href{http://compcert.inria.fr/}{http://compcert.inria.fr}}
+  howpublished = {\url{https://compcert.org}}
 }
-
-                  
 
 @Misc{SSR,
  author = 	 {Assia Mahboubi and Enrico Tassi},
   title = 	 {Mathematical Components},
-  howpublished = {\href{https://math-comp.github.io/mcb/}{https://math-comp.github.io/mcb/}}
+  howpublished = {\url{https://math-comp.github.io/mcb/}}
 }
 
 @Book{cantorbook,
@@ -632,22 +633,19 @@ and Rideau, Laurence
 and Solovyev, Alexey
 and Tassi, Enrico
 and Th{\'e}ry, Laurent",
-editor="Blazy, Sandrine
-and Paulin-Mohring, Christine
-and Pichardie, David",
 title="A Machine-Checked Proof of the Odd Order Theorem",
 booktitle="Interactive Theorem Proving",
 year="2013",
-publisher="Springer Berlin Heidelberg",
+publisher="Springer",
 address="Berlin, Heidelberg",
 pages="163--179",
+doi="10.1007/978-3-642-39634-2_14",
+url="https://hal.inria.fr/hal-00816699",
 abstract="This paper reports on a six-year collaborative effort that culminated in a complete formalization of a proof of the Feit-Thompson Odd Order Theorem in the Coq proof assistant. The formalized proof is constructive, and relies on nothing but the axioms and rules of the foundational framework implemented by Coq. To support the formalization, we developed a comprehensive set of reusable libraries of formalized mathematics, including results in finite group theory, linear algebra, Galois theory, and the theories of the real and complex algebraic numbers.",
 isbn="978-3-642-39634-2"
 }
 
-
 @book{tel_2000, place={Cambridge}, edition={2}, title={Introduction to Distributed Algorithms}, DOI={10.1017/CBO9781139168724}, publisher={Cambridge University Press}, author={Tel, Gerard}, year={2000}}
-
 
 @Misc{MCB,
   author = 	 {Assia Mahboubi, Enrico Tassi},
@@ -657,91 +655,76 @@ isbn="978-3-642-39634-2"
   year = 	 {2018}
 }
 
-
 @inproceedings{kosmatov:hal-01344110,
   TITLE = {{Static versus Dynamic Verification in Why3, Frama-C and SPARK 2014}},
   AUTHOR = {Kosmatov, Nikolai and March{\'e}, Claude and Moy, Yannick and Signoles, Julien},
   URL = {https://hal.inria.fr/hal-01344110},
-  BOOKTITLE = {{7th International Symposium on Leveraging Applications}},
-  ADDRESS = {Corfu, Greece},
-  PUBLISHER = {{Springer}},
-  SERIES = {7th International Symposium on Leveraging Applications},
+  doi = {10.1007/978-3-319-47166-2_32},
+  BOOKTITLE = {Leveraging Applications of Formal Methods, Verification and Validation: Foundational Techniques},
+  PUBLISHER = {Springer},
+  address = {Cham},
   PAGES = {16},
   YEAR = {2016},
-  MONTH = Oct,
-  KEYWORDS = {Deductive verification ;  Specification language ;  Dynamic Verification},
-  PDF = {https://hal.inria.fr/hal-01344110/file/paper063.pdf},
-  HAL_ID = {hal-01344110},
-  HAL_VERSION = {v1},
+  pages= {461--478},
+  isbn = {978-3-319-47166-2},
 }
-
 
 @article{bobot:hal-00967132,
   TITLE = {{Let's Verify This with Why3}},
   AUTHOR = {Bobot, Fran{\c c}ois and Filli{\^a}tre, Jean-Christophe and March{\'e}, Claude and Paskevich, Andrei},
   URL = {https://hal.inria.fr/hal-00967132},
-  JOURNAL = {{Software Tools for Technology Transfer (STTT)}},
-  PUBLISHER = {{Springer}},
+  JOURNAL = {Software Tools for Technology Transfer},
+  PUBLISHER = {Springer},
   VOLUME = {17},
   NUMBER = {6},
-  PAGES = {709-727},
+  PAGES = {709--727},
   YEAR = {2015},
-  PDF = {https://hal.inria.fr/hal-00967132/file/main.pdf},
-  HAL_ID = {hal-00967132},
-  HAL_VERSION = {v1},
+  doi = {10.1007/s10009-014-0314-5},  
 }
 
 @Article{reynolds93,
   author = 	 {John C. Reynolds},
-  title = 	 {The Discovery of Continuations},
-  journal = 	 {Lisp and Symbolic Computation},
+  title = 	 {The Discoveries of Continuations},
+  journal = 	 {LISP and Symbolic Computation},
   year = 	 {1993},
   volume = 	 {6},
-  pages = 	 {233-247}
+  pages = 	 {233--247},
+  doi = {10.1007/BF01019459},
+  url = {https://link.springer.com/content/pdf/10.1007/BF01019459.pdf},
 }
 
-@COMMENT { BibTex package created from National Library of Australia Catalogue https://catalogue.nla.gov.au  }
 @Book{burge,
-author = { Burge, William H. },
-title = { Recursive programming techniques / William H. Burge },
-isbn = { 0201144506 },
-publisher = { Addison-Wesley Pub. Co Reading, Mass },
-pages = { xv, 277 p. ; },
-year = { 1975 },
-type = { Book },
-language = { English },
-subjects = { Recursive programming.; Combinatory logic. },
-life-dates = { 1975 -  },
-catalogue-url = { https://nla.gov.au/nla.cat-vn2127416 },
+author = {Burge, William H.},
+title = {Recursive programming techniques},
+isbn = {0201144506},
+publisher = {Addison-Wesley},
+year = {1975},
 }
-
 
 @inproceedings{cohen:hal-01113453,
   TITLE = {{Refinements for Free!}},
   AUTHOR = {Cohen, Cyril and D{\'e}n{\`e}s, Maxime and M{\"o}rtberg, Anders},
   URL = {https://hal.inria.fr/hal-01113453},
-  BOOKTITLE = {{Certified Programs and Proofs}},
+  BOOKTITLE = {Certified Programs and Proofs},
   ADDRESS = {Melbourne, Australia},
   PAGES = {147 - 162},
   YEAR = {2013},
   MONTH = Dec,
   DOI = {10.1007/978-3-319-03545-1\_10},
   KEYWORDS = {Parametricity ; Efficient algorithms and data structures ; Formal proofs ; Data refinements ; Coq},
-  PDF = {https://hal.inria.fr/hal-01113453/file/refinements.pdf},
-  HAL_ID = {hal-01113453},
-  HAL_VERSION = {v1},
 }
 
-
-
-
-@InProceedings{BW85,
-  author = 	 {Wilfried Bucholz and Stan Wainer},
-  title = 	 {Provably Computable Functions and the Fast Growing Hierarchy},
-   booktitle = {Proceedings of the AMS-IMS-SIAM Joint Summer Research Conference },
-  year = 	 {1985},
-  editor = 	 {Stephen G. Simpson},
- }
+@incollection{BW85,
+ booktitle = {Contemporary Mathematics},
+ volume = {65},
+ pages = {179--198},
+ year = {1987},
+ address = {Providence, RI, USA},
+ title = {Provably computable functions and the fast growing hierarchy},
+ author = {Stan Wainer and Wilfried Buchholz},
+ editor = {Stephen G. Simpson},
+ url = {http://nbn-resolving.de/urn/resolver.pl?urn=nbn:de:bvb:19-epub-3843-7}
+}
 
 @Article{Wainer1970,
 author="Wainer, S. S.",
@@ -755,9 +738,8 @@ number="3",
 pages="136--153",
 issn="1432-0665",
 doi="10.1007/BF01973619",
-url="https://doi.org/10.1007/BF01973619"
+url="https://link.springer.com/article/10.1007%2FBF01973619"
 }
-
 
 @inproceedings{oddorderthm,
 author = {Gonthier, Georges and Asperti, Andrea and Avigad, Jeremy and Bertot, Yves and Cohen, Cyril and Garillot, François and Roux, Stéphane and Mahboubi, Assia and O'Connor, Russell and Biha, Sidi and Pasca, Ioana and Rideau, Laurence and Solovyev, Alexey and Tassi, Enrico and Théry, Laurent},
@@ -769,9 +751,6 @@ booktitle = {Proceedings of {ITP} 2013},
 doi = {10.1007/978-3-642-39634-2_14}
 }
 
-
-
-
 @article{zipper,
 author = {Huet, G\'{e}rard},
 title = {The Zipper},
@@ -782,104 +761,92 @@ address = {USA},
 volume = {7},
 number = {5},
 issn = {0956-7968},
-url = {https://doi.org/10.1017/S0956796897002864},
+url = {https://www.academia.edu/download/66730493/The_Zipper20210430-816-ieqbwj.pdf},
 doi = {10.1017/S0956796897002864},
 abstract = {Almost every programmer has faced the problem of representing a tree together with a subtree that is the focus of attention, where that focus may move left, right, up or down the tree. The Zipper is Huet's nifty name for a nifty data structure which fulfills this need. I wish I had known of it when I faced this task, because the solution I came up with was not quite so efficient or elegant as the Zipper.},
-journal = {J. Funct. Program.},
+journal = {Journal of Functional Programming},
 month = sep,
-pages = {549–554},
+pages = {549--554},
 numpages = {6}
 }
 
-  
-
-@InProceedings{a3pat,
-  author = 	 { Contejean, Evelyne and  Courtieu, Pierre and  Forest, Julien and  Paskevich, Andrei and Pons, Olivier and  Urbain, Xavier},
-  title = 	 {A≈Ò3PAT, an Approach for Certified Automated Termination Proofs},
- 
-  booktitle = {2010 ACM SIGPLAN Workshop on Partial Evaluation and Program Manipulation},
-  year = 	 {2010}, 
-  pages = 	 {63-72},
-  organization = {ACM},
+@inproceedings{a3pat,
+author = {Contejean, \'{E}velyne and Paskevich, Andrei and Urbain, Xavier and Courtieu, Pierre and Pons, Olivier and Forest, Julien},
+title = {{A3PAT}, an Approach for Certified Automated Termination Proofs},
+year = {2010},
+isbn = {9781605587271},
+publisher = {Association for Computing Machinery},
+address = {New York, NY, USA},
+url = {https://hal.inria.fr/inria-00535655},
+doi = {10.1145/1706356.1706370},
+booktitle = {Workshop on Partial Evaluation and Program Manipulation},
+pages = {63--72},
+numpages = {10},
+location = {Madrid, Spain},
 }
-
 
 @article{DershowitzRPO,
 title = "Orderings for term-rewriting systems",
 journal = "Theoretical Computer Science",
 volume = "17",
 number = "3",
-pages = "279 - 301",
+pages = "279--301",
 year = "1982",
 issn = "0304-3975",
-doi = "https://doi.org/10.1016/0304-3975(82)90026-3",
-url = "http://www.sciencedirect.com/science/article/pii/0304397582900263",
+doi = "10.1016/0304-3975(82)90026-3",
+url = "https://www.sciencedirect.com/science/article/pii/0304397582900263/pdf",
 author = "Nachum Dershowitz",
 }
-
 
 @article{Gallier91,
   author    = {Jean H. Gallier},
   title     = {What's So Special About {K}ruskal's Theorem and the Ordinal {G}amma\({}_{\mbox{0}}\)?
                {A} Survey of Some Results in Proof Theory},
-  journal   = {Ann. Pure Appl. Log.},
+  journal   = {Annals of Pure and Applied Logic},
   volume    = {53},
   number    = {3},
   pages     = {199--260},
   year      = {1991},
-  url       = {https://doi.org/10.1016/0168-0072(91)90022-E},
+  url       = {https://www.sciencedirect.com/science/article/pii/016800729190022E/pdf},
   doi       = {10.1016/0168-0072(91)90022-E},
-  timestamp = {Fri, 21 Feb 2020 21:18:28 +0100},
-  biburl    = {https://dblp.org/rec/journals/apal/Gallier91.bib},
-  bibsource = {dblp computer science bibliography, https://dblp.org}
 }
 
 @book{isabelle,
-  title={Isabelle/HOL: A Proof Assistant for Higher-Order Logic},
-  author={Nipkow, T. and Paulson, L.C. and Wenzel, M.},
+  title={{Isabelle/HOL}: A Proof Assistant for Higher-Order Logic},
+  author={Nipkow, Tobias and Paulson, Lawrence C. and Wenzel, Markus},
   isbn={9783540433767},
   lccn={02020906},
-  series={Lecture Notes in Computer Science},
-  url={https://books.google.fr/books?id=R6ul20M6nTIC},
+  url={https://link.springer.com/book/10.1007%2F3-540-45949-9},
+  doi={10.1007/3-540-45949-9},
   year={2002},
-  publisher={Springer Berlin Heidelberg}
+  publisher={Springer},
+  address={Berlin, Heidelberg},
 }
-
 
 @BOOK{HOL,
   EDITOR = {M. J. C. Gordon and T. F. Melham},
-  TITLE = {Introduction to {HOL}: A theorem proving environment for
-            higher order logic},
+  TITLE = {Introduction to {HOL}: A theorem proving environment for higher order logic},
   PUBLISHER = {Cambridge University Press},
   YEAR = {1993},
-  URL = {http://www.dcs.glasgow.ac.uk/~tfm/HOLbook.html}
+  URL = {http://www.cs.ox.ac.uk/tom.melham/pub/Gordon-1993-ITH.html},
 }
-
 
 @inproceedings{OConnor05, 
   author    = {Russell O'Connor},
-  editor    = {Joe Hurd and
-               Thomas F. Melham},
-  title     = {Essential Incompleteness of Arithmetic Verified by Coq},
-  booktitle = {Theorem Proving in Higher Order Logics, 18th International Conference,
-               TPHOLs 2005, Oxford, UK, August 22-25, 2005, Proceedings},
-  series    = {Lecture Notes in Computer Science},
-  volume    = {3603},
+  title     = {Essential Incompleteness of Arithmetic Verified by {Coq}},
+  booktitle = {International Conference on Theorem Proving in Higher Order Logics},
   pages     = {245--260},
   publisher = {Springer},
+  address = {Berlin, Heidelberg},
   year      = {2005},
-  url       = {https://doi.org/10.1007/11541868\_16},
+  url       = {https://arxiv.org/abs/cs/0505034},
   doi       = {10.1007/11541868\_16},
-  timestamp = {Tue, 14 May 2019 10:00:48 +0200},
-  biburl    = {https://dblp.org/rec/conf/tphol/OConnor05.bib},
-  bibsource = {dblp computer science bibliography, https://dblp.org}
 }
-
-
 
 @Misc{planetmath,
   title = 	 {Ackermann function is not primitive recursive},
-  howpublished = {https://planetmath.org/ackermannfunctionisnotprimitiverecursive}
+  howpublished = {https://planetmath.org/ackermannfunctionisnotprimitiverecursive},
+  year = {2013},
 }
 
 @inproceedings{alectryonpaper,
@@ -889,37 +856,14 @@ year = {2020},
 isbn = {9781450381765},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
-url = {https://doi.org/10.1145/3426425.3426940},
+url = {https://dl.acm.org/doi/pdf/10.1145/3426425.3426940},
 doi = {10.1145/3426425.3426940},
-abstract = {Proof assistants like Coq, Lean, or HOL4 rely heavily on stateful meta-programs called
-scripts to assemble proofs. Unlike pen-and-paper proofs, proof scripts only describe
-the steps to take (induct on x, apply a theorem, …), not the states that these steps
-lead to; as a result, plain proof scripts are essentially incomprehensible without
-the assistance of an interactive user interface able to run the script and show the
-corresponding proof states. Until now, the standard process to communicate a proof
-without forcing readers to execute its script was to manually copy-paste intermediate
-proof states into the script, as source code comments — a tedious and error-prone
-exercise. Additional prose (such as for a book or tutorial) was likewise embedded
-in comments, preserving executability at the cost of a mediocre text-editing experience.
-This paper describes a new approach to the development and dissemination of literate
-proof scripts, with a focus on the Coq proof assistant. Specifically, we describe
-two contributions: a compiler that interleaves Coq’s output with the original proof
-script to produce interactive webpages that are complete, self-contained presentations
-of Coq proofs; and a new literate programming toolkit that allows authors to switch
-seamlessly between prose- and code-oriented views of the same sources, by translating
-back and forth between reStructuredText documents and literate Coq source files. In
-combination, these tools offer a new way to write, communicate, and preserve proofs,
-combining the flexibility of procedural proof scripts and the intelligibility of declarative
-proofs.},
-booktitle = {Proceedings of the 13th ACM SIGPLAN International Conference on Software Language Engineering},
-pages = {155–174},
+booktitle = {International Conference on Software Language Engineering},
+pages = {155--174},
 numpages = {20},
-keywords = {literate programming, proof presentation, formal verification, proof browsing},
 location = {Virtual, USA},
-series = {SLE 2020}
 }
 
-  
 @Misc{alectryongithub,
   author = {Pit-Claudel, Cl\'{e}ment},
   title = 	 {Alectryon},

--- a/doc/thebib.bib
+++ b/doc/thebib.bib
@@ -5,17 +5,17 @@
  year = {2008},
  isbn = {978-3-540-71065-3},
  pages = {278--293},
- location = {Montreal, P.Q., Canada},
+ location = {Montreal, Canada},
  doi = {10.1007/978-3-540-71067-7_23},
  publisher = {Springer},
  address = {Berlin, Heidelberg},
- url = {https://sozeau.gitlabpages.inria.fr/www/research/publications/First-Class_Type_Classes.pdf},
+ note = {\url{https://sozeau.gitlabpages.inria.fr/www/research/publications/First-Class_Type_Classes.pdf}},
 }
 
 @Misc{PCMS,
  author = 	 {Pierre Cast{\'e}ran and Matthieu Sozeau},
  title = 	 {{A gentle Introduction to Type Classes and Relations in Coq}},
- howpublished = {http://www.labri.fr/perso/casteran/CoqArt/TypeClassesTut/typeclassestut.pdf},
+ howpublished = {\url{https://www.labri.fr/perso/casteran/CoqArt/TypeClassesTut/typeclassestut.pdf}},
 }
 
 @article{sozeau:hal-01671777,
@@ -27,7 +27,7 @@ publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
 volume = {3},
 number = {ICFP},
-url = {https://hal.inria.fr/hal-01671777},
+note = {\url{https://hal.inria.fr/hal-01671777}},
 doi = {10.1145/3341690},
 journal = {Proceedings of the ACM on Programming Languages},
 month = jul,
@@ -35,7 +35,7 @@ articleno = {86},
 numpages = {29},
 }
 
-@inbook{Bertot_theoremproving,
+@incollection{Bertot_theoremproving,
 author = {Yves Bertot},
 title = {Theorem proving support in programming language semantics},
 editor = {Yves Bertot and G{\'e}rard Huet and Jean-Jacques L{\'e}vy and Gordon Plotkin},
@@ -43,13 +43,14 @@ booktitle = {{From Semantics to Computer Science: Essays in Honour of Gilles Kah
 publisher = {Cambridge University Press},
 year = {2009},
 pages = {337--361},
-url = {http://hal.inria.fr/inria-00160309},
+note = {\url{http://hal.inria.fr/inria-00160309}},
 }
 
-@Misc{Coq,
-  author = 	 {{Coq Development Team}},
-  title = 	 {The Coq proof assistant},
-  howpublished = {https://coq.inria.fr}
+@misc{Coq,
+title={{The Coq Proof Assistant}},
+DOI={10.5281/zenodo.1003420},
+author={{The Coq Development Team}},
+howpublished = {\url{https://coq.inria.fr}},
 }
 
 @book{BC04,
@@ -60,7 +61,7 @@ url = {http://hal.inria.fr/inria-00160309},
   publisher = {Springer},
   address = {Berlin, Heidelberg},
   isbn = {978-3-662-07964-5},
-  url = {https://www.labri.fr/perso/casteran/CoqArt/},
+  note = {\url{https://www.labri.fr/perso/casteran/CoqArt/}},
 }
 
 @article{BS2011,
@@ -73,11 +74,11 @@ url = {http://hal.inria.fr/inria-00160309},
   author={Spitters, Bas and van der Weegen, Eelis},
   year={2011},
   pages={795--825},
-  url={https://arxiv.org/abs/1102.1323},
+  note={\url{https://arxiv.org/abs/1102.1323}},
 }
 
 @book{b-book,
- author = {Abrial, J.-R.},
+ author = {Abrial, Jean-Raymond},
  title = {The {B-book}: Assigning Programs to Meanings},
  year = {1996},
  isbn = {0-521-49619-5},
@@ -104,7 +105,7 @@ url = {http://hal.inria.fr/inria-00160309},
  location = {Victoria, BC, Canada},
  pages = {143--156},
  numpages = {14},
- url = {http://adam.chlipala.net/papers/PhoasICFP08/},
+ note = {\url{http://adam.chlipala.net/papers/PhoasICFP08/}},
  doi = {10.1145/1411204.1411226},
  publisher = {ACM},
  address = {New York, NY, USA},
@@ -116,7 +117,7 @@ url = {http://hal.inria.fr/inria-00160309},
   publisher = {MIT Press},
   year = 2011,
   isbn = {978-0-262-31786-3},
-  url = {http://adam.chlipala.net/cpdt/},
+  note = {\url{http://adam.chlipala.net/cpdt/}},
 }
 
 @InProceedings{Cohen2013,
@@ -129,7 +130,20 @@ address={Cham},
 pages={147--162},
 isbn={978-3-319-03545-1},
 doi={10.1007/978-3-319-03545-1_10},
-url={https://perso.crans.org/cohen/papers/refinements.pdf},
+note={\url{https://hal.inria.fr/hal-01113453}},
+}
+
+@inproceedings{cohen:hal-01113453,
+author={Cohen, Cyril and D{\'e}n{\`e}s, Maxime and M{\"o}rtberg, Anders},
+title={Refinements for Free!},
+booktitle={Certified Programs and Proofs},
+year={2013},
+publisher={Springer},
+address={Cham},
+pages={147--162},
+isbn={978-3-319-03545-1},
+doi={10.1007/978-3-319-03545-1_10},
+note={\url{https://hal.inria.fr/hal-01113453}},
 }
 
 @inproceedings{Wadler1989,
@@ -141,7 +155,7 @@ url={https://perso.crans.org/cohen/papers/refinements.pdf},
  location = {London, United Kingdom},
  pages = {347--359},
  numpages = {13},
- url = {https://homepages.inf.ed.ac.uk/wadler/papers/free/free.ps},
+ note = {\url{https://homepages.inf.ed.ac.uk/wadler/papers/free/free.ps}},
  doi = {10.1145/99370.99404},
  publisher = {ACM},
  address = {New York, NY, USA},
@@ -157,7 +171,7 @@ url={https://perso.crans.org/cohen/papers/refinements.pdf},
   number = {5},
   year = {1995},
   doi = {10.1051/ita/1995290504311},
-  url = {http://www.numdam.org/item/ITA_1995__29_5_431_0.pdf},
+  note = {\url{http://www.numdam.org/item/ITA_1995__29_5_431_0.pdf}},
 }
 
 @article{brauer1939,
@@ -169,7 +183,7 @@ pages = "736--739",
 publisher = "American Mathematical Society",
 title = "On addition chains",
 doi = "10.1090/S0002-9904-1939-07068-7",
-url = "https://www.ams.org/journals/bull/1939-45-10/S0002-9904-1939-07068-7/S0002-9904-1939-07068-7.pdf",
+note = "\url{https://www.ams.org/journals/bull/1939-45-10/S0002-9904-1939-07068-7/S0002-9904-1939-07068-7.pdf}",
 volume = "45",
 year = "1939"
 }
@@ -184,14 +198,14 @@ publisher="Springer",
 address="Berlin, Heidelberg",
 pages="379--393",
 isbn="978-3-540-46499-0",
-url="https://link.springer.com/content/pdf/10.1007%2F3540539816_77.pdf",
+note="\url{https://link.springer.com/content/pdf/10.1007%2F3540539816_77.pdf}",
 }
 
 @Misc{CantorContribSlide,
  author = 	 {Pierre Cast{\'e}ran and \'Evelyne Cont{\'e}jean},
   title = 	 {On Ordinal Notations},
   howpublished = {User Contributions to the Coq Proof Assistant},
-   year= {2006}
+  year= {2006}
 }
 
 @Misc{CantorContrib,
@@ -205,7 +219,7 @@ url="https://link.springer.com/content/pdf/10.1007%2F3540539816_77.pdf",
  author = 	 {Pierre Cast\'eran},
   title = 	 {Additions},
   howpublished = {User Contributions to the Coq Proof Assistant},
-  note = {https://github.com/coq-contribs/additions},
+  note = {\url{https://github.com/coq-contribs/additions}},
 }
 
 @article{DBLP:journals/ipl/BerstelB87,
@@ -217,7 +231,7 @@ pages = {23--28},
 year = {1987},
 issn = {0020-0190},
 doi = {10.1016/0020-0190(87)90031-7},
-url = {http://www-igm.univ-mlv.fr/~berstel/Articles/1987WordChains.pdf},
+note = {\url{http://www-igm.univ-mlv.fr/~berstel/Articles/1987WordChains.pdf}},
 author = {Berstel, Jean and Brlek, Sre{\'{c}}ko},
 }
 
@@ -259,7 +273,7 @@ updated = "9 May 2001"}
  issn = {1388-3690},
  pages = {11--49},
  numpages = {39},
- url = {https://www.cs.cmu.edu/~crary/819-f09/Strachey67.pdf},
+ note = {\url{https://www.cs.cmu.edu/~crary/819-f09/Strachey67.pdf}},
  doi = {10.1023/A:1010000313106},
  publisher = {Kluwer Academic Publishers},
  address = {Hingham, MA, USA},
@@ -268,18 +282,19 @@ updated = "9 May 2001"}
 @Misc{DanBrown-survey,
   author = 	 {Daniel Brown},
   title = 	 {Parametricity},
-  howpublished = {https://web.archive.org/web/20190628092255/http://www.ccs.neu.edu/home/matthias/369-s10/Transcript/parametricity.pdf},
+  howpublished = {\url{https://web.archive.org/web/20190628092255/http://www.ccs.neu.edu/home/matthias/369-s10/Transcript/parametricity.pdf}},
   year = 	 {2010},
   note = 	 {Transcript of a lecture by Matthias Felleisen},
 }
 
-@book{Tel:1994:IDA:203042,
- author = {Tel, Gerard},
- title = {Introduction to Distributed Algorithms},
- year = {1994},
- isbn = {0-521-47096-2},
- publisher = {Cambridge University Press},
- address = {New York, NY, USA},
+@book{tel_2000,
+ address={Cambridge, United Kingdom},
+ edition={second},
+ title={Introduction to Distributed Algorithms},
+ DOI={10.1017/CBO9781139168724},
+ publisher={Cambridge University Press},
+ author={Tel, Gerard},
+ year={2000}
 }
 
 @book{HommageJPJ,
@@ -290,10 +305,10 @@ updated = "9 May 2001"}
  publisher="Springer",
  address="Berlin, Heidelberg",
  isbn="978-3-540-73146-7",
- url="https://www.springer.com/gp/book/9783540731467",
+ note="\url{https://link.springer.com/book/10.1007%2F978-3-540-73147-4}",
 }
 
-@Inbook{Dershowitz2007,
+@incollection{Dershowitz2007,
 author="Dershowitz, Nachum and Moser, Georg",
 title="The Hydra Battle Revisited",
 bookTitle="Rewriting, Computation and Proof: Essays Dedicated to {Jean-Pierre Jouannaud} on the Occasion of His 60th Birthday",
@@ -303,7 +318,7 @@ address="Berlin, Heidelberg",
 pages="1--27",
 isbn="978-3-540-73147-4",
 doi="10.1007/978-3-540-73147-4_1",
-url="https://www.cs.tau.ac.il/~nachum/papers/LNCS/Hydra.pdf",
+note="\url{https://www.cs.tau.ac.il/~nachum/papers/LNCS/Hydra.pdf}",
 \crossref={HommageJPJ},
 }
 
@@ -315,13 +330,13 @@ volume = {14},
 number = {4},
 pages = {285--293},
 doi = {10.1112/blms/14.4.285},
-url = {https://faculty.baruch.cuny.edu/lkirby/accessible_independence_results.pdf},
+note = {\url{https://faculty.baruch.cuny.edu/lkirby/accessible_independence_results.pdf}},
 year = {1982},
 }
 
 @article{KS81,
  ISSN = {0003486X},
- URL = {http://www.jstor.org/stable/2006985},
+ note = {\url{http://www.jstor.org/stable/2006985}},
  author = {Jussi Ketonen and Robert Solovay},
  journal = {Annals of Mathematics},
  number = {2},
@@ -333,7 +348,7 @@ year = {1982},
  doi = {10.2307/2006985},
 }
 
-@Inbook{Promel2013,
+@incollection{Promel2013,
 author="Pr{\"o}mel, Hans J{\"u}rgen",
 title="Rapidly Growing Ramsey Functions",
 bookTitle="Ramsey Theory for Discrete Structures",
@@ -343,7 +358,7 @@ address="Cham",
 pages="97--103",
 isbn="978-3-319-01315-2",
 doi="10.1007/978-3-319-01315-2_8",
-url="https://link.springer.com/chapter/10.1007/978-3-319-01315-2_8"
+note="\url{https://link.springer.com/chapter/10.1007/978-3-319-01315-2_8}"
 }
 
 @article{fourcolors,
@@ -354,7 +369,7 @@ url="https://link.springer.com/chapter/10.1007/978-3-319-01315-2_8"
   year = {2008},
   volume = {55},
   number = {11},
-  url = {http://www.ams.org/notices/200811/tx081101382p.pdf},
+  note = {\url{http://www.ams.org/notices/200811/tx081101382p.pdf}},
 }
 
 @article{flyspeck2015,
@@ -386,14 +401,20 @@ url="https://link.springer.com/chapter/10.1007/978-3-319-01315-2_8"
             Ky Vu and
             Roland Zumkeller},
   year={2017},
-  url={https://arxiv.org/abs/1501.02155},
+  note={\url{https://arxiv.org/abs/1501.02155}},
 }
 
 @Misc{bauer2008,
  author = 	 {Andrej Bauer},
   title = 	 {The Hydra Game},
-  howpublished = {https://github.com/andrejbauer/hydra},
+  howpublished = {\url{https://github.com/andrejbauer/hydra}},
  year = 	 {2008}
+}
+
+@Misc{BauerHydra,
+  author = 	 {Andrej Bauer},
+  title = 	 {The Hydra Game},
+  howpublished = {\url{http://math.andrej.com/2008/02/02/the-hydra-game}}
 }
 
 @TechReport{CG88,
@@ -401,7 +422,7 @@ url="https://link.springer.com/chapter/10.1007/978-3-319-01315-2_8"
   title = 	 {A Tutorial on [Co-]Inductive Types in {Coq}},
   institution =  {INRIA},
   year = 	 {1998},
-  url =          {https://hal.inria.fr/hal-00344325},
+  note =         {\url{https://hal.inria.fr/hal-00344325}},
 }
 
 @article{Paulson84constructingrecursion,
@@ -413,23 +434,14 @@ pages = {325--355},
 year = {1986},
 issn = {0747-7171},
 doi = {10.1016/S0747-7171(86)80002-5},
-url = {https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-57.pdf},
+note = {\url{https://www.sciencedirect.com/science/article/pii/S0747717186800025/pdf}},
 author = {Lawrence C. Paulson},
-}
-
-@ARTICLE{Paulson84constructingrecursion,
-    author = {Lawrence C Paulson},
-    title = {Constructing Recursion Operators in Intuitionistic Type Theory},
-    journal = {Journal of Symbolic Computation},
-    year = {1984},
-    volume = {2},
-    pages = {325--355}
 }
 
 @Misc{SF,
   author = 	 {Benjamin Pierce and others},
   title = 	 {Software Foundations},
-  howpublished = {https://softwarefoundations.cis.upenn.edu}
+  howpublished = {\url{https://softwarefoundations.cis.upenn.edu}}
 }
 
 @article{CF2011,
@@ -440,7 +452,7 @@ author = {Lawrence C. Paulson},
   number    = {1},
   pages     = {39--86},
   year      = {2011},
-  url       = {https://hal.archives-ouvertes.fr/hal-00596712},
+  note       = {\url{https://hal.archives-ouvertes.fr/hal-00596712}},
 }
 
 @InProceedings{ABC13,
@@ -453,7 +465,7 @@ address="Cham",
 pages="178--190",
 isbn="978-3-319-03089-0",
 doi="10.1007/978-3-319-03089-0_13",
-url="https://arxiv.org/abs/1306.4242",
+note="\url{https://arxiv.org/abs/1306.4242}",
 }
 
 @article{DBLP:journals/ipl/CourtieuRTU15,
@@ -465,14 +477,14 @@ pages = {447--452},
 year = {2015},
 issn = {0020-0190},
 doi = {10.1016/j.ipl.2014.11.001},
-url = {https://arxiv.org/abs/1405.5902},
+note = {\url{https://arxiv.org/abs/1405.5902}},
 author = {Pierre Courtieu and Lionel Rieg and S{\'{e}}bastien Tixeuil and Xavier Urbain},
 }
 
 @article{DBLP:journals/corr/RamosQMA15,
  title={Formalization of the pumping lemma for context-free languages},
  volume={9},
- url={https://jfr.unibo.it/article/view/5595},
+ note={\url{https://jfr.unibo.it/article/view/5595}},
  DOI={10.6092/issn.1972-5787/5595},
  number={2},
  journal={Journal of Formalized Reasoning},
@@ -495,13 +507,13 @@ pages="387--423",
 abstract="Termination proofs are of critical importance for establishing the correct behavior of both transformational and reactive computing systems. A general setting for establishing termination proofs involves the use of the ordinal numbers, an extension of the natural numbers into the transfinite that were introduced by Cantor in the nineteenth century and are at the core of modern set theory. We present the first comprehensive treatment of ordinal arithmetic on compact ordinal notations and give efficient algorithms for various operations, including addition, subtraction, multiplication, and exponentiation. Using the ACL2 theorem proving system, we implemented our ordinal arithmetic algorithms, mechanically verified their correctness, and developed a library of theorems that can be used to significantly automate reasoning involving the ordinals. To enable users of the ACL2 system to fully utilize our work required that we modify ACL2, e.g., we replaced the underlying representation of the ordinals and added a large library of definitions and theorems. Our modifications are available starting with ACL2 version 2.8.",
 issn="1573-0670",
 doi="10.1007/s10817-005-9023-9",
-url="http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf",
+note="\url{http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf}",
 }
 
 @techreport{grimm:hal-00911710,
   TITLE = {Implementation of three types of ordinals in {Coq}},
   AUTHOR = {Grimm, Jos{\'e}},
-  URL = {https://hal.inria.fr/hal-00911710},
+  note = {\url{https://hal.inria.fr/hal-00911710}},
   TYPE = {Research Report},
   NUMBER = {RR-8407},
   PAGES = {74},
@@ -515,13 +527,7 @@ url="http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf",
   booktitle = {Actes des Journ{\'e}es Francophones des Langages Applicatifs},
   year = 	 {2007},
   pages = {30--44},
-  url = {http://jfla.inria.fr/2007/actes/PDF/03_casteran.pdf},
-}
-
-@Misc{BauerHydra,
-  author = 	 {Andrej Bauer},
-  title = 	 {The Hydra Game},
-  howpublished = {http://math.andrej.com/2008/02/02/the-hydra-game}
+  note = {\url{http://jfla.inria.fr/2007/actes/PDF/03_casteran.pdf}},
 }
 
 @Book{schutte,
@@ -531,7 +537,7 @@ url="http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf",
  publisher = {Springer},
  year = {1977},
  doi = {10.1007/978-3-642-66473-1},
- url = {https://www.springer.com/gp/book/9783642664755},
+ note = {\url{https://link.springer.com/book/10.1007%2F978-3-642-66473-1}},
 }
 
 @Misc{Sladek07thetermite,
@@ -539,6 +545,13 @@ url="http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf",
  title = {The {T}ermite and the {T}ower: {Goodstein} sequences and provability in {PA}},
  howpublished={\url{https://www.uio.no/studier/emner/matnat/ifi/INF5170/v08/undervisningsmateriale/sladekgoodstein.pdf}},
  year = {2007}
+}
+
+@Misc{Sladek07,
+  author = 	{Will Sladek},
+  title = 	 {The {T}ermite and the {T}ower: {Goodstein} sequences and provability in {PA}},
+  howpublished = {\url{https://www.uio.no/studier/emner/matnat/ifi/INF5170/v08/undervisningsmateriale/sladekgoodstein.pdf}},
+  year = 	 {2007}
 }
 
 @article{goodstein_1944,
@@ -551,14 +564,7 @@ url="http://www.ccs.neu.edu/home/pete/pub/ordinal-arithmetic-algs-mech.pdf",
  author={Goodstein, R. L.},
  year={1944},
  pages={33--41},
- url={https://www.jstor.org/stable/2268019},
-}
-
-@Misc{Sladek07,
-  author = 	{Will Sladek},
-  title = 	 {The {T}ermite and the {T}ower: {Goodstein} sequences and provability in {PA}},
-  howpublished = {\url{https://www.uio.no/studier/emner/matnat/ifi/INF5170/v08/undervisningsmateriale/sladekgoodstein.pdf}},
-  year = 	 {2007}
+ note={\url{https://www.jstor.org/stable/2268019}},
 }
 
 @article{DBLP:journals/corr/Schmitz13,
@@ -571,7 +577,7 @@ address = {New York, NY, USA},
 volume = {8},
 number = {1},
 issn = {1942-3454},
-url = {https://arxiv.org/abs/1312.5686},
+note = {\url{https://arxiv.org/abs/1312.5686}},
 doi = {10.1145/2858784},
 journal = {ACM Transactions on Computation Theory},
 month = feb,
@@ -588,7 +594,7 @@ address="Berlin, Heidelberg",
 doi="10.1007/978-3-642-39634-2_12",
 pages="133--146",
 isbn="978-3-642-39634-2",
-url="https://ts.data61.csiro.au/publications/nicta_full_text/6676.pdf",
+note="\url{https://ts.data61.csiro.au/publications/nicta_full_text/6676.pdf}",
 }
 
 @Manual{Jessie,
@@ -604,12 +610,6 @@ url="https://ts.data61.csiro.au/publications/nicta_full_text/6676.pdf",
   howpublished = {\url{https://compcert.org}}
 }
 
-@Misc{SSR,
- author = 	 {Assia Mahboubi and Enrico Tassi},
-  title = 	 {Mathematical Components},
-  howpublished = {\url{https://math-comp.github.io/mcb/}}
-}
-
 @Book{cantorbook,
   author = 	 {Georg Cantor},
   title = 	 {Contributions to the Founding of the Theory of Transfinite Numbers},
@@ -617,7 +617,7 @@ url="https://ts.data61.csiro.au/publications/nicta_full_text/6676.pdf",
   year = 	 {1955}
 }
 
-@InProceedings{feit,
+@inproceedings{oddorderthm,
 author="Gonthier, Georges
 and Asperti, Andrea
 and Avigad, Jeremy
@@ -640,25 +640,28 @@ publisher="Springer",
 address="Berlin, Heidelberg",
 pages="163--179",
 doi="10.1007/978-3-642-39634-2_14",
-url="https://hal.inria.fr/hal-00816699",
-abstract="This paper reports on a six-year collaborative effort that culminated in a complete formalization of a proof of the Feit-Thompson Odd Order Theorem in the Coq proof assistant. The formalized proof is constructive, and relies on nothing but the axioms and rules of the foundational framework implemented by Coq. To support the formalization, we developed a comprehensive set of reusable libraries of formalized mathematics, including results in finite group theory, linear algebra, Galois theory, and the theories of the real and complex algebraic numbers.",
+note="\url{https://hal.inria.fr/hal-00816699}",
 isbn="978-3-642-39634-2"
 }
-
-@book{tel_2000, place={Cambridge}, edition={2}, title={Introduction to Distributed Algorithms}, DOI={10.1017/CBO9781139168724}, publisher={Cambridge University Press}, author={Tel, Gerard}, year={2000}}
 
 @Misc{MCB,
   author = 	 {Assia Mahboubi, Enrico Tassi},
   title = 	 {Mathematical Components},
-  note = {with contributions by Yves Bertot and Georges Gonthier},
-  howpublished = {https://math-comp.github.io/mcb/book.pdf},
+  note = {With contributions by Yves Bertot and Georges Gonthier},
+  howpublished = {\url{https://math-comp.github.io/mcb/book.pdf}},
   year = 	 {2018}
+}
+
+@Misc{SSR,
+ author = 	 {Assia Mahboubi and Enrico Tassi},
+  title = 	 {Mathematical Components},
+  howpublished = {\url{https://math-comp.github.io/mcb/}}
 }
 
 @inproceedings{kosmatov:hal-01344110,
   TITLE = {{Static versus Dynamic Verification in Why3, Frama-C and SPARK 2014}},
   AUTHOR = {Kosmatov, Nikolai and March{\'e}, Claude and Moy, Yannick and Signoles, Julien},
-  URL = {https://hal.inria.fr/hal-01344110},
+  note = {\url{https://hal.inria.fr/hal-01344110}},
   doi = {10.1007/978-3-319-47166-2_32},
   BOOKTITLE = {Leveraging Applications of Formal Methods, Verification and Validation: Foundational Techniques},
   PUBLISHER = {Springer},
@@ -672,7 +675,7 @@ isbn="978-3-642-39634-2"
 @article{bobot:hal-00967132,
   TITLE = {{Let's Verify This with Why3}},
   AUTHOR = {Bobot, Fran{\c c}ois and Filli{\^a}tre, Jean-Christophe and March{\'e}, Claude and Paskevich, Andrei},
-  URL = {https://hal.inria.fr/hal-00967132},
+  note = {\url{https://hal.inria.fr/hal-00967132}},
   JOURNAL = {Software Tools for Technology Transfer},
   PUBLISHER = {Springer},
   VOLUME = {17},
@@ -690,7 +693,7 @@ isbn="978-3-642-39634-2"
   volume = 	 {6},
   pages = 	 {233--247},
   doi = {10.1007/BF01019459},
-  url = {https://link.springer.com/content/pdf/10.1007/BF01019459.pdf},
+  note = {\url{https://link.springer.com/content/pdf/10.1007/BF01019459.pdf}},
 }
 
 @Book{burge,
@@ -699,19 +702,6 @@ title = {Recursive programming techniques},
 isbn = {0201144506},
 publisher = {Addison-Wesley},
 year = {1975},
-}
-
-@inproceedings{cohen:hal-01113453,
-  TITLE = {{Refinements for Free!}},
-  AUTHOR = {Cohen, Cyril and D{\'e}n{\`e}s, Maxime and M{\"o}rtberg, Anders},
-  URL = {https://hal.inria.fr/hal-01113453},
-  BOOKTITLE = {Certified Programs and Proofs},
-  ADDRESS = {Melbourne, Australia},
-  PAGES = {147 - 162},
-  YEAR = {2013},
-  MONTH = Dec,
-  DOI = {10.1007/978-3-319-03545-1\_10},
-  KEYWORDS = {Parametricity ; Efficient algorithms and data structures ; Formal proofs ; Data refinements ; Coq},
 }
 
 @incollection{BW85,
@@ -723,7 +713,7 @@ year = {1975},
  title = {Provably computable functions and the fast growing hierarchy},
  author = {Stan Wainer and Wilfried Buchholz},
  editor = {Stephen G. Simpson},
- url = {http://nbn-resolving.de/urn/resolver.pl?urn=nbn:de:bvb:19-epub-3843-7}
+ note = {\url{http://nbn-resolving.de/urn/resolver.pl?urn=nbn:de:bvb:19-epub-3843-7}}
 }
 
 @Article{Wainer1970,
@@ -738,17 +728,7 @@ number="3",
 pages="136--153",
 issn="1432-0665",
 doi="10.1007/BF01973619",
-url="https://link.springer.com/article/10.1007%2FBF01973619"
-}
-
-@inproceedings{oddorderthm,
-author = {Gonthier, Georges and Asperti, Andrea and Avigad, Jeremy and Bertot, Yves and Cohen, Cyril and Garillot, François and Roux, Stéphane and Mahboubi, Assia and O'Connor, Russell and Biha, Sidi and Pasca, Ioana and Rideau, Laurence and Solovyev, Alexey and Tassi, Enrico and Théry, Laurent},
-year = {2013},
-month = {07},
-pages = {163-179},
-title = {A Machine-Checked Proof of the Odd Order Theorem},
-booktitle = {Proceedings of {ITP} 2013},
-doi = {10.1007/978-3-642-39634-2_14}
+note="\url{https://link.springer.com/article/10.1007%2FBF01973619}"
 }
 
 @article{zipper,
@@ -761,7 +741,7 @@ address = {USA},
 volume = {7},
 number = {5},
 issn = {0956-7968},
-url = {https://www.academia.edu/download/66730493/The_Zipper20210430-816-ieqbwj.pdf},
+note = {\url{https://www.cambridge.org/core/journals/journal-of-functional-programming/article/zipper/0C058890B8A9B588F26E6D68CF0CE204}},
 doi = {10.1017/S0956796897002864},
 abstract = {Almost every programmer has faced the problem of representing a tree together with a subtree that is the focus of attention, where that focus may move left, right, up or down the tree. The Zipper is Huet's nifty name for a nifty data structure which fulfills this need. I wish I had known of it when I faced this task, because the solution I came up with was not quite so efficient or elegant as the Zipper.},
 journal = {Journal of Functional Programming},
@@ -777,7 +757,7 @@ year = {2010},
 isbn = {9781605587271},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
-url = {https://hal.inria.fr/inria-00535655},
+note = {\url{https://hal.inria.fr/inria-00535655}},
 doi = {10.1145/1706356.1706370},
 booktitle = {Workshop on Partial Evaluation and Program Manipulation},
 pages = {63--72},
@@ -794,7 +774,7 @@ pages = "279--301",
 year = "1982",
 issn = "0304-3975",
 doi = "10.1016/0304-3975(82)90026-3",
-url = "https://www.sciencedirect.com/science/article/pii/0304397582900263/pdf",
+note = "\url{https://www.sciencedirect.com/science/article/pii/0304397582900263/pdf}",
 author = "Nachum Dershowitz",
 }
 
@@ -807,7 +787,7 @@ author = "Nachum Dershowitz",
   number    = {3},
   pages     = {199--260},
   year      = {1991},
-  url       = {https://www.sciencedirect.com/science/article/pii/016800729190022E/pdf},
+  note       = {\url{https://www.sciencedirect.com/science/article/pii/016800729190022E/pdf}},
   doi       = {10.1016/0168-0072(91)90022-E},
 }
 
@@ -816,7 +796,7 @@ author = "Nachum Dershowitz",
   author={Nipkow, Tobias and Paulson, Lawrence C. and Wenzel, Markus},
   isbn={9783540433767},
   lccn={02020906},
-  url={https://link.springer.com/book/10.1007%2F3-540-45949-9},
+  note={\url{https://link.springer.com/book/10.1007%2F3-540-45949-9}},
   doi={10.1007/3-540-45949-9},
   year={2002},
   publisher={Springer},
@@ -828,7 +808,7 @@ author = "Nachum Dershowitz",
   TITLE = {Introduction to {HOL}: A theorem proving environment for higher order logic},
   PUBLISHER = {Cambridge University Press},
   YEAR = {1993},
-  URL = {http://www.cs.ox.ac.uk/tom.melham/pub/Gordon-1993-ITH.html},
+  note = {\url{http://www.cs.ox.ac.uk/tom.melham/pub/Gordon-1993-ITH.html}},
 }
 
 @inproceedings{OConnor05, 
@@ -839,13 +819,13 @@ author = "Nachum Dershowitz",
   publisher = {Springer},
   address = {Berlin, Heidelberg},
   year      = {2005},
-  url       = {https://arxiv.org/abs/cs/0505034},
+  note       = {\url{https://arxiv.org/abs/cs/0505034}},
   doi       = {10.1007/11541868\_16},
 }
 
 @Misc{planetmath,
   title = 	 {Ackermann function is not primitive recursive},
-  howpublished = {https://planetmath.org/ackermannfunctionisnotprimitiverecursive},
+  howpublished = {\url{https://planetmath.org/ackermannfunctionisnotprimitiverecursive}},
   year = {2013},
 }
 
@@ -856,7 +836,7 @@ year = {2020},
 isbn = {9781450381765},
 publisher = {Association for Computing Machinery},
 address = {New York, NY, USA},
-url = {https://dl.acm.org/doi/pdf/10.1145/3426425.3426940},
+note = {\url{https://dl.acm.org/doi/pdf/10.1145/3426425.3426940}},
 doi = {10.1145/3426425.3426940},
 booktitle = {International Conference on Software Language Engineering},
 pages = {155--174},
@@ -867,5 +847,5 @@ location = {Virtual, USA},
 @Misc{alectryongithub,
   author = {Pit-Claudel, Cl\'{e}ment},
   title = 	 {Alectryon},
-  howpublished = {https://github.com/cpitclaudel/alectryon}
+  howpublished = {\url{https://github.com/cpitclaudel/alectryon}}
 }

--- a/doc/thebib.bib
+++ b/doc/thebib.bib
@@ -694,6 +694,7 @@ year = {1975},
  title = {Provably computable functions and the fast growing hierarchy},
  author = {Stan Wainer and Wilfried Buchholz},
  editor = {Stephen G. Simpson},
+ publisher = {American Mathematical Society},
  note = {\url{http://nbn-resolving.de/urn/resolver.pl?urn=nbn:de:bvb:19-epub-3843-7}}
 }
 
@@ -805,6 +806,7 @@ author = "Nachum Dershowitz",
 }
 
 @Misc{planetmath,
+  author = {{PlanetMath}},
   title = 	 {Ackermann function is not primitive recursive},
   howpublished = {\url{https://planetmath.org/ackermannfunctionisnotprimitiverecursive}},
   year = {2013},

--- a/doc/thebib.bib
+++ b/doc/thebib.bib
@@ -133,19 +133,6 @@ doi={10.1007/978-3-319-03545-1_10},
 note={\url{https://hal.inria.fr/hal-01113453}},
 }
 
-@inproceedings{cohen:hal-01113453,
-author={Cohen, Cyril and D{\'e}n{\`e}s, Maxime and M{\"o}rtberg, Anders},
-title={Refinements for Free!},
-booktitle={Certified Programs and Proofs},
-year={2013},
-publisher={Springer},
-address={Cham},
-pages={147--162},
-isbn={978-3-319-03545-1},
-doi={10.1007/978-3-319-03545-1_10},
-note={\url{https://hal.inria.fr/hal-01113453}},
-}
-
 @inproceedings{Wadler1989,
  author = {Wadler, Philip},
  title = {Theorems for Free!},
@@ -645,17 +632,11 @@ isbn="978-3-642-39634-2"
 }
 
 @Misc{MCB,
-  author = 	 {Assia Mahboubi, Enrico Tassi},
-  title = 	 {Mathematical Components},
+  author = 	 {Assia Mahboubi and Enrico Tassi},
+  title = 	 {{Mathematical Components}},
   note = {With contributions by Yves Bertot and Georges Gonthier},
-  howpublished = {\url{https://math-comp.github.io/mcb/book.pdf}},
+  howpublished = {\url{https://doi.org/10.5281/zenodo.3999478}},
   year = 	 {2018}
-}
-
-@Misc{SSR,
- author = 	 {Assia Mahboubi and Enrico Tassi},
-  title = 	 {Mathematical Components},
-  howpublished = {\url{https://math-comp.github.io/mcb/}}
 }
 
 @inproceedings{kosmatov:hal-01344110,


### PR DESCRIPTION
While reading the PDF, I noticed that many (perhaps most) of the references did not contain links to open access versions of the papers, even when these are available. Quite a few of the links were also dead. Here is a complete refactoring of the bibliography where I provide open access links for most papers and fix dead links. I tried to use archives like arXiv and HAL when I could, and otherwise author websites. Finally, I deleted some duplicate bibliography entries.