### PR TITLE
[doc] Add an \inputsnippets command and demo it in Schutte/AP.v

### DIFF
--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 fetchTarball {
-         url = https://github.com/Zimmi48/nixpkgs/archive/b454dafa6170cdd170d7513b845fe9eea05ad77c.tar.gz;
-         sha256 = "0fasks1d1afg48zwfp1952w54wz5jkk07mgp5mr3ca240npfchpq";
+         url = https://github.com/Zimmi48/nixpkgs/archive/1092468cb7115327cbef339e3b1185b37fb375b0.tar.gz;
+         sha256 = "1c5d01qcjcsf01hww09xjz7wcsxsfqffczwrrz52v99c5y5d0lpm";
        }

--- a/doc/hydras.tex
+++ b/doc/hydras.tex
@@ -43,6 +43,20 @@
 \renewcommand{\alectryon@hyps@sep}{\alectryon@nl}
 \makeatother
 
+%%% \snippets{A,B,C,…} inputs a series of snippets as one block (with \itemsep
+%%% between them).  A, B, C should be paths to files in movies/snippets/.
+\usepackage{etoolbox}
+\makeatletter
+\newcommand{\inputsnippets}[1]
+  {{\setlength{\itemsep}{1pt}\setlength{\parsep}{0pt}% Adjust spacing
+    \alectryon@copymacros\begin{io}
+      \forcsvlist{\item\@inputsnippet}{#1}
+    \end{io}}}
+\let\input@old\input % Save definition of \input
+\newcommand{\@inputsnippet}[1]
+  {{\renewenvironment{alectryon}{}{}% Skip \begin{alectryon} included in snippet
+    \input@old{movies/snippets/#1}}}
+\makeatother
 
 \SetWatermarkLightness{0.8}
 \definecolor{lightorange}{rgb}{1,0.9,0.9}

--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -6620,8 +6620,7 @@ The rest of our library \texttt{AP} is devoted to the proof of properties of add
 
 The set of additive principal ordinals is not empty: it contains at least the ordinals  $1$ and  $\omega$. 
 
-\input{movies/snippets/AP/APOne}
-
+\inputsnippets{AP/APOne,AP/APOne_least_AP,AP/APOne_AP_omega,AP/APOne_omega_second_AP}
 
 The set  \texttt{AP} is  \emph{closed} under addition, and unbounded.
 

--- a/theories/ordinals/Schutte/AP.v
+++ b/theories/ordinals/Schutte/AP.v
@@ -78,10 +78,9 @@ Definition epsilon0 := omega_limit omega_tower.
 
 (** ** About additive principals *)
 
-(* begin snippet APOne *)
-
-Lemma AP_one : In AP 1. (* .no-out *)
-(*| .. coq:: none |*)
+(* begin snippet APOne:: no-out *)
+Lemma AP_one : In AP 1.
+(* end snippet APOne *)
 Proof with auto with schutte.
   split.
   -  simpl (F 1) ...
@@ -90,10 +89,10 @@ Proof with auto with schutte.
      { apply lt_succ_le_2 ... }
      rewrite (le_alpha_zero H0), zero_plus_alpha...
 Qed.
-(*||*)
 
-Lemma least_AP :least_member  lt AP 1. (* .no-out *)
-(*| .. coq:: none |*)
+(* begin snippet APOne_least_AP:: no-out *)
+Lemma least_AP : least_member lt AP 1.
+(* end snippet APOne_least_AP *)
 Proof with auto with schutte.
   repeat split ...
   - simpl (F 1) ...
@@ -108,10 +107,10 @@ Proof with auto with schutte.
     subst x; left; trivial.
     right; auto.
 Qed.
-(*||*)
 
-Lemma AP_omega : In AP omega. (* .no-out *)
-(*| .. coq:: none |*)
+(* begin snippet APOne_AP_omega:: no-out *)
+Lemma AP_omega : In AP omega.
+(* end snippet APOne_AP_omega *)
 Proof with auto with schutte.
   repeat split.
   - apply lt_trans with (F 1).
@@ -140,13 +139,13 @@ Proof with auto with schutte.
 Qed.
 
 (** Thus, omega is the second additive principal *)
-(*||*)
 
+(* begin snippet APOne_omega_second_AP:: no-out *)
 Lemma omega_second_AP :
-  least_member   lt 
-                 (fun alpha => 1 < alpha /\ In AP alpha)
-                 omega. (* .no-out *)
-(*| .. coq:: none |*)
+  least_member lt
+               (fun alpha => 1 < alpha /\ In AP alpha)
+               omega.
+(* end snippet APOne_omega_second_AP *)
 Proof with auto with schutte.
   split  ...
   split ...
@@ -162,10 +161,6 @@ Proof with auto with schutte.
      red.
      intuition.
 Qed.
-(*||*)
-(* end snippet APOne *)
-
-
 
 (* begin snippet APPlusClosed *)
 


### PR DESCRIPTION
As discussed in https://github.com/coq-community/hydra-battles/issues/70 ; see the diff.
I'll need @Zimmi48 to fetch the latest Alectryon for this to work, though :innocent: 