### PR TITLE
suppress deprecation warnings that are unfixable in 8.13

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,8 @@
 
 -arg -w -arg -notation-overridden
 -arg -w -arg -ambiguous-paths
+-arg -w -arg -deprecated-instance-without-locality
+-arg -w -arg -deprecated-hint-rewrite-without-locality
 
 theories/ordinals/OrdinalNotations/ON_Omega.v
 theories/ordinals/OrdinalNotations/ON_Generic.v

--- a/theories/additions/dune
+++ b/theories/additions/dune
@@ -2,4 +2,4 @@
  (name additions)
  (package coq-addition-chains)
  (synopsis "Exponentiation algorithms following addition chains")
- (flags -w -notation-overridden -w -ambiguous-paths))
+ (flags -w -notation-overridden -w -ambiguous-paths -w -deprecated-instance-without-locality))

--- a/theories/ordinals/dune
+++ b/theories/ordinals/dune
@@ -1,6 +1,7 @@
 (coq.theory
  (name hydras)
  (package coq-hydra-battles)
- (synopsis "Exploration of some properties of Kirby and Paris' hydra battles, with the help of Coq"))
+ (synopsis "Exploration of some properties of Kirby and Paris' hydra battles, with the help of Coq")
+ (flags -w -deprecated-instance-without-locality -w -deprecated-hint-rewrite-without-locality))
 
 (include_subdirs qualified)


### PR DESCRIPTION
I noticed in the CI runs for #51 that Coq `master` currently gives a lot of deprecation warnings for the project, specifically, `instance-without-locality` and `hint-rewrite-without-locality`. These warnings are unavoidable in 8.13, i.e., compatibility with 8.13 has to dropped for the warnings to be fixed. Hence, this PR suppresses the warnings during both coq_makefile and Dune builds for now.