### PR TITLE
[movies] Simplify the driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ doc/*.json
 doc/cutting-table/
 doc/auto/
 doc/*.pyg
-doc/movies/snippets
-doc/movies/*.tex
+doc/movies/snippets/
+doc/movies/targets.mk
 __pycache__
 alectryon-html/

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-         url = https://github.com/Zimmi48/nixpkgs/archive/5addba8675aa31463adc3fa4dce96f22774b87f2.tar.gz;
-         sha256 = "0zvklz35nlk8f4x0b4ilfwbhlhqyricg2ilghb8x43crvhb1zx32";
+         url = https://github.com/Zimmi48/nixpkgs/archive/b454dafa6170cdd170d7513b845fe9eea05ad77c.tar.gz;
+         sha256 = "0fasks1d1afg48zwfp1952w54wz5jkk07mgp5mr3ca240npfchpq";
        }

--- a/doc/hydras.tex
+++ b/doc/hydras.tex
@@ -33,7 +33,7 @@
 \usepackage{texments}
 %%% for movies by alectryon
 \usepackage{movies/snippets/assets/alectryon}
-\usepackage{movies/snippets/assets/tango_subtle}
+\usepackage{movies/snippets/assets/pygments}
 
 \setcounter{tocdepth}{1}
 \input{coqmacros}

--- a/doc/movies/Makefile
+++ b/doc/movies/Makefile
@@ -1,58 +1,25 @@
+PYTHON ?= python3
 
-### Naive Makefile
-##################
+export coq_root := ../../theories/ordinals
+export snippets_root := ./snippets
+assets_root := $(snippets_root)/assets
 
-INPUT_DIR=../../theories/ordinals
-OPTIONS= -R ${INPUT_DIR} hydras
-vpath %.v ${INPUT_DIR}/Hydra
-vpath %.v ${INPUT_DIR}/Ackermann
-vpath %.v ${INPUT_DIR}/MoreAck
-vpath %.v ${INPUT_DIR}/Schutte
-vpath %.v ${INPUT_DIR}/Epsilon0
-vpath %.v ${INPUT_DIR}/Gamma0
-vpath %.v ${INPUT_DIR}/OrdinalNotations
-vpath %.v ${INPUT_DIR}/Prelude
-vpath %.v ${INPUT_DIR}/solutions_exercises
+default: all
 
-COQ_FILES = Ack.v AckNotPR.v    \
-	    extEqualNat.v  primRec.v PrimRecExamples.v   \
-	    F_alpha.v L_alpha.v F_omega.v Hprime.v \
-	    Hydra_Definitions.v O2H.v \
-	    Hydra_Theorems.v  Hydra_Examples.v    \
-	    Hydra_Lemmas.v   Hydra_Termination.v    \
-	    Epsilon0_Needed_Generic.v Epsilon0_Needed_Free.v \
-	    Epsilon0_Needed_Std.v \
-	    BigBattle.v      \
-	    Battle_length.v      \
-	    MorePRExamples.v FibonacciPR.v  isqrt.v       \
-	    Iterates.v       \
-	    Exp2.v       \
-	    MoreVectors.v MoreOrders.v Restriction.v \
-	    Omega_Small.v       \
-	    Comparable.v       \
-	    ON_Generic.v ON_Omega.v ON_plus.v ON_Omega_plus_omega.v \
-	    ON_mult.v ON_Omega2.v ON_Finite.v \
-	    Omega2_Small.v \
-	    Correctness_E0.v \
-	    T1.v E0.v Hessenberg.v \
-	    T2.v Gamma0.v \
-	    Canon.v Paths.v Large_Sets.v Large_Sets_Examples.v \
-	    Schutte_basics.v Well_Orders.v Lub.v \
-	    MoreEpsilonIota.v \
-	    Ordering_Functions.v Addition.v AP.v Critical.v CNF.v \
+targets.mk:
+	@$(PYTHON) gen_targets.py "$(coq_root)" "$(snippets_root)" > "$@"
 
-TEX_FILE = $(COQ_FILES:.v=.tex)
+include targets.mk
 
-SNIPPET_OUTPUT = ./snippets/
+coq_flags := -R $(coq_root) hydras
+alectryon_flags := --frontend coq --backend snippets-hydras $(coq_flags)
 
-.PHONY: all
-all: $(TEX_FILE)
+alectryon = $(PYTHON) ./driver.py $(alectryon_flags) --output-directory "$@"
 
+.PHONY: all clean targets.mk
 
-.PHONY: clean
+all: $(targets)
+	@$(PYTHON) ./driver.py --frontend coq --backend assets --output-directory $(assets_root) -
+
 clean:
-	@${RM} ${TEX_FILE}
-	@${RM} -r ${SNIPPET_OUTPUT}
-
-%.tex : %.v
-	@python3 extract_snippets.py $< -o ${SNIPPET_OUTPUT} -d ${OPTIONS}
+	rm -fr $(snippets_root)

--- a/doc/movies/driver.py
+++ b/doc/movies/driver.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+import re
+from collections import namedtuple
+from itertools import zip_longest, groupby
+from pathlib import Path
+
+from alectryon import cli, transforms
+from alectryon.latex import ASSETS
+
+def pair(*iterable):
+    iters = [iter(iterable)] * 2
+    return zip_longest(*iters, fillvalue=None)
+
+Snippet = namedtuple("Snippet", "name io_annots s")
+
+SNIPPET_DELIM_RE = re.compile(r"""
+  [(][*]\s*
+    (?P<kind>begin|end)\s+ snippet\s+ (?P<name>[^ ]+)
+    (?:[:][:]\s+ (?P<io_flags>.*?))?
+  \s*[*][)]
+""", re.VERBOSE)
+
+SNIPPET_IO_FLAGS_RE = re.compile(r"""
+  (?:\n\s*)? # As if flags were at end of last non-empty line
+  [(][*][|]\s*
+    (?:..\s+ coq::\s+ (.*?))?
+  \s*[|]?[*][)]
+""", re.VERBOSE)
+
+class NoSnippets(Exception):
+    pass
+
+def check_snippet_boundaries(before, after):
+    assert before
+    if not after:
+        MSG = "Missing final ``(* end snippet {} *)`` delimiter"
+        raise ValueError(MSG.format(before.group("before_name")))
+    if before.group("kind") != "begin":
+        raise ValueError("Unexpected delimiter ``{}``".format(before.group()))
+    if after.group("kind") != "end":
+        raise ValueError("Unexpected delimiter ``{}``".format(before.group()))
+    if before.group("name") != after.group("name"):
+        MSG = "Mismatched delimiters: (* begin snippet {} *) and (* end snippet {} *)"
+        raise ValueError(MSG.format(before.group("name"), after.group("name")))
+
+def split_snippet(name, io_flags, contents):
+    for substr, subsnippet in pair(io_flags, *SNIPPET_IO_FLAGS_RE.split(contents)):
+        io_annots = transforms.read_all_io_flags(substr or "")
+        yield Snippet(name, io_annots, subsnippet)
+
+def parse_coq_snippets(coq, ctx):
+    end, chunks = 0, []
+    for before, after in pair(*SNIPPET_DELIM_RE.finditer(coq)):
+        check_snippet_boundaries(before, after)
+        if before.start() > end:
+            chunks.append(coq[end:before.start()])
+        name, io_flags = before.group("name", "io_flags")
+        chunks.extend(split_snippet(name, io_flags, coq[before.end():after.start()]))
+        end = after.end()
+    if not chunks:
+        raise NoSnippets()
+    if end < len(coq):
+        chunks.append(coq[end:])
+    ctx["chunks"] = chunks
+    return [(c.s if isinstance(c, Snippet) else c) for c in chunks]
+
+def _prepare_snippets(annotated, chunks):
+    for chunk, frs in zip(chunks, annotated):
+        if isinstance(chunk, Snippet):
+            frs = transforms.inherit_io_annots(frs, chunk.io_annots)
+            yield chunk, list(frs)
+
+def prepare_snippets(annotated, chunks, ctx):
+    ctx["snippets"], annotated = zip(*_prepare_snippets(annotated, chunks))
+    return annotated
+
+def drop_hidden(annotated, snippets):
+    for snippet, frs in zip(snippets, annotated):
+        yield [] if transforms.all_hidden(frs, snippet.io_annots) else frs
+
+def _group_subsnippets(annotated, snippets):
+    for name, group in groupby(zip(snippets, annotated), lambda p: p[0].name):
+        frs = transforms.coalesce_text(fr for _, frs in group for fr in frs)
+        yield name, list(frs)
+
+def group_subsnippets(annotated, snippets, ctx):
+    ctx["names"], annotated = zip(*_group_subsnippets(annotated, snippets))
+    return annotated
+
+def trim_annotated(annotated):
+    for frs in annotated:
+        yield transforms.strip_text(frs)
+
+def write_snippets(latex, names, fpath, output_directory):
+    for name, ltx in zip(names, latex):
+        target = (Path(output_directory) / name).with_suffix(".tex")
+        print(">> {} → {}".format(fpath, target))
+        target.write_text(ltx.render())
+
+def record_assets(v, assets):
+    cli._record_assets(assets, ASSETS.PATH, ASSETS.ALECTRYON_STY + ASSETS.PYGMENTS_STY)
+    return v
+
+cli.PIPELINES['coq']['snippets-hydras'] = (
+    cli.read_plain, parse_coq_snippets, cli.annotate_chunks, prepare_snippets,
+    # Transforms applied twice: once to prepare comments for drop_hidden, once
+    # to add comments and newlines to sentences after grouping subsnippets.
+    cli.apply_transforms, drop_hidden, group_subsnippets,
+    cli.apply_transforms, trim_annotated, cli.gen_latex_snippets, write_snippets
+)
+
+cli.PIPELINES['coq']['assets'] = (record_assets, cli.copy_assets)
+
+if __name__ == '__main__':
+    try:
+        cli.main()
+    except NoSnippets:
+        pass

--- a/doc/movies/gen_targets.py
+++ b/doc/movies/gen_targets.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from os import getenv, sep
+from pathlib import Path
+
+root, snippets = Path(getenv("coq_root")), Path(getenv("snippets_root"))
+
+RULE = """
+{}: {}
+	$(alectryon) "$<"
+	@touch "$@"
+"""
+
+targets = []
+
+for coqfile in root.glob('**/*.v'):
+    pth = coqfile.relative_to(root)
+    target = str(snippets / pth.stem) + sep
+    targets.append(target)
+    print(RULE.format(target, coqfile))
+
+print("targets := {}".format(" ".join(str(t) for t in targets)))

--- a/theories/ordinals/Ackermann/primRec.v
+++ b/theories/ordinals/Ackermann/primRec.v
@@ -318,11 +318,10 @@ Qed.
 
 (** ** Usual projections (in curried form) are primitive recursive *)
 
-(*| 
-.. coq:: no-out 
-|*)
-
 (* begin snippet idIsPR *)
+(*|
+.. coq:: no-out
+|*)
 
 Lemma idIsPR : isPR 1 (fun x : nat => x).
 Proof.
@@ -330,9 +329,8 @@ Proof.
   exists (projFunc 1 0 H); cbn; auto.
 Qed.
 
-(* end snippet idIsPR *)
-
 (*||*)
+(* end snippet idIsPR *)
 
 Lemma pi1_2IsPR : isPR 2 (fun a b : nat => a).
 Proof.

--- a/theories/ordinals/Epsilon0/E0.v
+++ b/theories/ordinals/Epsilon0/E0.v
@@ -79,7 +79,6 @@ Proof.
   refine (@mkord (T1.succ (@cnf alpha)) _); 
   apply succ_nf, cnf_ok.
 Defined.
-(*||*)
 
 
 

--- a/theories/ordinals/Hydra/Hydra_Theorems.v
+++ b/theories/ordinals/Hydra/Hydra_Theorems.v
@@ -14,6 +14,7 @@ Import E0 Large_Sets Hprime Paths MoreLists  O2H Hydra_Definitions Iterates.
 (* begin snippet AliveThms *)
 
 Theorem Alive_free :   Alive free. (* .no-out *)
+
 (*|
 .. coq:: none 
 |*)

--- a/theories/ordinals/MoreAck/AckNotPR.v
+++ b/theories/ordinals/MoreAck/AckNotPR.v
@@ -19,11 +19,10 @@ Import extEqualNat  VectorNotations.
 
  *)
 
+(* begin snippet vApply *)
 (*|
 .. coq:: no-out
 |*)
-
-(* begin snippet vApply *)
 
 Notation "'v_apply' f v" := (evalList _ v f) (at level 10, f at level 9).
 
@@ -40,9 +39,8 @@ Proof.
   intros; now cbn.
 Qed.
 
-(* end snippet vApply *)
-
 (*||*)
+(* end snippet vApply *)
 
 (*  begin snippet majorizedDefs *)
 
@@ -253,8 +251,8 @@ Proof.
         intro H2;lia.
       * rewrite max_comm; apply nested_Ack_bound.
  
-  (*||*)
   (* begin snippet majorAnyPRb *)
+  (*||*)
         
   -  (* .no-out *)  destruct IHx1 as [r Hg]; destruct IHx2 as [s Hh]. (* .no-out *)
 
@@ -333,9 +331,6 @@ Proof.
    -  (* .no-out *) red;cbn;  red; exists 0. (* .none *)
     intro; rewrite Ack_0;  cbn; auto with arith. (* .none *)
   - (* .no-out *) red; cbn; red; destruct IHx, IHx0; exists (max x0 x1).
-(*|
-.. coq:: none
-|*)
     intros v;  cbn; specialize (H0 v).
     pose (X :=
             (max_v (map (fun f : naryFunc n => v_apply f v)
@@ -347,8 +342,7 @@ Proof.
       *  apply Ack_mono_l; apply le_max_l.
     + transitivity (Ack x1 (max_v v)); auto.
       * apply Ack_mono_l; apply le_max_r.
-(*||*)
-Qed. 
+Qed.
 
 
 

--- a/theories/ordinals/MoreAck/PrimRecExamples.v
+++ b/theories/ordinals/MoreAck/PrimRecExamples.v
@@ -54,11 +54,10 @@ Qed.
 
 (** ** Examples of terms of type [PrimRec n] and their interpretation *)
 
+(* begin snippet evalPrimRecEx  *)
 (*|
 .. coq:: no-out
 |*)
-
-(* begin snippet evalPrimRecEx  *)
 
 Example Ex1 : evalPrimRec 0 zeroFunc = 0.
 Proof. reflexivity. Qed.
@@ -136,9 +135,8 @@ primRecFunc 0
                                   (PRnil 3))
                           succFunc))))).
 
-(* end snippet bigPRa  *)
-
 (*||*)
+(* end snippet bigPRa  *)
 
 (* begin snippet bigPRb  *)
 Example  mystery_fun : nat -> nat := evalPrimRec 1 bigPR.
@@ -250,11 +248,11 @@ Qed.
 
 (* end snippet zeroIsPR *)
 
+(* begin snippet SuccIsPR *)
+
 (*|
 .. coq:: no-out
 |*)
-
-(* begin snippet SuccIsPR *)
 
 Lemma SuccIsPR : isPR 1 S.
 Proof.
@@ -265,6 +263,10 @@ Qed.
 
 (* begin snippet pi25IsPR *)
 
+(*|
+.. coq:: no-out
+|*)
+
 Lemma pi2_5IsPR : isPR 5 (fun a b c d e => b).
 Proof.
  assert (H: 3 < 5) by auto.
@@ -272,9 +274,9 @@ Proof.
  cbn; reflexivity.
 Qed.
 
-(* end snippet pi25IsPR *)
-
 (*||*)
+
+(* end snippet pi25IsPR *)
 
 Check composeFunc 0 1.
 

--- a/theories/ordinals/OrdinalNotations/ON_Finite.v
+++ b/theories/ordinals/OrdinalNotations/ON_Finite.v
@@ -291,22 +291,3 @@ Proof. reflexivity. Qed.
 
 Example Ex1 : In  (bigO beta1) alpha1.
 Proof. reflexivity. Qed.
-
-(* results in a CI error 
-
-(* begin snippet bad *)
-
-Program Definition bad : t 10 := 10.
-Next Obligation.
-  compute.
-Abort.
-
-(* end snippet bad *)
-
-
- *)
-
-
-
-
-


### PR DESCRIPTION
This is a follow-up to https://github.com/coq-community/hydra-battles/issues/70

With the change that I suggested there, I was able to refactor the movies script into a standard Alectryon pipeline, with just a few custom actions to isolate snippets in the source `.v` file.

@Casteran I tried to make a minimally invasive patch, so I didn't touch the source files.  Instead I just made the code look for existing `(*| .. coq:: …flags… |*)` annotations and propagate the corresponding flags.

I kept the folder structure, and AFAICT the only differences are spaces; I hope I didn't miss anything (I made it so that spaces before and after snippets get stripped (which is a bit tricky due to `(*| .. coq |*)` visibility annotations).

This pipeline doesn't go through reST at all.  `(*| .. coq |*)` visibility annotations outside of snippets are ignores.  Visibility settings get reset after each snippet, so `(*||*)` can be useful in the middle of a snippet but is not needed at the end of a snippet.

The syntax `(* begin snippet ABC:: …flags… *)` is supported but not used (to avoid a larger diff than necessary.

@Zimmi48 I need your help to pull the latest Alectryon.