### PR TITLE
split TotalDecPreorder into TotalPreOrder and Decision typeclasses

### DIFF
--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -1044,23 +1044,25 @@ Proof.
   - right; apply le_lt_eq ; now left. 
 Defined.
 
-
-Instance epsilon0_pre_order : TotalDecPreOrder (leq lt).
+Instance epsilon0_pre_order : TotalPreOrder (leq lt).
 Proof.
-  do 2 split.
+  split; [split|].
   - intro x; apply le_refl.
   - red; apply le_trans.
   - intros a b.
     destruct (lt_le_dec a b).
     + now do 2 left.
     + now right.
-  - intros a b.
-    destruct (lt_eq_lt_dec a b) as [[Hlt | Heq] | Hgt].
-    + now do 2 left.
-    + subst; now left; right.
-    + right; now apply lt_not_ge.
 Defined.
 
+Instance epsilon0_dec : RelDecision (leq lt).
+Proof.
+intros a b.
+destruct (lt_eq_lt_dec a b) as [[Hlt | Heq] | Hgt].
++ now do 2 left.
++ subst; now left; right.
++ right; now apply lt_not_ge.
+Defined.
 
 Ltac auto_nf :=
   match goal with

--- a/theories/ordinals/Prelude/Sort_spec.v
+++ b/theories/ordinals/Prelude/Sort_spec.v
@@ -132,16 +132,15 @@ Global Hint Constructors LocallySorted : lists.
 (** A sort must work on any decidable total pre-order *)
 
 Definition sort_spec (f : sort_fun_t) :=
-forall  (A:Type)(le:relation A)(P:TotalDecPreOrder le)
-        (l:list A),
-    let l' := f A (leb le) l in Permutation l l' /\ LocallySorted le l'.
+ forall (A:Type) (le:relation A) (P:TotalPreOrder le) (dec:RelDecision le) (l:list A),
+ let l' := f A (fun x y => bool_decide (le x y)) l in Permutation l l' /\ LocallySorted le l'.
 
 (** A prototype for using TotalDecPreOrder type class *)
 
 Definition sort (f:sort_fun_t)
-           {A} {le : relation A}{P: TotalDecPreOrder le}
-           (l: list A) :=
-  f A (leb le) l.
+ {A} {le : relation A} {P: TotalPreOrder le} {dec:RelDecision le}
+ (l: list A) :=
+  f A (fun x y => bool_decide (le x y)) l.
 
 
 
@@ -157,15 +156,12 @@ list (A * B) -> Prop :=
                            leA a a' -> lt  b b') ->
             marked leA leB ((a,b)::l).
 
-
-
 Definition stable (f : sort_fun_t) : Prop :=
-  forall (A B : Type) leA leB (PA : TotalDecPreOrder leA)
-         (PB : TotalDecPreOrder leB)
-         (l : list (A * B)),
+  forall (A B : Type) leA leB
+    (PA : TotalPreOrder leA) (PB : TotalPreOrder leB)
+    (dec : RelDecision leA) (l : list (A * B)),
          marked leA leB l ->
-         marked leA  leB
-                (sort f  (P:= TotalDec_Inverse_fun
+         marked leA leB (sort f  (P:= Total_Inverse_fun
                                 (f:= fst : A * B -> A))
                       l).
                            
@@ -179,10 +175,10 @@ end.
 
 
 Definition stable_test (f : sort_fun_t)
-      {A} {le : relation A}{P: TotalDecPreOrder le}
+      {A} {le : relation A}{P: TotalPreOrder le} {dec:RelDecision le}
            (l: list A) : list (A  * nat)                                                               :=
     let m := mark l 0 in
-      sort f  (P:= @TotalDec_Inverse_fun (A * nat) A fst le P) m. 
+      sort f  (P:= @Total_Inverse_fun (A * nat) A fst le P) m.
 
 
 


### PR DESCRIPTION
This is the first PR following the discussion in #74. It introduces the `Decision` typeclass originally defined by Spitters and van der Weegen (and currently used in the stdpp library) and unbundles the `TotalDecPreOrder` class. I also removed some superfluous boolean manipulation - the preferred way is to use `Decision` instances whenever possible. I kept the old bundled `TotalDecPreOrder` definition but masked it in the module `Semibundled`.