### PR TITLE
Fix typos and small issues in powers part

### DIFF
--- a/doc/chapter-powers.tex
+++ b/doc/chapter-powers.tex
@@ -329,7 +329,7 @@ Compute fib 20.
 = 10946 : N
 \end{Coqanswer}
 
-In~\cite{BC04}, several exercices~\footnote{Exercises 9.8 (page 270), 9.10 (page 271), 9.15 (page 276), 9.17 (page 284), and 15.8 (page 418).}  
+In~\cite{BC04}, several exercises~\footnote{Exercises 9.8 (page 270), 9.10 (page 271), 9.15 (page 276), 9.17 (page 284), and 15.8 (page 418).}
 present ways to compute Fibonacci numbers, with the less number of recursive calls  as possible. Please note that these optimizations and the formal proof of their correctness are \emph{ad-hoc}, \emph{i.e.} exclusively written for the 
 Fibonacci numbers.
 In contrast, the optimizations we present in this document apply, in their vast majority, \emph{generic} techniques of efficient computation of powers in a monoid. 
@@ -472,7 +472,7 @@ Lemma fib_mul2_OK n : fib n = fib_mul2 n.
 \end{Coqsrc}
 
 Thus, any function able to compute more or less efficiently powers in a monoid will
-give an algorithm for computing Fibonacci numbers. Unlike the \emph{ad-hoc} aforementionned proofs of~\cite{BC04}, the correctness of such an algorithm is a direct consequence 
+give an algorithm for computing Fibonacci numbers. Unlike the \emph{ad-hoc} aforementioned proofs of~\cite{BC04}, the correctness of such an algorithm is a direct consequence
 of the correctness of the used powering function.
 Several examples will be presented in the rest of this document
 (in sections~\vref{sect:fibonacci-pos-bpow}).
@@ -1698,7 +1698,7 @@ Let  \texttt{A} be some type;  a \emph{computation} on \texttt{A} is
 \end{itemize}
   
   In the following inductive type definition, the intended meaning 
-  of the contruct (\texttt{Mult $x$ $y$ $k$})  is \emph{``multiply \texttt{x} with 
+  of the construct (\texttt{Mult $x$ $y$ $k$})  is \emph{``multiply \texttt{x} with
 \texttt{y}, then send  the result of this multiplication to 
   the continuation  \texttt{k}''}.
 
@@ -1717,7 +1717,7 @@ Inductive computation {A:Type}  : Type :=
 
 The following \emph{monadic} 
 notation makes terms of type \texttt{computation} look like
-expressions of a small programming language dedicated to sequences of mutiplications.
+expressions of a small programming language dedicated to sequences of multiplications.
 Please look at \emph{CPDT}~\cite{chlipalacpdt2011} for more details on monadic notations in \coq.
 \label{monadic-mult}
 
@@ -2095,7 +2095,7 @@ The rest of this chapter is devoted to the  presentation of more efficient
 Instead of letting the tactic \texttt{rewrite} look for contexts in which
 setoid rewriting is possible, we propose to use (deterministic) computations for
 obtaining a ``canonical'' form for terms generated from a variable \texttt{x}
-by contructors associated with monoid multiplication and neutral element.
+by constructors associated with monoid multiplication and neutral element.
 
 The reader will find general explanations about proofs by reflection in \coq{},
 for instance in Chapter 16 of Coq'Art\cite{BC04} and the numerous examples (including the \texttt{ring} tactic) 
@@ -2395,7 +2395,7 @@ are related \emph{w.r.t.} \texttt{R}.
 
 
 \subsubsection{Definition}
-A chain $c$ is \emph{parametric} if it has the same behaviour for any
+A chain $c$ is \emph{parametric} if it has the same behavior for any
 pair of types $A$  and $B$, any relation $R$
 between  $A$ and $B$ and any $R$-related pair of 
 arguments $a$ and $b$:
@@ -3481,7 +3481,7 @@ Let F23 := Fplus F3 (Fplus (Fexp2 4) (Fexp2 2)).
 \end{Coqbad}
 
 Unfortunately, our construct is still very inefficient, since it results in 
-duplications of computations, as shown by the normal form of \texttt{F23}.
+duplication of computations, as shown by the normal form of \texttt{F23}.
 
 \begin{Coqbad}
 Compute F23
@@ -3668,7 +3668,7 @@ Qed.
 \subsection{Systematic construction of  correct f-chains and k-chains}
 
 We are now ready to define various operators on f- and k-chains, and prove these
-operators preserve correcness and properness. We will also show that 
+operators preserve correctness and properness. We will also show that
 these operators allow to generate easily correct chains for any positive 
 exponent. They will be used to generate chains for
 numbers of the form $n=bq+r$ where $0\leq r < b$, assuming the previous
@@ -3991,7 +3991,7 @@ f-chains, associated with a single exponent, and k-chains, associated with two e
 
 Since our construction is based on Euclidean division, we could not
 define our chain generator by structural recursion. 
-For simplicity's sake, we chosed to avoid dependent elimination
+For simplicity's sake, we chose to avoid dependent elimination
  and used \texttt{Function}  with a decreasing measure.
 
  For this purpose, we define a single data-type for associated with
@@ -4000,7 +4000,7 @@ For simplicity's sake, we chosed to avoid dependent elimination
 
 We had two slight technical problems to consider:
 \begin{itemize}
-\item The generation of a k-chain for $n$ and $p$ is meaningfull only if $p < n$. Thus, in order to avoid a clumsy  dependent pattern-matching, we chosed to represent 
+\item The generation of a k-chain for $n$ and $p$ is meaningful only if $p < n$. Thus, in order to avoid a clumsy  dependent pattern-matching, we chose to represent
      a pair $(n,p)$ where $0<p<n$ by a pair of positive numbers $(p,d)$ where 
      $d=n-p$
 \item In order to avoid to deal explicitly with mutual recursion, we
@@ -4081,7 +4081,7 @@ Definition  OK (s: signature)
 
 \end{Coqsrc}
 
-\subsection{Generation of chains using Euclidean Dibision}
+\subsection{Generation of chains using Euclidean Division}
 
 Assume we want to build automatically a correct  f-chain for some 
 positive integer $n$.
@@ -4466,7 +4466,7 @@ greater than or equal to $\floor{\log_2{n}}$.
 of positive integers $n$, the first chain  is strictly shorter
 than  the latter.
 \item Prove that our implementation of the dichotomic strategy describes
- the same function as in the litterature (for instance ~\cite{DBLP:journals/ita/BrlekCHM95}.)
+ the same function as in the literature (for instance ~\cite{DBLP:journals/ita/BrlekCHM95}.)
 This is important if we want to follow the complexity analyses in this and similar articles.
 \item Study how to \emph{compile} a chain into imperative code, using a register allocation strategy (it may be useful  to define \emph{chain width} ).
 

--- a/doc/chapter-powers.tex
+++ b/doc/chapter-powers.tex
@@ -2,13 +2,13 @@
 \label{chapter-powers}
 \section{Introduction}
 
-Nothing looks simpler than writing some function for computing $x^n$.
-On the contrary, this simple programming exercise allows us to address
+Nothing looks simpler than writing a function for computing $x^n$.
+But on the contrary, this simple programming exercise allows us to address
 advanced programming techniques such as:
 \begin{itemize}
 \item monadic programming, and continuation passing style
 \item type classes, and generalized rewriting
-\item proof engineering, in particular proof re-using
+\item proof engineering, in particular proof reuse
 \item proof by reflection
 \item polymorphism and parametricity
 \item composition of correct programs, etc.
@@ -330,7 +330,7 @@ Compute fib 20.
 \end{Coqanswer}
 
 In~\cite{BC04}, several exercises~\footnote{Exercises 9.8 (page 270), 9.10 (page 271), 9.15 (page 276), 9.17 (page 284), and 15.8 (page 418).}
-present ways to compute Fibonacci numbers, with the less number of recursive calls  as possible. Please note that these optimizations and the formal proof of their correctness are \emph{ad-hoc}, \emph{i.e.} exclusively written for the 
+present ways to compute Fibonacci numbers, with the less number of recursive calls  as possible. Please note that these optimizations and the formal proof of their correctness are \emph{ad-hoc}, \emph{i.e.}, exclusively written for the
 Fibonacci numbers.
 In contrast, the optimizations we present in this document apply, in their vast majority, \emph{generic} techniques of efficient computation of powers in a monoid. 
 This example of Fibonacci numbers has been developed with Yves Bertot, who wrote a first version with \texttt{SSreflect/Mathcomp}~\cite{MCB}.
@@ -639,7 +639,7 @@ these definitions for defining the \texttt{Monoid} type class.
 \subsection{A common notation for multiplication}
 \label{op-classes}
 \index{coq}{Type classes!Operational type classes}
-≈Ò
+
 \emph{Operational type classes}~\cite{BS2011}
 allow us to define a common notation 
 for multiplication in any algebraic structure. 
@@ -894,8 +894,8 @@ End Bad.
 In Sect.\vref{naive-matrix}, we defined a function for computing powers of any $2\times 2$ 
 matrix over any semi-ring. For proving a simple property of matrix exponentiation, we had
  to prove that matrix multiplication is associative and admits the identity matrix as a neutral element. These properties are easily expressed within the type class framework, by defining a \emph{family} of monoids.
-It suffices to define an instance of \texttt{Monoid} within the scope of an hypothesis
-of type \texttt{semi\_ring\_theory}
+It suffices to define an instance of \texttt{Monoid} within the scope of a hypothesis
+of type \texttt{semi\_ring\_theory}.
 
 \begin{Coqsrc}
 Section M2_def.
@@ -1532,13 +1532,13 @@ intermediary results are explicitly named for further use in the rest of the com
 
 \section{Addition chains}
 \index{maths}{Addition chains}
-An \emph{addition chain} (In short : \emph{a chain})~\cite{brauer1939} is a representation of a sequence of
+An \emph{addition chain} (in short, a \emph{chain})~\cite{brauer1939} is a representation of a sequence of
 intermediate steps that lead to the evaluation of  $x^n$, under the 
 assumption that each of these steps is a computation of  a power $x^i$, with 
 $i<n$.
 
 In articles from the combinatorist  community, 
-\emph{e.g.}~\cite{brauer1939,DBLP:journals/ipl/BerstelB87},  addition chains 
+\emph{e.g.},~\cite{brauer1939,DBLP:journals/ipl/BerstelB87},  addition chains
 are represented as sequences of positive integers, each member of which 
 is either $1$ or  the sum of two previous elements.
 For instance, the three following sequences are addition chains for the exponent $87$:
@@ -1554,7 +1554,7 @@ whenever $i=j+k$, there is an arc from $x^j$ to $x^i$ and an arc
 from $x^k$ to $x^i$. Figures~\ref{fig:chain-87-eucl}  and 
 \ref{fig:chain-87-bin} show the graphical representations of 
  $c_{87}$  and $c'_{87}$. 
-Please note that some chains may be represented by various different dags.
+Please note that some chains may be represented by various different dags (directed acyclic graphs).
 For instance, we can associate four different dags to the chain $(1,2,3,4,6,9,13)$. 
 
 
@@ -2126,7 +2126,7 @@ Arguments A_node {A} _ .
 
 
 
-Thus, the main steps of a correctness proof of a given chain, \emph{e.g.}
+Thus, the main steps of a correctness proof of a given chain, \emph{e.g.},
 \texttt{C87} will be the following ones:
 \begin{enumerate}
 \item generate a subgoal as in page~\pageref{fig:big-goal},

--- a/doc/chapter-primrec.tex
+++ b/doc/chapter-primrec.tex
@@ -51,7 +51,7 @@ Contributions (under the form of comments, new examples or exercises) are welcom
 \section{First look at the Ackermann library}
 
 O'Connor's library on Gödel's incompleteness theorems contains a little more 
-than 45K lines of scripts. The part dedicated to primitive recursive functions and Peano arithmetics is 32K lines long and is originally structured in 38 modules.
+than 45K lines of scripts. The part dedicated to primitive recursive functions and Peano arithmetic is 32K lines long and is originally structured in 38 modules.
 Thus, we propose a partial exploration of this library, through examples and exercises. Our additions to the original library --- mainly examples and counter-examples ---,
 are stored in the directory \texttt{theories/ordinals/MoreAck}.
 
@@ -199,7 +199,7 @@ Let us now interpret this term as an arithmetic function.
 \input{movies/snippets/PrimRecExamples/bigPRb}
 
 
-After this test, the term \texttt{bigPR} looks to be a primitive recursive definition of the factorial function, although we haven't proved this fact yet. Fortunately, we will see in the following sections simple ways to prove that a given function is primitive recursive, whithout building such an unreadable term.
+After this test, the term \texttt{bigPR} looks to be a primitive recursive definition of the factorial function, although we haven't proved this fact yet. Fortunately, we will see in the following sections simple ways to prove that a given function is primitive recursive, without building such an unreadable term.
 
 \section{Proving that a given arithmetic function is primitive recursive}
 \label{sect:proofs-of-isPR}
@@ -212,14 +212,14 @@ The example in the preceding section clearly shows that, in order to prove that 
 \item Prove handy lemmas which may help to prove that a given function is primitive recursive.
 \end{enumerate}
 
-Thus, the proof that a function, like \texttt{factorial}, is primitive recursive may be interactive, whithout having to type complex terms at any step of the development.
+Thus, the proof that a function, like \texttt{factorial}, is primitive recursive may be interactive, without having to type complex terms at any step of the development.
 
 \subsection{The predicate \texttt{isPR}}
 
 \index{primrec}{Predicates!isPR}
-\index{coq}{Extensionnaly equal functions}
+\index{coq}{Extensionally equal functions}
 
-Let $f$ be an arithmetic function of arity $n$. We say that $f$ is primitive recursive if $f$ is \textbf{extensionnaly}
+Let $f$ be an arithmetic function of arity $n$. We say that $f$ is primitive recursive if $f$ is \textbf{extensionally}
 equal to the interpretation of some term of type \texttt{PrimRec $n$}. 
 
 \vspace{4pt}
@@ -485,7 +485,7 @@ This way, both functions \texttt{Ack} and \texttt{Ackm} have a (structurally) st
 
 \input{movies/snippets/Ack/AckFixpointAlt.tex}
 
-We prefered to define a variant which uses explicitely 
+We preferred to define a variant which uses explicitly
  the functional \texttt{iterate},
 where (\texttt{iterate\,$f$\,$n$})
 is the $n$-th iteration of $f$\,\footnote{Please not confuse with \texttt{primRec.iterate}, which is monomorphic and does not share the same order of arguments.}. It makes it possible to apply a few lemmas proved in 
@@ -517,14 +517,14 @@ Thus, our definition of the Ackermann function is as follows:
 
 \begin{exercise}
 The file \href{../theories/html/hydras.MoreAck.Ack.html}{MoreAck.Ack} presents two other definitions of the Ackermann functions based on the lexicographic ordering on $\mathbb{N}\times\mathbb{N}$.
-Prove that the four functions are extensionnally equal.
+Prove that the four functions are extensionally equal.
 \end{exercise}
 
 
 \subsubsection{First properties of the Ackermann function}
 
 The three first lemmas make us sure that our function 
-\texttt{Ack} satifies the ``usual'' equations.
+\texttt{Ack} satisfies the ``usual'' equations.
 
 \input{movies/snippets/Ack/AckRewrite}
 
@@ -582,7 +582,7 @@ Please note also that for any given $n$, the unary function
 
 \subsection{A proof by induction on all primitive recursive functions}
 
-Ìn order to prove that \texttt{Ack} (considered as a function of two arguments) is not primitive recursive, the usual method consists in two steps:
+In order to prove that \texttt{Ack} (considered as a function of two arguments) is not primitive recursive, the usual method consists in two steps:
 
 
 \begin{enumerate}
@@ -606,7 +606,7 @@ The following scheme allows us to write proofs by induction on the class of prim
 
 
 
-Please note that, in order to prove a property shared by any primitive recursive function of, say, arity 2, this induction scheme  leads you to consider an expension of the considered property to primitive recursive function of any arity.
+Please note that, in order to prove a property shared by any primitive recursive function of, say, arity 2, this induction scheme  leads you to consider an extension of the considered property to primitive recursive function of any arity.
 
 Thus the lemma we will have to prove is the following one:
 
@@ -769,7 +769,7 @@ Thus, our impossibility proof is just a sequence of easy small steps.
 \input{movies/snippets/AckNotPR/AckNotPR}
 
 \begin{remark}
-It is easy to prove that any unary function which dominatates \texttt{fun n => Ack n n} fails to be primitive recursive. To this end, we use an instance of \texttt{majorAnyPR} dealing with unary functions.
+It is easy to prove that any unary function which dominates \texttt{fun n => Ack n n} fails to be primitive recursive. To this end, we use an instance of \texttt{majorAnyPR} dealing with unary functions.
 
 \vspace{4pt}
 \noindent
@@ -788,7 +788,7 @@ Then, we write  a short proof by contradiction.
 Note that the Ackermann function is a counter-example to the (false) statement:
 \begin{quote}
 {\color{red}
-  ``Let $f$ be a function of type \texttt{naryFunc\,2}. If, for any $n$, the fonction $f(n)$ is primitive recursive, then f is primitive recursive.''}
+  ``Let $f$ be a function of type \texttt{naryFunc\,2}. If, for any $n$, the function $f(n)$ is primitive recursive, then f is primitive recursive.''}
 \end{quote}
 \end{remark}
 
@@ -821,7 +821,7 @@ Let us consider the hydra represented by the ordinal $\omega^\omega$.
 \input{movies/snippets/Hydra_Theorems/battleLengthNotPRb}
 
 
-In order to get rid of the substraction in the definition of \texttt{l\_std}, we work with a helper function.
+In order to get rid of the subtraction in the definition of \texttt{l\_std}, we work with a helper function.
 
 \input{movies/snippets/Hydra_Theorems/battleLengthNotPRc}
 
@@ -838,7 +838,7 @@ $H'_{\omega^\alpha}(k)\geq F_\alpha(k)$.
 \input{movies/snippets/F_alpha/HprimeF}
 
 
-Our proof of this lemma is not trivial at all, it uses some properties of the Ketonen-Solovay's toolkit. We advise the reader to explore this proof, with the help of an ide or software like alectryon.
+Our proof of this lemma is not trivial at all, it uses some properties of the Ketonen-Solovay's toolkit. We advise the reader to explore this proof, with the help of an IDE or software like Alectryon.
 %%
 %%% To move the path chapter
 %%%%

--- a/doc/thebib.bib
+++ b/doc/thebib.bib
@@ -188,25 +188,20 @@ isbn="978-3-540-46499-0",
 note="\url{https://link.springer.com/content/pdf/10.1007%2F3540539816_77.pdf}",
 }
 
-@Misc{CantorContribSlide,
- author = 	 {Pierre Cast{\'e}ran and \'Evelyne Cont{\'e}jean},
-  title = 	 {On Ordinal Notations},
-  howpublished = {User Contributions to the Coq Proof Assistant},
-  year= {2006}
-}
-
 @Misc{CantorContrib,
- author = 	 {Pierre Cast{\'e}ran and \'Evelyne Cont{\'e}jean},
+ author = 	 {Pierre Cast{\'e}ran and \'Evelyne Contejean},
   title = 	 {On Ordinal Notations},
-  howpublished = {User Contributions to the Coq Proof Assistant},
-   year= {2006}
+  howpublished = {User Contributions to the {Coq} Proof Assistant},
+  year= {2006},
+  note = {\url{https://github.com/coq-contribs/cantor}},
 }
 
 @Misc{AdditionsContrib,
  author = 	 {Pierre Cast\'eran},
   title = 	 {Additions},
-  howpublished = {User Contributions to the Coq Proof Assistant},
+  howpublished = {User Contributions to the {Coq} Proof Assistant},
   note = {\url{https://github.com/coq-contribs/additions}},
+  year = {2004},
 }
 
 @article{DBLP:journals/ipl/BerstelB87,


### PR DESCRIPTION
I did a pass to fix typos like in #53 but for the powers and primrec chapters. While doing that, I also noticed some small non-typo issues.