### PR TITLE
Lazy snippet generation

### DIFF
--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -4305,27 +4305,20 @@ We have now proved there exists no bounded variant for the class of free battles
 
 \input{movies/snippets/Epsilon0_Needed_Free/CheckDemo}
 
-
 \section{The case of standard battles}
 \label{sec:standard-intro}\label{std-case}
 One may wonder if our theorem holds also in the framework of standard battles. Unfortunately, its proof relies on the lemma \texttt{LT\_to\_round\_plus} of
 Module~\href{../theories/html/hydras.Hydra.O2H.html}{Hydra.O2H}.
 
-\begin{Coqsrc}
-Lemma LT_to_round_plus alpha beta :
-    beta t1< alpha ->  iota alpha -+-> iota beta.
-\end{Coqsrc}
+\input{movies/snippets/O2H/LTToRoundPlus}
 
 This lemma builds a battle out of any inequality $\beta<\alpha$. 
 It is a straightforward application of \texttt{LT\_path\_to} of
 Module~\href{../theories/html/hydras.Epsilon0.Paths.html}{Epsilon0.Paths}:
 
-\begin{Coqsrc}
-Lemma LT_path_to (alpha beta : T1) :
-  beta t1< alpha -> {s : list nat | path_to beta s alpha}.
-\end{Coqsrc}
+\input{movies/snippets/Paths/LTPathTo}
 
-The sequence $s$, used to build the sequence of replication factors of the battle depends on 
+The sequence $s$, used to build the sequence of replication factors of the battle, depends on 
 $\beta$, so we cannot be sure that the generated battle is a genuine standard battle.
 
 
@@ -4343,20 +4336,7 @@ In \coq{}, standard paths can be defined as follows.
 \emph{From
 Module~\href{../theories/html/hydras.Epsilon0.Paths.html}{Epsilon0.Paths}}
 
-\begin{Coqsrc}
-(**  standard path from (i, alpha) to (j, beta) *)
-
-Inductive standard_pathR(j:nat)( beta:T1):  nat -> T1 -> Prop :=
-  std_1 : forall i alpha, 
-       beta = canon alpha i -> j = S i ->
-       standard_pathR j beta i  alpha
-| std_S : forall i alpha, 
-      standard_pathR j beta (S i) (canon alpha i)  ->
-      standard_pathR j beta i alpha.
-
-Definition standard_path  i alpha j beta := 
-   standard_pathR j beta i alpha.
-\end{Coqsrc}
+\input{movies/snippets/Paths/standardPathR}
 
 In the mathematical text and figures, we shall use the notation 
 $\alpha \xrightarrow[i,j]{}\beta$ for the proposition 
@@ -4387,17 +4367,7 @@ enjoy nice properties. They are defined as paths where all the $i_j$ are equal t
 
 Like in~\cite{KS81}, we shall use the notation $\alpha \xrightarrow[i]{} \beta$ for denoting such a path, also called an $i$-path.
 
-\begin{Coqsrc}
-Definition const_pathS i :=
-  clos_trans_1n T1 (fun alpha beta => alpha <> zero /\
-                                      beta = canon alpha (S i)).
-
-Definition const_path i alpha beta :=
-  match i with
-    0 => False
-  | S j => const_pathS j alpha beta
-end.
-\end{Coqsrc}
+\input{movies/snippets/Paths/constPathDef}
 
 % Paths with a given index can be effectively computed.
 % Given $i$, $\alpha$ and $l$, the following function returns the ordinal $\beta$ such that there exists a path 
@@ -4442,8 +4412,6 @@ end.
 % = (omega ^ 4 * 4 + omega ^ 3 * 4 + omega ^ 2 + omega * 4 + 4)%pT1
 %      : ppT1
 % \end{Coqanswer}
-
-
 
 
 A most interesting property of $i$-paths is that we can ``upgrade'' their index, as stated by K.\&S.'s Corollary 12.

--- a/theories/ordinals/Epsilon0/Paths.v
+++ b/theories/ordinals/Epsilon0/Paths.v
@@ -13,6 +13,7 @@
  *)
 
 
+(*| .. coq:: none |*)
 
 Require Import Canon  MoreLists First_toggle OrdNotations.
 Import Relations Relation_Operators.
@@ -23,7 +24,7 @@ Open Scope t1_scope.
 
 
 (** ** relations  associated with canonical sequences *)
-
+(*||*)
 (* begin snippet transitionDefs *)
 
 Definition transition_S i : relation T1 :=
@@ -33,6 +34,8 @@ Definition transition i : relation T1 :=
   match i with 0 => fun _ _ => False | S j => transition_S j end.
 
 (* end snippet transitionDefs *)                             
+
+(*| ..coq:: none |*)
 
 Definition bounded_transition (n:nat) alpha beta :=
   exists i:nat, (i <= n)%nat /\ transition_S i alpha beta. 
@@ -53,7 +56,7 @@ associated with   the [canonS i] functions. In module [O2H] we show how pathes a
 
    Note that only beta can be equal to zero
  *)
-
+(*||*)
 (* begin snippet pathDef *)
 
 Inductive path_to (beta: T1) : list nat -> T1 -> Prop :=
@@ -70,6 +73,8 @@ Inductive path_to (beta: T1) : list nat -> T1 -> Prop :=
 Definition path alpha s beta := path_to beta s alpha.
 
 (* end snippet pathDef *)
+
+(*| .. coq:: none |*)
 
 (** tries to solve a goal of the form (path_to beta s alpha) *)
 
@@ -164,7 +169,7 @@ Definition KP_arrow n := clos_trans_1n T1 (bounded_transition n).
 
 
 (** ** Paths with constant index *)
-
+(*||*)
 (* begin snippet constPathDef *)
 
 Definition const_pathS i :=
@@ -179,6 +184,7 @@ Definition const_path i alpha beta :=
 
 (* end snippet constPathDef *)
 
+(*| .. coq:: none |*)
 
 Definition const_pathS_eps i := clos_refl _ (const_pathS i).
 
@@ -198,9 +204,11 @@ Inductive standard_pathRS (j:nat)( beta : T1):  nat -> T1 -> Prop :=
 
 Definition standard_pathS  i alpha j beta := standard_pathRS j beta i alpha.
 
+(*||*)
 (* begin snippet standardPathR *)
 
-Inductive standard_pathR (j:nat)( beta : T1):  nat -> T1 -> Prop :=
+Inductive standard_pathR (j:nat)( beta : T1)
+  :  nat -> T1 -> Prop :=
   std_1 : forall i alpha,
     alpha <> zero ->
     beta = canon alpha i -> j = i -> i <> 0 ->
@@ -216,6 +224,7 @@ Definition standard_path  i alpha j beta :=
   standard_pathR j beta i alpha.
 (* end snippet standardPathR *)
 
+(*| .. coq:: none |*)
 
 Lemma path_to_interval_inv_le alpha beta i j :
   path_to beta (interval i j) alpha ->
@@ -808,6 +817,10 @@ Lemma gnaw_path_to : forall s alpha , s <> nil -> ~ In 0 s ->
 Qed.
 
 
+(* just for testing latex generation  *)
+Compute (9999+1)%nat.
+
+
 
 (** **  Properties of acc_from  *)
 
@@ -857,6 +870,7 @@ Proof with eauto with T1.
            -- now rewrite canon_succ.
 Defined.
 
+(*||*)
 (* begin snippet LTPathTo *)
 
 Lemma LT_path_to (alpha beta : T1) :
@@ -869,6 +883,8 @@ Defined.
 (*||*)
 
 (* end snippet LTPathTo *)
+
+(*| .. coq:: none |*)
 
 (*
 From Coq Require Import Extraction.
@@ -897,6 +913,7 @@ Proof.
   subst; apply canonS_LT; auto.   
 Qed.
 
+(*||*)
 (* begin snippet pathToLT *)
 
 Lemma path_to_LT beta s alpha :
@@ -911,7 +928,7 @@ Qed.
 (*||*)
 (* end snippet pathToLT *)
 
-
+(*| .. coq:: none |*)
 
 Lemma acc_from_LT (alpha beta : T1) :
   acc_from alpha beta ->  nf alpha ->   beta t1< alpha.
@@ -1346,13 +1363,20 @@ Qed.
 
 (**  Corollary 12 of [KS] *)
 
-Corollary Cor12 (alpha : T1) :  nf alpha ->
-                forall beta i n, beta  t1< alpha  ->
-                                 i < n ->
-                                 const_pathS i alpha beta ->
-                                 const_pathS n alpha beta.
+(*||*)
+(* begin snippet Cor12 *)
+
+(*| .. coq:: no-out |*)
+
+Corollary Cor12 (alpha : T1) :
+  nf alpha ->
+  forall beta i n, beta  t1< alpha  ->
+                   i < n ->
+                   const_pathS i alpha beta ->
+                   const_pathS n alpha beta.
 Proof.
   transfinite_induction_lt alpha.
+  (* ... *) (*| .. coq:: none |*)
   clear alpha ; intros alpha Hrec Halpha; intros.
   destruct (zero_limit_succ_dec   Halpha).
   -  destruct s.
@@ -1434,18 +1458,27 @@ Proof.
          + auto. 
     }
 Qed.
+(*||*)
+(* end snippet Cor12 *)
+
+(* begin snippet Cor121 *)
 
 Corollary Cor12_1 (alpha : T1) :
   nf alpha ->
   forall beta i n, beta t1< alpha ->
                    i <= n ->
                    const_pathS i alpha beta ->
-                   const_pathS n alpha beta.
+                   const_pathS n alpha beta. (* .no-out *)
+(*| .. coq:: none |*)
 Proof.
   intros H beta i n H0 H1 H2; destruct (Lt.le_lt_or_eq _ _ H1).
   -   eapply Cor12;eauto.
   -   now subst.
 Qed.
+(*||*)
+(* end snippet Cor121 *)
+
+(*| .. coq:: none |*)
 
 Corollary Cor12_2 (alpha : T1) : 
     nf alpha ->
@@ -3054,3 +3087,5 @@ Proof.
      f_equal; apply nf_proof_unicity.
   - right; auto.
 Qed.
+
+(*||*)

--- a/theories/ordinals/Epsilon0/Paths.v
+++ b/theories/ordinals/Epsilon0/Paths.v
@@ -165,6 +165,8 @@ Definition KP_arrow n := clos_trans_1n T1 (bounded_transition n).
 
 (** ** Paths with constant index *)
 
+(* begin snippet constPathDef *)
+
 Definition const_pathS i :=
   clos_trans_1n T1 (fun alpha beta => alpha <> zero /\
                                       beta = canon alpha (S i)).
@@ -175,12 +177,15 @@ Definition const_path i alpha beta :=
   | S j => const_pathS j alpha beta
   end.
 
+(* end snippet constPathDef *)
+
+
 Definition const_pathS_eps i := clos_refl _ (const_pathS i).
 
 (** ** standard paths *)
 
 
-(**  standard path from (i, alpha) to (j, beta) *)
+
 
 (* todo : use transition_S in the definition *)
 
@@ -193,15 +198,24 @@ Inductive standard_pathRS (j:nat)( beta : T1):  nat -> T1 -> Prop :=
 
 Definition standard_pathS  i alpha j beta := standard_pathRS j beta i alpha.
 
+(* begin snippet standardPathR *)
+
 Inductive standard_pathR (j:nat)( beta : T1):  nat -> T1 -> Prop :=
-  std_1 : forall i alpha, alpha <> zero ->
-                          beta = canon alpha i -> j = i -> i <> 0 ->
-                          standard_pathR j beta i  alpha
-| std_S : forall i alpha, standard_pathR j beta (S i) (canon alpha i)  ->
-                          standard_pathR j beta i alpha.
+  std_1 : forall i alpha,
+    alpha <> zero ->
+    beta = canon alpha i -> j = i -> i <> 0 ->
+    standard_pathR j beta i  alpha
+| std_S : forall i alpha,
+    standard_pathR j beta (S i) (canon alpha i)  ->
+    standard_pathR j beta i alpha.
 
 
-Definition standard_path  i alpha j beta := standard_pathR j beta i alpha.
+(**  standard path from (i, alpha) to (j, beta) *)
+
+Definition standard_path  i alpha j beta :=
+  standard_pathR j beta i alpha.
+(* end snippet standardPathR *)
+
 
 Lemma path_to_interval_inv_le alpha beta i j :
   path_to beta (interval i j) alpha ->

--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -1,3 +1,5 @@
+(*| .. coq:: none |*)
+
 (**  
 
   A type for ordinals terms in Cantor Normal Form
@@ -5,6 +7,7 @@
 After Manolios and Vroon's work on ACL2 
 
 *)
+
 
 From Coq Require Import Arith Max Bool Lia  Compare_dec  Relations Ensembles
      Wellfounded Bool RelationClasses Operators_Properties ArithRing
@@ -38,6 +41,7 @@ This issue is solved later which the help of the predicate [nf]
 
 *)
 
+(*||*)
 (* begin snippet T1Def *)
 
 Inductive T1 : Set  :=
@@ -46,10 +50,12 @@ Inductive T1 : Set  :=
 
 (* end snippet T1Def *)
 
+(*| .. coq:: none |*)
+
 (** Basic functions and predicates on [T1] 
 *)
 
-
+(*||*)
 (* begin snippet finiteOrds *)
 
 Notation one := (ocons zero 0 zero).
@@ -75,6 +81,8 @@ Notation omega := (ocons (ocons zero 0 zero) 0 zero).
 
 (* end snippet omegaDef *)
 
+(*| .. coq:: none |*)
+
 (* begin hide *)
 Lemma FS_rw (n:nat) : FS n = S n.
 Proof. reflexivity. Qed.
@@ -82,7 +90,7 @@ Proof. reflexivity. Qed.
 
 
 (** Successor and limits (syntactic definitions) *)
-
+(*||*)
 (* begin snippet succbLimitb *)
 
 Fixpoint succb alpha :=
@@ -110,13 +118,17 @@ Compute succb omega.
 
 (* end snippet succbLimitb *)
 
+(*| .. coq:: none |*)
 (** Exponential of base [omega] *)
 
+(*||*)
 (* begin snippet phi0Def *)
 
 Notation phi0 alpha := (ocons alpha 0 zero).
 
 (* end snippet phi0Def *)
+
+(*| .. coq:: none |*)
 
 (** multiples of [phi0 alpha]  *)
 
@@ -127,6 +139,7 @@ Definition omega_term (alpha:T1)(k:nat) :=
 (**  omega towers 
 *)
 
+(*||*)
 (* begin snippet towerDef *)
 
 Fixpoint tower (height:nat) : T1 := 
@@ -136,6 +149,8 @@ Fixpoint tower (height:nat) : T1 :=
  end.
 
 (* end snippet towerDef *)
+
+(*| .. coq:: none |*)
 
 (** Additive principal ordinals
  *)
@@ -148,6 +163,7 @@ Inductive ap : T1 -> Prop :=
 (**  **  A linear  strict order on [T1]
  *)
 
+(*||*)
 (* begin snippet compareDef *)
 
 Fixpoint compare (alpha beta:T1):comparison :=
@@ -186,8 +202,11 @@ Proof.  discriminate.  Qed.
 
 (* end snippet ltExamples *)
 
+(*| .. coq:: none |*)
+
 (** ** Properties of [compare] *)
 
+(*||*)
 (* begin snippet compareRev *)
 
 Lemma compare_rev :
@@ -196,7 +215,8 @@ Lemma compare_rev :
 Proof. (* .no-out *)
   induction alpha, beta. (* .unfold -.g#* .g#1 *)
   (* end snippet compareRev *)
-  
+
+  (*| .. coq:: none |*)
   1-3: easy.
   simpl.
   rewrite IHalpha1, Nat.compare_antisym.
@@ -453,7 +473,7 @@ Qed.
 
 
 
-
+(*||*)
 (* begin snippet Instances *)
 
 #[global] Instance t1_strorder: StrictOrder lt. (* .no-out *)
@@ -480,6 +500,8 @@ Qed.
 
 (* end snippet Instances *)
 
+(*| .. coq:: none |*)
+
 Lemma lt_inv_head :
   forall a n b a' n' b',
     lt (ocons a n b) (ocons a' n' b') -> leq lt  a a'.
@@ -501,6 +523,7 @@ Qed.
 Cantor normal form needs the exponents of omega to be
    in strict decreasing order *)
 
+(*||*)
 (* begin snippet nfDef *)
 
 Fixpoint nf_b (alpha : T1) : bool :=
@@ -523,6 +546,7 @@ Example bad_term: T1 := ocons 1 1 (ocons omega 2 zero).
 
 (* end snippet badTerm *)
 
+(*| .. coq:: none |*)
 (** epsilon0 as a set *)
 
 Definition epsilon_0 : Ensemble T1 := nf.
@@ -532,6 +556,7 @@ Definition epsilon_0 : Ensemble T1 := nf.
 
 (** *** Successor *)
 
+(*||*)
 (* begin snippet succDef *)
 
 Fixpoint succ (alpha:T1) : T1 :=
@@ -541,6 +566,8 @@ Fixpoint succ (alpha:T1) : T1 :=
   end.
 
 (* end snippet succDef *)
+
+(*| .. coq:: none |*)
 
 (** *** Predecessor (partial function *)
 
@@ -557,6 +584,7 @@ Fixpoint pred (c:T1) : option T1 :=
 
 (** *** Addition *)
 
+(*||*)
 (* begin snippet plusDef *)
 
 Fixpoint plus (alpha beta : T1) :T1 :=
@@ -574,9 +602,11 @@ where "alpha + beta" := (plus alpha beta) : t1_scope.
 
 (* end snippet plusDef *)
 
+(*| .. coq:: none |*)
 
 (** *** multiplication *)
 
+(*||*)
 (* begin snippet multDef *)
 
 Fixpoint mult (alpha beta : T1) :T1 :=
@@ -593,6 +623,8 @@ Fixpoint mult (alpha beta : T1) :T1 :=
 where "alpha * beta" := (mult alpha beta) : t1_scope.
 
 (* end snippet multDef *)
+
+(*| .. coq:: none |*)
 
 (**  *** Substraction  (used as a helper for exponentiation) *)
 
@@ -1251,6 +1283,7 @@ Reserved Notation "x 't1<=' y 't1<' z" (at level 70, y at next level).
 Reserved Notation "x 't1<' y 't1<' z" (at level 70, y at next level).
 Reserved Notation "x 't1<' y 't1<=' z" (at level 70, y at next level).
 
+(*||*)
 (* begin snippet LTDef *)
 
 Definition LT := restrict nf lt.
@@ -1260,6 +1293,8 @@ Definition LE := restrict nf (leq lt).
 Infix "t1<=" := LE : t1_scope.
 
 (* end snippet LTDef *)
+
+(*| .. coq:: none |*)
 
 Notation "alpha t1< beta t1< gamma" :=
   (LT alpha beta /\ LT beta gamma) : t1_scope.
@@ -1524,7 +1559,7 @@ Module Direct_proof.
       split; intros y (H1, (H2, H3)). destruct (not_lt_zero H2).
     Qed.
 
-
+    (*||*)
     (* begin snippet wfLTBada *)
 
     (*|
@@ -1553,9 +1588,12 @@ Module Direct_proof.
 
     End First_attempt.
 
-   (* end snippet wfLTBadz *)
+    (* end snippet wfLTBadz *)
+
+    (*| .. coq:: none |*)
 
     (** *** Strong accessibility (inspired by Tait's proof) *)
+    (*||*)
     (* begin snippet AccStrongDef *)
     
     Let Acc_strong (alpha:T1) :=
@@ -1563,12 +1601,15 @@ Module Direct_proof.
         nf (ocons alpha n beta) -> Acc LT (ocons alpha  n beta).
     (* end snippet AccStrongDef *)
 
+    (*| .. coq:: none |*)
+
     Remark acc_impl {A} {R: A -> A -> Prop} (a b:A) :
       R a b -> Acc R b -> Acc R a.
     Proof.
       intros H H0; revert a H; now destruct H0.
     Qed.
 
+    (*||*)
     (* begin snippet AccStrongStronger *)
 
     (*|
@@ -1710,7 +1751,9 @@ Module Direct_proof.
          apply nf_inv1 in H; auto.
     Qed.
 
-       (* end snippet nfAcc *)
+    (* end snippet nfAcc *)
+
+    (*| .. coq:: none |*)
 
   End well_foundedness_proof.
 End Direct_proof.
@@ -1721,11 +1764,13 @@ Definition nf_Acc := Direct_proof.nf_Acc.
 Corollary nf_Wf : well_founded_restriction _ nf lt.
 Proof.  red; intros; now apply nf_Acc. Qed.
 
+(*||*)
 (* begin snippet T1Wf *)
 
 Corollary T1_wf : well_founded LT. (* .no-out *)
 (* end snippet T1Wf *)
 
+(*| .. coq:: none |*)
 Proof.
   intros alpha; case_eq(nf_b alpha).
   - intro H; now generalize (nf_Wf H).
@@ -1746,6 +1791,7 @@ Proof.
     intros; apply X0; repeat split;auto. 
 Defined.
 
+(*||*)
 (* begin snippet transfiniteRecursor *)
 
 Definition transfinite_recursor := well_founded_induction_type T1_wf.
@@ -1754,17 +1800,22 @@ Check transfinite_recursor.
 
 (* end snippet transfiniteRecursor *)
 
+(*| .. coq:: none |*)
+
 Import Direct_proof.
 
 Ltac transfinite_induction_lt alpha :=
   pattern alpha; apply transfinite_recursor_lt.
 
+(*||*)
 (* begin snippet transfiniteInduction *)
 
 Ltac transfinite_induction alpha :=
   pattern alpha; apply transfinite_recursor.
 
 (* end snippet transfiniteInduction *)
+
+(*| .. coq:: none |*)
 
 (** **  Properties of successor *)
 
@@ -1802,6 +1853,7 @@ Proof.
    case alpha; now simpl.
 Qed.
 
+(*||*)
 (* begin snippet succIsPlusOne *)
 
 Lemma succ_is_plus_one (alpha : T1) :  succ alpha = alpha + 1. (* .no-out *)
@@ -1818,10 +1870,12 @@ Proof. (* .no-out *)
 Qed.
 (* end snippet succIsPlusOne *)
 
+(*| .. coq:: none |*)
+
 Lemma succ_of_plus_finite :
   forall alpha (H: nf alpha) (i:nat) , succ (alpha + i) = alpha + S i.
 Proof.
-  induction  alpha; cbn.
+  induction alpha; cbn.
   -  destruct i; reflexivity.
   -  destruct i.
      + simpl.
@@ -1988,6 +2042,7 @@ Proof.
            exact 0.
 Defined.
 
+(*||*)
 (* begin snippet plusNf *)
 
 Lemma plus_nf:
@@ -2015,6 +2070,8 @@ Qed.
 
 (* end snippet plusNf *)
 
+(*| .. coq:: none |*)
+
 Lemma omega_term_plus_rw:
   forall a n b,
     nf (ocons a n b) ->
@@ -2028,7 +2085,7 @@ Proof.
        now apply nf_inv3, compare_gt_iff in H as ->.
 Qed.
 
-
+(*||*)
 (* begin snippet plusIsZero *)
 
 Lemma plus_is_zero alpha beta :
@@ -2036,6 +2093,7 @@ Lemma plus_is_zero alpha beta :
   alpha + beta  = zero -> alpha = zero /\  beta = zero. (* .no-out *)
 (* end snippet plusIsZero *)
 
+(*| .. coq:: none |*)
 Proof.
   destruct alpha, beta.
   - now split.
@@ -2051,7 +2109,7 @@ Proof.
     2-3: easy.
     now destruct (compare beta0 beta) eqn:?.
 Qed.
-
+(*||*)
 (* begin snippet notMono *)
 
 (*|
@@ -2075,7 +2133,7 @@ Qed.
 (*||*)
 (* end snippet notMono *)
 
-
+(*| .. coq:: none |*)
 
 (** ** monotonicity of [succ]  *)
 
@@ -2614,6 +2672,8 @@ Proof.
     + assumption.
 Defined.
 
+(*||*)
+
 (* begin snippet LTOne *)
 
 Lemma LT_one alpha :
@@ -2634,6 +2694,8 @@ Proof. (* .no-out *)
 (*||*)
 Qed.
 (* end snippet LTOne *)
+
+(*| .. coq:: none |*)
 
 Lemma lt_omega_inv :
   forall alpha,
@@ -3561,6 +3623,8 @@ Proof.
   -   exact H0.
 Defined.
 
+(*||*)
+
 (* begin snippet succbIff *)
 
 Lemma succb_iff alpha (Halpha : nf alpha) :
@@ -3581,6 +3645,8 @@ Proof.
 Qed.
 (*||*)
 (* end snippet succbIff *)
+
+(*| .. coq:: none |*)
 
 Lemma LE_r : forall alpha beta, alpha t1< beta -> alpha t1<= beta.
 Proof.
@@ -4023,6 +4089,9 @@ End Proof_of_dist.
 
 
 (**  **  An abstract syntax for ordinals in Cantor normal form *)
+
+(*||*)
+
 (* begin snippet ppT1Def *)
 
 
@@ -4051,6 +4120,7 @@ Check (_omega ^ _omega * 2 + PP_fin 1)%pT1.
 
 (* end snippet ppT1Def *)
 
+(*| .. coq:: none |*)
 
 Fixpoint pp0 (alpha : T1) : ppT1 :=
   match alpha with
@@ -4172,7 +4242,7 @@ Compute pp (3 * (omega * 7 + 15)).
 
 (** * Examples *)
 
-
+(*||*)
 (* begin snippet plusMultExamples *)
 
 (*|
@@ -4195,11 +4265,14 @@ Proof. now compute. Qed.
 (*||*)
 (* end snippet plusMultExamples *)
 
+(*| .. coq:: none |*)
 
 Example Ex5 : limitb (omega ^ (omega + 5)).
 Proof. reflexivity. Qed.
 
 (* Demo *)
+
+(*||*)
 
 (* begin snippet alpha0 *)
 
@@ -4238,6 +4311,7 @@ Compute nf_b bad_term.
 
 (* end snippet nfBadTerm *)
 
+(*||*)
 
 Example alpha_0_eq : alpha_0 = phi0 omega  +
                                phi0 3 * 5 + 2.

--- a/theories/ordinals/Hydra/Epsilon0_Needed_Std.v
+++ b/theories/ordinals/Hydra/Epsilon0_Needed_Std.v
@@ -33,7 +33,7 @@ Section Impossibility_Proof.
 
   (**  The measure is strictly decreasing along any round *)
 
-  Lemma Lvar : forall h h0 i ,  h <> head -> 
+  Lemma Lvar : forall h h0 i,  h <> head -> 
                                 battle_rel standard i h h0 -> m h0 t1< m h.
   Proof.   
     intros h h0 i H  H1;  apply Var with  i; auto.
@@ -47,7 +47,7 @@ Section Impossibility_Proof.
     induction 2.  
     -  apply Lvar with i; auto. 
     -  destruct (h_eq_dec h'' head).
-       +  rewrite e in H1;  elimtype False.
+       + rewrite e in H1;  elimtype False.
           eapply standard_battle_head; eauto.  
        + apply LT_trans with (m h'');auto.
          apply Lvar with i; auto.
@@ -83,14 +83,12 @@ Section Impossibility_Proof.
   Qed.
 
   Lemma o2iota_1 : forall j beta i alpha,
-      standard_pathR j beta ( S i) alpha ->  nf alpha ->
+      standard_pathR j beta (S i) alpha ->  nf alpha ->
       nf beta ->  beta <> T1.zero -> 
       battle standard  i (iota alpha) j (iota beta) .
   Proof.
-    intros.    
-    change i with (Nat.pred (S i)).
-    apply o2iota_0; auto.
- auto with arith.
+    intros; change i with (Nat.pred (S i)); apply o2iota_0; trivial. 
+    auto with arith.
   Qed.
   
   Lemma o2iota : forall alpha  ,

--- a/theories/ordinals/Hydra/O2H.v
+++ b/theories/ordinals/Hydra/O2H.v
@@ -655,7 +655,7 @@ Qed.
 
   (* begin snippet LTToRoundPlus *)
   
-  Theorem LT_to_round_plus alpha beta :
+  Lemma LT_to_round_plus alpha beta :
     beta t1< alpha ->  iota alpha -+-> iota beta. (* .no-out *)
   (*| .. coq:: none |*)
   Proof.


### PR DESCRIPTION
@Zimmi48 On this branch I put systematically `.. coq:: none` blocks around snippet-free regions of Epsilon0/T1.v and Epsilon0/Paths.v The size of T1.tex was reduced by a factor of 70, and Paths.tex by a factor of 336 !
Do you think this can help to reduce documentation generation time too?

