### PR TITLE
add Compare operational typeclass

### DIFF
--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -1701,24 +1701,25 @@ to Schütte's model.
 
 
 
-\subsection{A class for ordinal notations}
+\subsection{Classes for ordinal notations}
 
 From the \coq{} user's point of view, an ordinal notation is
 a structure allowing to compare two ordinals by computation, and proving by well-founded induction.
 
-\subsubsection{The \texttt{Comparable class}}
+\subsubsection{The \texttt{Comparison} and \texttt{Comparable} classes}
 
-The following class, contributed by Jérémy Damour and Théo Zimmermann, allows us to apply generic lemmas and tactics
-about decidable strict orders.
+We use the operational class \texttt{Comparison} of comparison functions to define the \texttt{Comparable} class, contributed by Jérémy Damour and Théo Zimmermann, which allows us to apply generic lemmas and tactics about decidable strict orders.
 The correctness of the comparison function is expressed through Stdlib's type 
-\texttt{Datatypes.CompareSpec}.
-
+\texttt{Datatypes.CompareSpec} as specialized by \texttt{Datatypes.CompSpec}.
 
 \begin{Coqsrc}
 Inductive CompareSpec (Peq Plt Pgt : Prop) : comparison -> Prop :=
     CompEq : Peq -> CompareSpec Peq Plt Pgt Eq
   | CompLt : Plt -> CompareSpec Peq Plt Pgt Lt
   | CompGt : Pgt -> CompareSpec Peq Plt Pgt Gt.
+
+Definition CompSpec {A} (eq lt : A->A->Prop)(x y:A) : comparison -> Prop :=
+ CompareSpec (eq x y) (lt x y) (lt y x).
 \end{Coqsrc}
 
 \emph{From Module~\href{../theories/html/hydras.Prelude/mparable.html\#Hvariant}{Prelude.Comparable}}

--- a/theories/gaia/T1Bridge.v
+++ b/theories/gaia/T1Bridge.v
@@ -1,9 +1,7 @@
 (**  * Bridge between Hydra-battle's and Gaia's [T1]  (Experimental) 
  *)
 
-
-
-
+From hydras Require Import DecPreOrder.
 From hydras Require T1.
 From mathcomp Require Import all_ssreflect zify.
 From gaia Require Import ssete9.
@@ -286,18 +284,17 @@ Proof.
   by rewrite -(pi_iota a) -(pi_iota b) -(pi_iota c) !mult_refR mulA. 
 Qed.
 
-
 Lemma Comparable_T1lt_eq a b:
-  DecPreOrder.bool_decide (T1.lt a b) = (iota a < iota b).
+  bool_decide (T1.lt a b) = (iota a < iota b).
 Proof.
   rewrite /T1.lt; generalize (compare_ref a b);
   rewrite /Comparable.compare /=.
-  destruct (DecPreOrder.decide (T1.compare_T1 a b = Lt)).
-  - pose proof e as bd.
-    apply T1.bool_decide_eq_true in bd.
+  destruct (decide (T1.compare_T1 a b = Lt)).
+  - have bd := e.
+    apply (bool_decide_eq_true _) in bd.
     by rewrite bd e.
-  - pose proof n as bd.
-    apply T1.bool_decide_eq_false in bd.
+  - have bd := n.
+    apply (bool_decide_eq_false _) in bd.
     rewrite bd.
     destruct (T1.compare_T1 a b).
     * by move => ->; rewrite T1ltnn.
@@ -306,7 +303,7 @@ Proof.
       symmetry.
       apply/negP => Hlt'.
       have H1 : (iota b < iota b) by apply T1lt_trans with (iota a).
-      by rewrite T1ltnn in H1. 
+      by rewrite T1ltnn in H1.
 Qed.
 
 Lemma nf_ref a : T1.nf_b a = T1nf (iota a).
@@ -316,5 +313,3 @@ Proof.
     rewrite IHa IHb;  change (phi0 (iota a)) with (iota (T1.phi0 a)).
     by rewrite andbA Comparable_T1lt_eq.
 Qed.
-
- 

--- a/theories/ordinals/Epsilon0/Canon.v
+++ b/theories/ordinals/Epsilon0/Canon.v
@@ -13,6 +13,7 @@ Pierre Casteran,
 From Coq Require Export Arith Lia.
 Import Relations Relation_Operators.
 
+From hydras.Prelude Require Import DecPreOrder.
 From hydras.Epsilon0 Require Export T1 E0.
 
 Set Implicit Arguments.
@@ -916,7 +917,7 @@ Fixpoint  approx alpha beta fuel i :=
           FO => None
         | Fuel.FS f =>
           let gamma := canonS alpha i in
-          if lt_b beta gamma
+          if decide (lt beta gamma)
           then Some (i,gamma)
           else approx alpha beta  (f tt) (S i)
         end.
@@ -924,12 +925,12 @@ Fixpoint  approx alpha beta fuel i :=
 
 Lemma approx_ok alpha beta :
   forall fuel i j gamma, approx alpha beta fuel i = Some (j,gamma) ->
-                         gamma = canonS alpha j /\ lt_b beta gamma.
+                         gamma = canonS alpha j /\ lt beta gamma.
 Proof.
   induction fuel as [| f IHfuel ].
   - cbn; discriminate. 
   - intros i j gamma H0;  cbn in H0.
-    case_eq (lt_b beta (canonS alpha i));intro H1; rewrite H1 in *.
+    destruct (decide (lt beta (canonS alpha i))) as [H1|H1].
     + injection H0; intros; subst; split;auto.
     + now specialize (IHfuel tt (S i) _ _ H0).
 Qed.

--- a/theories/ordinals/Epsilon0/E0.v
+++ b/theories/ordinals/Epsilon0/E0.v
@@ -316,12 +316,11 @@ Proof.
     apply LT_trans.
  Qed.
 
-Definition compare (alpha beta:E0): comparison :=
-  T1.compare (cnf alpha) (cnf beta).
+Instance compare_E0 : Compare E0 :=
+ fun (alpha beta:E0) => compare (cnf alpha) (cnf beta).
 
-Lemma compare_correct alpha beta :
-  CompareSpec (alpha = beta) (alpha o< beta) (beta o< alpha)
-              (compare alpha beta).
+Lemma compare_correct (alpha beta : E0) :
+  CompSpec eq Lt alpha beta (compare alpha beta).
 Proof.
   destruct alpha, beta; unfold compare, Lt; cbn;
     destruct (T1.compare_correct cnf0 cnf1).

--- a/theories/ordinals/Epsilon0/Hessenberg.v
+++ b/theories/ordinals/Epsilon0/Hessenberg.v
@@ -359,8 +359,9 @@ Proof.
   - intros; rewrite (oplus_eqn  (ocons a n b) (ocons x1 n0 x2)).
     apply nf_helper_phi0 in H1.
     destruct (lt_inv H1).
-    + unfold T1.lt, lt_b in H2; rewrite compare_rev. 
-      destruct (compare x1 a);auto; try discriminate. 
+    + unfold T1.lt in H2.
+      rewrite compare_rev, H2.
+      reflexivity.
     + decompose [or and] H2.
       *  inversion H5.
       * T1_inversion H6.
@@ -522,7 +523,7 @@ Section Proof_of_oplus_lt1.
     -  simpl; auto with T1.
     - rewrite oplus_eqn;case_eq (compare x1 a1).
       +  auto with T1 arith. 
-      +  intros H2; apply head_lt; unfold T1.lt, lt_b; now  rewrite H2. 
+      +  intros H2; apply head_lt. unfold T1.lt; now  rewrite H2. 
       + intro; apply tail_lt,  H1 ;  trivial.
         eapply nf_inv2, H.
         now  apply tail_lt_ocons.
@@ -619,7 +620,7 @@ Proof with eauto with T1.
        absurd  (T1.lt (ocons a1 n0 b2) (ocons c1 n1 c2)).
        - apply lt_not_gt.
          apply head_lt.
-         unfold T1.lt, lt_b;rewrite compare_rev. now   rewrite H2.
+         unfold T1.lt;rewrite compare_rev. now   rewrite H2.
        -   auto.
      }
      {
@@ -652,7 +653,7 @@ Proof with eauto with T1.
            case_eq (compare a1 c2_1).
            intro.
            apply coeff_lt;  auto with arith. 
-           intro H6; apply head_lt; unfold T1.lt, lt_b; now rewrite H6.
+           intro H6; apply head_lt; unfold T1.lt; now rewrite H6.
            intros; apply tail_lt. 
            apply oplus_lt1; trivial.
            T1_inversion H5.

--- a/theories/ordinals/Epsilon0/Paths.v
+++ b/theories/ordinals/Epsilon0/Paths.v
@@ -2623,7 +2623,7 @@ Section Constant_to_standard_Proof.
 
   Instance P_dec i : Decision (P i).
   Proof.
-   destruct (standard_gnaw (S n) alpha i <?> beta) eqn:Hc.
+   destruct (compare (standard_gnaw (S n) alpha i) beta) eqn:Hc.
    - left; unfold P.
      rewrite Hc; discriminate.
    - right; unfold P.

--- a/theories/ordinals/Epsilon0/Paths.v
+++ b/theories/ordinals/Epsilon0/Paths.v
@@ -14,7 +14,7 @@
 
 (** TODO: Check wether the predicates ...PathS... are still useful *)
 
-Require Import Canon  MoreLists First_toggle OrdNotations.
+From hydras Require Import DecPreOrder Canon MoreLists First_toggle OrdNotations.
 Import Relations Relation_Operators.
 From Coq Require Import Lia.
 
@@ -2592,23 +2592,22 @@ Section Constant_to_standard_Proof.
     unfold t; pattern (proj1_sig Rem2); apply proj2_sig.
   Qed. 
 
-  Let P (i:nat) := le_b beta (standard_gnaw (S n) alpha i).
+  Let P (i:nat) := compare (standard_gnaw (S n) alpha i) beta <> Datatypes.Lt.
 
   Remark Rem04 : P 0.
   Proof.
-    unfold P;red; simpl.  
-    unfold le_b, lt_b.
-    eenough (T1.compare alpha beta = Datatypes.Gt) as -> by auto.
+    unfold P;red; simpl.
+    enough (Hgt: (compare alpha beta = Datatypes.Gt)) by congruence.
     apply compare_gt_iff.
     generalize (const_pathS_LT Halpha Hpa).
     destruct 1; tauto.
-  Qed. 
+  Qed.
 
 
-  Remark Rem05 : P t = false.
+  Remark Rem05 : ~ P t.
   Proof.
-    unfold P, le_b, lt_b;
-    enough(T1.compare (standard_gnaw (S n) alpha t) beta = Datatypes.Lt) as -> by reflexivity.
+    unfold P.
+    enough (compare (standard_gnaw (S n) alpha t) beta = Datatypes.Lt) by congruence.
     apply compare_lt_iff.
     destruct Rem03; tauto.
   Qed.
@@ -2621,8 +2620,21 @@ Section Constant_to_standard_Proof.
        eapply const_pathS_LT; eauto.
     - auto with arith. 
   Qed.
+
+  Instance P_dec i : Decision (P i).
+  Proof.
+   destruct (standard_gnaw (S n) alpha i <?> beta) eqn:Hc.
+   - left; unfold P.
+     rewrite Hc; discriminate.
+   - right; unfold P.
+     rewrite Hc.
+     intro H.
+     contradiction.
+   - left; unfold P.
+     rewrite Hc; discriminate.
+  Defined.
   
-  Let l_def :=  first_toggle P 0 t  Rem06 Rem04 Rem05.
+  Let l_def :=  first_toggle P P_dec 0 t  Rem06 Rem04 Rem05.
 
   Let l := proj1_sig l_def.
   
@@ -2633,7 +2645,7 @@ Section Constant_to_standard_Proof.
     (l < t)%nat /\
     (forall i : nat,
         (0 <= i)%nat ->
-        (i <= l)%nat -> P i = true) /\ P (S l) = false.
+        (i <= l)%nat -> P i) /\ ~ P (S l).
   Proof.
     unfold l; pattern (proj1_sig l_def); apply proj2_sig.
   Qed.
@@ -2641,13 +2653,13 @@ Section Constant_to_standard_Proof.
   Remark Rem09 : (l < t)%nat.
   Proof.   destruct Rem08; tauto. Qed.
 
-  Remark Rem10 : P l = true.
+  Remark Rem10 : P l.
   Proof.
     destruct Rem08 as [H H0];decompose [and] H0.
     apply H3; auto with arith.
   Qed.
   
-  Remark Rem11 : P (S l) = false.
+  Remark Rem11 : ~ P (S l).
   Proof.
     destruct Rem08 as [H H0]; now decompose [and] H0.  
   Qed.
@@ -2726,13 +2738,13 @@ Section Constant_to_standard_Proof.
 
   Remark R19 : beta t1<= gamma.
   Proof.
-    generalize Rem10; unfold P; fold gamma ;unfold le_b, lt_b.
+    generalize Rem10; unfold P; fold gamma.
     intro H.
-    destruct (T1.compare gamma beta) eqn: Hcomp.
+    destruct (compare gamma beta) eqn: Hcomp.
     - apply compare_eq_iff in Hcomp as ->.
       apply LE_refl.
       eapply LT_nf_r; eauto.
-    - intros; discriminate.
+    - contradiction.
     - apply LE_r.
       rewrite compare_gt_iff in Hcomp; repeat split; auto.
       + eapply LT_nf_r; eauto.
@@ -2787,15 +2799,14 @@ Section Constant_to_standard_Proof.
 
    Remark R25 : delta t1< beta.
   Proof.
-    rewrite R22; generalize Rem11;unfold P; intro H;
-      unfold le_b, lt_b in H.
-    destruct( T1.compare (standard_gnaw (S n) alpha (S l)) beta) eqn: H0.
-    - discriminate.
+    rewrite R22; generalize Rem11;unfold P; intro H.      
+    destruct(compare (standard_gnaw (S n) alpha (S l)) beta) eqn: H0.
+    - contradict H; congruence.
     - rewrite compare_lt_iff in H0.
        repeat split;auto.
        +  apply standard_gnaw_nf;auto.
        +  eapply LT_nf_r; eauto.
-    - discriminate.
+    - contradict H; congruence.
   Qed.
 
    Remark R26 : ~ const_pathS (n+l) gamma beta.
@@ -3021,7 +3032,7 @@ Proof.
      red in H0;unfold E0.cnf; simpl in *.
      destruct beta.
      + destruct H; now apply E0_eq_intro.
-     + destruct (T1.compare alpha beta1) eqn:H2.
+     + destruct (compare alpha beta1) eqn:H2.
          * unfold lt in H1; simpl in H1.
            rewrite compare_eq_iff in H2;  subst beta1.
            destruct (LT_inv H1).

--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -679,18 +679,6 @@ Lemma single_nf :
   forall a n, nf a -> nf (ocons a n zero).
 Proof.   unfold nf; now cbn. Qed. 
 
-Lemma bool_decide_eq_true (P : Prop) `{Decision P} : bool_decide P = true <-> P.
-Proof.
-  unfold bool_decide.
-  destruct H; intuition discriminate.
-Qed.
-
-Lemma bool_decide_eq_false (P : Prop) `{Decision P} : bool_decide P = false <-> ~P.
-Proof. 
-  unfold bool_decide.
-  destruct H; intuition discriminate.
-Qed.
-
 Lemma ocons_nf :
   forall a n a' n' b, 
   lt a' a ->
@@ -700,9 +688,8 @@ Lemma ocons_nf :
 Proof.
   unfold nf.
   simpl.
-  intros a n a' n' b' Hlta Ha.  
-  apply bool_decide_eq_true in Hlta.
-  rewrite Hlta.
+  intros a n a' n' b' Hlta Ha.
+  apply (bool_decide_eq_true _) in Hlta.
   destruct b'.
   - intro Hnfa'.
     now rewrite Ha, Hnfa'.
@@ -739,7 +726,7 @@ Proof.
   unfold nf; cbn;
   destruct a, a', b'; try discriminate; auto with T1;
   intro H; red in H; repeat rewrite andb_true_iff in H; 
-  decompose [and] H; apply bool_decide_eq_true; auto.
+  decompose [and] H; apply (bool_decide_eq_true _); auto.
 Qed.
 
 
@@ -786,12 +773,12 @@ Proof.
     intro H; rewrite H.
   destruct (decide (lt b (phi0 a))) as [Hdec|Hdec].
   - pose proof Hdec as Heq.
-    rewrite <- bool_decide_eq_true in Heq.
+    rewrite <- (bool_decide_eq_true _) in Heq.
     split; case (nf_b a); case (nf_b b);
       cbn; auto with bool; intros H0;
         decompose [and] H0; try discriminate.
   - pose proof Hdec as Heq.
-    rewrite <- bool_decide_eq_false in Heq.
+    rewrite <- (bool_decide_eq_false _) in Heq.
     rewrite Heq.
     split; intro H0; repeat rewrite andb_true_iff in H0; 
        decompose [and] H0; [congruence|].

--- a/theories/ordinals/Epsilon0/T1.v
+++ b/theories/ordinals/Epsilon0/T1.v
@@ -146,24 +146,24 @@ Inductive ap : T1 -> Prop :=
  *)
 
 (* begin snippet compareDef *)
-
-Fixpoint compare (alpha beta:T1):comparison :=
+Instance compare_T1 : Compare T1 :=
+ fix cmp (alpha beta:T1) :=
   match alpha, beta with
   | zero, zero => Eq
   | zero, ocons a' n' b' => Lt
   | _   , zero => Gt
   | (ocons a n b),(ocons a' n' b') =>
-      (match compare a a' with 
+      (match cmp a a' with
        | Lt => Lt
        | Gt => Gt
-       | Eq => (match Nat.compare n n' with
-                | Eq => compare b b'
+       | Eq => (match n ?= n' with
+                | Eq => cmp b b'
                 | comp => comp
                 end)
        end)
   end.
 
-Definition lt alpha beta : Prop :=
+Definition lt (alpha beta : T1) : Prop :=
   compare alpha beta = Lt.
 (* end snippet compareDef *)
 
@@ -177,23 +177,37 @@ Proof. discriminate.  Qed.
 
 (** ** Properties of [compare] *)
 
+Lemma compare_ocons : 
+ forall a n b a' n' b',
+ compare (ocons a n b) (ocons a' n' b') =
+ match compare a a' with
+ | Lt => Lt
+ | Gt => Gt
+ | Eq => (match n ?= n' with
+        | Eq => compare b b'
+        | comp => comp
+        end)
+ end.
+Proof.
+intros; reflexivity.
+Qed.
+
 (* begin snippet compareRev *)
 
 Lemma compare_rev :
-  forall alpha beta,
+  forall (alpha beta : T1),
   compare beta alpha = CompOpp (compare alpha beta). (* .no-out *)
 Proof. (* .no-out *)
   induction alpha, beta. (* .unfold -.g#* .g#1 *)
   (* end snippet compareRev *)
-  
+
   1-3: easy.
-  simpl.
+  rewrite !compare_ocons.
   rewrite IHalpha1, Nat.compare_antisym.
-  destruct (compare alpha1 beta1).
+  destruct (compare alpha1 beta1); simpl.
   2-3: easy.
   now destruct (n ?= n0) eqn:?; simpl.
 Qed.
-
 
 Lemma compare_reflect :
   forall alpha beta,
@@ -205,9 +219,9 @@ Lemma compare_reflect :
 Proof.
   unfold lt; induction alpha, beta.
   1-3: easy.
-  simpl.
   specialize (IHalpha1 beta1).
   specialize (IHalpha2 beta2).
+  rewrite !compare_ocons.
   rewrite compare_rev with alpha1 beta1,
           compare_rev with alpha2 beta2,
           Nat.compare_antisym in *.
@@ -220,8 +234,7 @@ Proof.
 Qed.
 
 Lemma compare_correct (alpha beta: T1):
-  CompareSpec (alpha = beta) (lt alpha beta) (lt beta alpha)
-              (compare alpha beta).
+  CompSpec eq lt alpha beta (compare alpha beta).
 Proof.
   unfold lt.
   generalize (compare_reflect alpha beta).
@@ -231,14 +244,14 @@ Qed.
 (** ** Properties of Eq *)
 
 Lemma compare_refl :
-  forall alpha, compare alpha alpha = Eq.
+  forall alpha : T1, compare alpha alpha = Eq.
 Proof.
  induction alpha; cbn; auto.
  rewrite IHalpha1, IHalpha2.
  now rewrite Nat.compare_refl.
 Qed.
 
-Lemma compare_eq_iff a b : 
+Lemma compare_eq_iff (a b : T1) : 
   compare a b = Eq <-> a = b.
 Proof.
   split; intro H.
@@ -283,7 +296,7 @@ Lemma lt_inv_strong :
   lt_cases a b n a' b' n'.
 Proof.
   unfold lt.
-  intros; simpl in H.
+  intros; rewrite compare_ocons in H.
   destruct (compare a a') eqn:Ha.
   - apply compare_eq_iff in Ha as ->.
     destruct (n ?= n') eqn:?.
@@ -371,7 +384,7 @@ Lemma head_lt :
 Proof.
   unfold lt.
   intros * H.
-  simpl.
+  rewrite compare_ocons.
   now rewrite H.
 Qed.
 
@@ -381,7 +394,7 @@ Lemma coeff_lt :
 Proof.
   unfold lt.
   intros * H.
-  simpl.
+  rewrite compare_ocons.
   rewrite compare_refl.
   now apply Nat.compare_lt_iff in H as ->.
 Qed.
@@ -395,7 +408,7 @@ Lemma tail_lt :
 Proof.
   unfold lt.
   intros * H.
-  simpl.
+  rewrite compare_ocons.
   now rewrite compare_refl, Nat.compare_refl.
 Qed.
 
@@ -407,8 +420,8 @@ Lemma compare_fin_rw (n n1: nat) :
   - easy.
   - now cbn.
   - now cbn.
-  - cbn; case (n ?= n1); trivial.
-Qed. 
+  - cbn; unfold compare; case (n ?= n1); trivial.
+Qed.
 
 Lemma lt_fin_iff (i j : nat): lt (fin i) (fin j) <-> Nat.lt i j.
 Proof.
@@ -417,9 +430,11 @@ Proof.
   - split; [ auto with arith| cbn; constructor ].
   - split; inversion 1.
   - split; inversion 1.
-     + destruct (Nat.compare_spec i j); try discriminate.
-        auto with arith. 
-     +   apply coeff_lt; auto with arith.   
+     + unfold compare in H1.
+       simpl in H1.
+       destruct (Nat.compare_spec i j); try discriminate.
+       auto with arith. 
+     + apply coeff_lt; auto with arith.
      + apply coeff_lt; lia.
 Qed.
 
@@ -490,6 +505,9 @@ Qed.
 Cantor normal form needs the exponents of omega to be
    in strict decreasing order *)
 
+Instance lt_dec : RelDecision lt :=
+fun alpha beta => decide (compare alpha beta = Lt).
+
 (* begin snippet nfDef *)
 
 Fixpoint nf_b (alpha : T1) : bool :=
@@ -497,7 +515,7 @@ Fixpoint nf_b (alpha : T1) : bool :=
   | zero => true
   | ocons a n zero => nf_b a
   | ocons a n ((ocons a' n' b') as b) =>
-      (nf_b a && nf_b b && lt_b a' a)%bool
+      (nf_b a && nf_b b && (bool_decide (lt a' a)))%bool
   end.
 
 Definition nf alpha :Prop := 
@@ -661,6 +679,18 @@ Lemma single_nf :
   forall a n, nf a -> nf (ocons a n zero).
 Proof.   unfold nf; now cbn. Qed. 
 
+Lemma bool_decide_eq_true (P : Prop) `{Decision P} : bool_decide P = true <-> P.
+Proof.
+  unfold bool_decide.
+  destruct H; intuition discriminate.
+Qed.
+
+Lemma bool_decide_eq_false (P : Prop) `{Decision P} : bool_decide P = false <-> ~P.
+Proof. 
+  unfold bool_decide.
+  destruct H; intuition discriminate.
+Qed.
+
 Lemma ocons_nf :
   forall a n a' n' b, 
   lt a' a ->
@@ -670,8 +700,9 @@ Lemma ocons_nf :
 Proof.
   unfold nf.
   simpl.
-  intros a n a' n' b' Hlta Ha.
-  apply lt_b_iff in Hlta as ->.
+  intros a n a' n' b' Hlta Ha.  
+  apply bool_decide_eq_true in Hlta.
+  rewrite Hlta.
   destruct b'.
   - intro Hnfa'.
     now rewrite Ha, Hnfa'.
@@ -708,7 +739,7 @@ Proof.
   unfold nf; cbn;
   destruct a, a', b'; try discriminate; auto with T1;
   intro H; red in H; repeat rewrite andb_true_iff in H; 
-  decompose [and] H; apply lt_b_iff; auto.
+  decompose [and] H; apply bool_decide_eq_true; auto.
 Qed.
 
 
@@ -719,7 +750,8 @@ Proof.
   -  repeat split; auto with T1.
   - intro H; red in H; repeat rewrite andb_true_iff in H;
    decompose [and]  H; repeat split; auto.
-   red; cbn; unfold lt_b in H1; destruct (compare b1 a); try discriminate. 
+   apply bool_decide_eq_true in H1; red in H1.
+   red; cbn; destruct (compare b1 a); try discriminate. 
    trivial. 
 Qed. 
 
@@ -747,26 +779,24 @@ Proof.
     assert (false)  by (now apply H0);  discriminate.
 Qed.
 
-
-Lemma lt_b_lt_iff a b : lt_b a b <-> lt a b.
-Proof.
-  split.
-  - intro H;red in H; now rewrite lt_b_iff in H.  
-  - intro; red; now rewrite  lt_b_iff.
-Qed.
-
-
 Lemma nf_b_cons_eq a n b : nf_b (ocons a n b) =
-                           nf_b a && nf_b b && lt_b b (phi0 a).
+                           nf_b a && nf_b b && bool_decide (lt b (phi0 a)).
 Proof.
   rewrite bool_eq_iff; generalize (nf_cons_iff a n b); unfold nf;
     intro H; rewrite H.
-  rewrite <- lt_b_lt_iff; split. 
-  -  case (nf_b a); case (nf_b b); case_eq (lt_b b (phi0 a));
-       cbn; auto with bool;
-         intros _ H0; decompose [and] H0; try discriminate.
-  -  intro H0;  red in H0; repeat rewrite andb_true_iff in H0; 
-       decompose [and] H0;  now rewrite H2, H3, H4.
+  destruct (decide (lt b (phi0 a))) as [Hdec|Hdec].
+  - pose proof Hdec as Heq.
+    rewrite <- bool_decide_eq_true in Heq.
+    split; case (nf_b a); case (nf_b b);
+      cbn; auto with bool; intros H0;
+        decompose [and] H0; try discriminate.
+  - pose proof Hdec as Heq.
+    rewrite <- bool_decide_eq_false in Heq.
+    rewrite Heq.
+    split; intro H0; repeat rewrite andb_true_iff in H0; 
+       decompose [and] H0; [congruence|].
+    rewrite andb_false_r in H0.
+    discriminate.
 Qed.
 
       
@@ -863,7 +893,7 @@ Proof.
   intros; simpl in H. unfold lt in H.
   destruct (compare _ _) eqn:?.
   1,3: easy.
-  simpl in *.
+  unfold compare in Heqc; simpl in Heqc.
   destruct (n ?= p) eqn:?.
   1,3: easy.
   now apply Nat.compare_lt_iff.
@@ -1141,7 +1171,7 @@ Proof.
   - red in H.
     repeat rewrite andb_true_iff in H. 
     destruct H as ((_, _), Hlt).
-    apply lt_b_iff in Hlt.
+    apply bool_decide_eq_true in Hlt.
     now right.
 Qed.
 
@@ -2035,6 +2065,7 @@ Proof.
     1-3: discriminate.
     simpl.
     intros * Hnf_1 Hnf_2.
+    rewrite compare_ocons.
     destruct (compare alpha0 alpha) eqn:?.
     2-3: easy.
     destruct (n2 ?= n1) eqn:?.
@@ -2707,7 +2738,7 @@ Proof.
     + assert (H0 :alpha2 = zero).
       { eapply nf_of_finite; eauto. }
       subst; rewrite plus_compat; f_equal;  ring.
-    + simpl; repeat rewrite compare_refl. rewrite Nat.compare_refl.
+    + simpl; repeat rewrite compare_refl. 
       f_equal; lia.
 Qed.
 
@@ -3882,26 +3913,33 @@ Section Proof_of_dist.
     destruct b1, a1; try destruct c1; simpl.
     5,7,9,11,13-16: now apply not_lt_zero in Hcomp_b1_c1.
     - f_equal; lia.
-    - rewrite Nat.compare_refl, !compare_refl.
+    - rewrite compare_ocons.
+      rewrite Nat.compare_refl, !compare_refl.
       f_equal; lia.
-    - now rewrite Nat.compare_refl, !compare_refl.
+    - rewrite compare_ocons.
+      now rewrite Nat.compare_refl, !compare_refl.
     - rewrite compare_refl.
       now destruct (compare a1_1 b1_1).
     - reflexivity.
     - compare destruct a1_1 c1_1 as Hcomp_a11_c11.
-      + rewrite compare_refl.
+      + rewrite compare_ocons.
+        rewrite compare_refl.
         enough (Nat.compare n2 (S (n2 + n3)) = Lt) as -> by reflexivity.
         apply Nat.compare_lt_iff; lia.
-
-      + now apply compare_lt_iff in Hcomp_a11_c11 as ->.
-      + rewrite compare_refl, Nat.compare_refl.
+      + rewrite compare_ocons.
+        now apply compare_lt_iff in Hcomp_a11_c11 as ->.
+      + rewrite compare_ocons.
+        rewrite compare_refl, Nat.compare_refl.
         eenough (compare a1_2 (a1_2 + _) = Lt) as -> by reflexivity.
         apply compare_lt_iff, lt_plus_l.
     - apply lt_inv_strong in Hcomp_b1_c1 as [Hlt | Heqa  Hlt | Heqa Heqn Hlt].
-      + now apply compare_lt_iff in Hlt as ->.
-      + rewrite Heqa, compare_refl.
+      + rewrite compare_ocons.
+        now apply compare_lt_iff in Hlt as ->.
+      + rewrite compare_ocons.
+        rewrite Heqa, compare_refl.
         now apply Nat.compare_lt_iff in Hlt as ->.
-      + rewrite Heqa, Heqn, compare_refl, Nat.compare_refl.
+      + rewrite compare_ocons.
+        rewrite Heqa, Heqn, compare_refl, Nat.compare_refl.
         now apply compare_lt_iff in Hlt as ->.
     - compare destruct a1_1 c1_1 as Hcomp_a11_c11.
       + apply lt_inv_strong in Hcomp_b1_c1 as [Hlt | Heqa  Hlt | Heqa Heqn Hlt].
@@ -3942,10 +3980,13 @@ Section Proof_of_dist.
     -  rewrite_ind Hind b2. 
     -  rewrite_ind Hind b2.
        apply lt_inv_strong in Hcomp_b1_c1 as [Hlt | Heqa  Hlt | Heqa Heqn Hlt].
-       + now apply compare_gt_iff in Hlt as ->. 
-       + rewrite Heqa, compare_refl.
+       + rewrite compare_ocons.
+         now apply compare_gt_iff in Hlt as ->. 
+       + rewrite compare_ocons.
+         rewrite Heqa, compare_refl.
          now apply Nat.compare_gt_iff in Hlt as ->.
-       + rewrite Heqa, Heqn, compare_refl, Nat.compare_refl.
+       + rewrite compare_ocons.
+         rewrite Heqa, Heqn, compare_refl, Nat.compare_refl.
          now apply compare_gt_iff in Hlt as ->.
     -  rewrite_ind Hind b2.
        compare destruct a1_1 b1_1 as Hcomp_a11_b11.

--- a/theories/ordinals/Gamma0/Gamma0.v
+++ b/theories/ordinals/Gamma0/Gamma0.v
@@ -298,7 +298,8 @@ Defined.
 
 (* begin snippet compare *)
 
-Definition compare (t1 t2 : T2) : comparison := 
+Instance compare_T2 : Compare T2 := 
+fun (t1 t2 : T2) =>
   match lt_eq_lt_dec t1 t2 with
   | inleft (left _) => Lt
   | inleft (right _) => Eq
@@ -787,7 +788,7 @@ Lemma compare_reflect alpha beta : match compare alpha beta with
                                      | Gt => beta t2< alpha
                                      end.
 Proof.
-  unfold compare.
+  unfold compare,compare_T2.
   intros; case (lt_eq_lt_dec alpha beta);auto.
   destruct s;auto with T2.
 Qed.
@@ -814,7 +815,7 @@ Qed.
 Example Ex6 : gcons 1 0 12 omega t2< [0,[2,1]].
 Proof. now apply compare_Lt. Qed.
 
-Lemma compare_Eq : forall alpha beta, compare alpha beta = Eq -> 
+Lemma compare_Eq : forall (alpha beta : T2), compare alpha beta = Eq -> 
                                          alpha = beta.
 Proof.
   intros alpha beta; destruct (compare_correct alpha beta); trivial;
@@ -845,7 +846,7 @@ Proof.
     eapply lt_trans;eauto with T2.
 Qed.
 
-Lemma compare_rw_eq  alpha beta:  alpha = beta ->
+Lemma compare_rw_eq (alpha beta : T2):  alpha = beta ->
                                   compare alpha beta = Eq.
   intros; subst beta; generalize (compare_reflect alpha alpha);
     case (compare alpha alpha); trivial.
@@ -3682,8 +3683,9 @@ Module G0.
   Class G0 := mkg0 {vnf : T2; vnf_ok : nfb vnf}.
 
   Definition lt (alpha beta : G0) := T2.lt (@vnf alpha) (@vnf beta).
-
-  Definition compare alpha beta := compare (@vnf alpha) (@vnf beta).
+  
+  Instance compare_G0 : Compare G0 :=
+    fun alpha beta => compare (@vnf alpha) (@vnf beta).
 
   (* end snippet G0b *)
 
@@ -3719,18 +3721,18 @@ Module G0.
   (*||*)
   (* end snippet ltWf *)
 
-  Lemma compare_correct alpha beta :
-    CompareSpec (alpha = beta) (lt alpha beta) (lt beta alpha)
-                (compare alpha beta).
-  Proof.
-    destruct alpha, beta; cbn.
-    destruct (compare_correct vnf0 vnf1);subst. 
-    unfold compare; simpl.
-    -  rewrite compare_rw_eq; auto.
-       + constructor 1; f_equal; apply nfb_proof_unicity.
-    - unfold compare; rewrite compare_rw_lt; auto.
-    - unfold compare; rewrite compare_rw_gt; auto.
-  Qed. 
+Lemma compare_correct alpha beta :
+  CompareSpec (alpha = beta) (lt alpha beta) (lt beta alpha)
+              (compare alpha beta).
+Proof.
+  destruct alpha, beta; cbn.
+  destruct (compare_correct vnf0 vnf1);subst. 
+  unfold compare,compare_G0; simpl.
+  -  rewrite compare_rw_eq; auto.
+   + constructor 1; f_equal; apply nfb_proof_unicity.
+  - unfold compare,compare_G0; rewrite compare_rw_lt; auto.
+  - unfold compare,compare_G0; rewrite compare_rw_gt; auto.
+Qed. 
 
   Instance zero : G0.
   Proof.

--- a/theories/ordinals/Hydra/Omega2_Small.v
+++ b/theories/ordinals/Hydra/Omega2_Small.v
@@ -21,7 +21,7 @@ Section Impossibility_Proof.
   
   Variable m : Hydra -> ON_Omega2.t.
   Context
-    (Hvar: @Hvariant _ _ (ON_Generic.wf (ON:=Omega2)) free m).
+    (Hvar: @Hvariant _ _ (ON_Generic.ON_wf (ON:=Omega2)) free m).
 
   (* end snippet Impossibilitya *)
 
@@ -172,7 +172,7 @@ Section Impossibility_Proof.
   Proof. (* .no-out *)
     unfold small_h;
     pattern (m big_h);
-      apply  well_founded_induction with (R := ON_lt) (1:= wf);
+      apply  well_founded_induction with (R := ON_lt) (1:= ON_wf);
       intros (i,j) IHij.
 
     (* end snippet mGe *)

--- a/theories/ordinals/OrdinalNotations/Example_3PlusOmega.v
+++ b/theories/ordinals/OrdinalNotations/Example_3PlusOmega.v
@@ -12,7 +12,7 @@ Definition O3O  :=  ON_plus (FinOrd 3) Omega.
 Existing Instance O3O.
 
 Arguments ON_t : clear implicits.
-Arguments ON_t {A lt compare} _.
+Arguments ON_t {A lt cmp} _.
 
 
 Program Definition f (z: ON_t O3O) : ON_t Omega :=

--- a/theories/ordinals/OrdinalNotations/ON_Finite.v
+++ b/theories/ordinals/OrdinalNotations/ON_Finite.v
@@ -43,13 +43,11 @@ Abort.
 
 (* begin snippet compareDef:: no-out *)
 
-Definition compare {n:nat} (alpha beta : t n) :=
-  Nat.compare (proj1_sig alpha) (proj1_sig beta).
- 
+#[global] Instance compare_t {n:nat} : Compare (t n) :=
+  fun (alpha beta : t n) => Nat.compare (proj1_sig alpha) (proj1_sig beta).
 
 Lemma compare_correct {n} (alpha beta : t n) :
-  CompareSpec (alpha = beta) (lt alpha beta) (lt beta alpha)
-              (compare alpha beta).
+  CompSpec eq lt alpha beta (compare alpha beta).
 (* end snippet compareDef *)
 
 Proof.
@@ -68,10 +66,10 @@ Proof.
       destruct y, (x0 <? S n); auto; right; discriminate.    
      (* ... *)
 (* end snippet compareCorrectd *)
-    +  rewrite Nat.compare_lt_iff;  constructor 2.
-       destruct x0; [  lia |  apply leb_correct; lia].
-    +   rewrite Nat.compare_gt_iff; constructor 3.
-        destruct x; [lia | apply leb_correct; lia].
+    + rewrite Nat.compare_lt_iff;  constructor 2.
+      simpl; destruct x0; [  lia |  apply leb_correct; lia].
+    + rewrite Nat.compare_gt_iff; constructor 3.
+      simpl; destruct x; [lia | apply leb_correct; lia].
 Qed.
 
 Lemma compare_reflect {n:nat} (alpha beta : t  n) :

--- a/theories/ordinals/OrdinalNotations/ON_Generic.v
+++ b/theories/ordinals/OrdinalNotations/ON_Generic.v
@@ -21,26 +21,23 @@ Local Open Scope ON_scope.
 *)
 
 (* begin snippet ONDef *)
-Class ON {A:Type}(lt: relation A)
-      (compare: A -> A -> comparison) :=
+Class ON {A:Type} (lt: relation A) (cmp: Compare A) :=
   {
-  comp :> Comparable lt compare;
-  wf : well_founded lt;
+  ON_comp :> Comparable lt cmp;
+  ON_wf : well_founded lt;
   }.
 (* end snippet ONDef *)
 
 (* begin snippet ONDefsa:: no-out  *)
 Section Definitions.
-  
-  Context  {A:Type}{lt : relation A}
-           {compare : A -> A -> comparison}
-           {on : ON lt compare}.
+
+  Context {A:Type} {lt : relation A} {cmp : Compare A} {on: ON lt cmp}.
   
   #[using="All"]
    Definition ON_t := A.
 
   #[using="All"]
-   Definition ON_compare := compare.
+   Definition ON_compare : A -> A -> comparison := compare.
 
   #[using="All"]
    Definition ON_lt := lt.
@@ -60,7 +57,7 @@ Section Definitions.
   Proof.
     intro x; eapply Acc_incl  with (fun x y =>  ON_lt (m x) (m  y)).
     - intros y z H; apply H.
-    - eapply Acc_inverse_image, wf.
+    - eapply Acc_inverse_image, ON_wf.
   Qed.
 
   (* begin snippet ONDefsb *)
@@ -315,7 +312,7 @@ Section SubON_properties.
   Lemma SubON_least : forall a ,  Least a  <-> Least (f a).
   Proof.
     split; intro H.
-    - intros y; destruct (compare_correct (f a) y).
+    - intros y; destruct (comparable_comp_spec (f a) y).
       + subst y; right.
       + now  left.
       + exfalso.
@@ -329,7 +326,7 @@ Section SubON_properties.
           apply (StrictOrder_Irreflexive a).
           auto.
         }
-    - intro x; destruct (compare_correct a x).
+    - intro x; destruct (comparable_comp_spec a x).
       subst; right.
       + now left.
       + apply SubON_mono in H0; specialize (H (f x)).

--- a/theories/ordinals/OrdinalNotations/ON_Omega.v
+++ b/theories/ordinals/OrdinalNotations/ON_Omega.v
@@ -8,9 +8,12 @@ From hydras Require Import Schutte.
 
 Import Relations RelationClasses.
 
+#[global]
+Instance compare_nat : Compare nat := Nat.compare.
+
 (* begin snippet OmegaDefa:: no-out *)
 #[global]
- Instance Omega_comp : Comparable Peano.lt  Nat.compare.
+ Instance Omega_comp : Comparable Peano.lt compare_nat.
 Proof.
   split.
   - apply Nat.lt_strorder.
@@ -18,7 +21,7 @@ Proof.
 Qed.
 
 #[global]
- Instance Omega : ON Peano.lt Nat.compare.
+ Instance Omega : ON Peano.lt compare_nat.
 Proof.
  split.
  - apply Omega_comp.
@@ -67,7 +70,7 @@ Proof.
   - apply finite_lt_omega.
   - intros beta Hbeta; destruct (lt_omega_finite Hbeta) as [i Hi].
     exists i; now subst.
-  -  intros n p; destruct (Nat.compare_spec n p).
+  -  intros n p; unfold compare_nat; destruct (Nat.compare_spec n p).
      + now subst.
      + now apply finite_mono.
      + now apply finite_mono.

--- a/theories/ordinals/OrdinalNotations/ON_Omega2.v
+++ b/theories/ordinals/OrdinalNotations/ON_Omega2.v
@@ -12,9 +12,13 @@ Import Relations ON_Generic.
 Open Scope ON_scope.
 
 (* begin snippet Omega2Def:: no-out *)
-Instance Omega2: ON _ _ := ON_mult Omega Omega.
 
-Definition t := ON_t.  
+Instance compare_nat_nat : Compare t :=
+ compare_t compare_nat compare_nat.
+
+Instance Omega2: ON _ compare_nat_nat := ON_mult Omega Omega.
+
+Definition t := ON_t.
 
 Example ex1 : (5,8) o< (5,10).
 Proof.
@@ -128,14 +132,21 @@ Lemma compare_reflect alpha beta :
   | Gt => beta o< alpha
   end.
 Proof.
-  destruct alpha, beta; cbn; unfold ON_compare.  
-  destruct (compare_correct (n,n0) (n1,n2)); auto.
+  destruct alpha, beta; cbn; unfold ON_compare.
+  destruct (comparable_comp_spec (n,n0) (n1,n2)).
+  - rewrite H, compare_refl; reflexivity.
+  - apply compare_lt_iff in H.
+    rewrite H.
+    apply compare_lt_iff.
+    assumption.
+  - apply compare_gt_iff in H.
+    rewrite H.
+    apply compare_gt_iff.
+    assumption.
 Qed.
 
-
 Lemma compare_correct alpha beta :
-    CompareSpec (alpha = beta) (ON_lt alpha beta) (ON_lt beta alpha)
-                (ON_compare alpha beta).
+    CompSpec eq ON_lt alpha beta (ON_compare alpha beta).
 Proof.
   generalize (compare_reflect alpha beta).
   destruct (ON_compare alpha beta); now constructor. 

--- a/theories/ordinals/OrdinalNotations/ON_Omega_plus_omega.v
+++ b/theories/ordinals/OrdinalNotations/ON_Omega_plus_omega.v
@@ -3,7 +3,7 @@
 
 
 From Coq Require Import Arith Compare_dec Lia.
-From hydras Require Import Simple_LexProd ON_Generic
+From hydras Require Import Comparable Simple_LexProd ON_Generic
         ON_plus ON_Omega.
 
 Import Relations.
@@ -14,7 +14,11 @@ Open Scope opo_scope.
 
 (* begin snippet OmegaPlusOmegaDef *)
 
-Instance Omega_plus_Omega: ON _ _ :=  ON_plus Omega Omega.
+Instance compare_nat_nat : Compare t :=
+ compare_t compare_nat compare_nat.
+
+Instance Omega_plus_Omega: ON _ compare_nat_nat :=
+ ON_plus Omega Omega.
 
 Definition t := ON_t.
 
@@ -377,7 +381,7 @@ Lemma Omega_as_lub  :
    forall alpha, 
      (forall i,  fin i o< alpha) <-> omega o<= alpha.
  Proof.
-   intro alpha; destruct (Comparable.compare_correct  omega alpha).
+   intro alpha; destruct (comparable_comp_spec omega alpha).
    - subst;split.
      +  right.
      + intros; constructor.

--- a/theories/ordinals/OrdinalNotations/ON_plus.v
+++ b/theories/ordinals/OrdinalNotations/ON_plus.v
@@ -16,11 +16,11 @@ Coercion is_true: bool >-> Sortclass.
 Section Defs.
 
   Context `(ltA: relation A)
-          (compareA : A -> A -> comparison)
-          (NA: ON ltA  compareA).
+          (cmpA : Compare A)
+          (NA: ON ltA cmpA).
   Context `(ltB: relation B)
-          (compareB : B -> B -> comparison)
-          (NB: ON ltB compareB).
+          (cmpB : Compare B)
+          (NB: ON ltB cmpB).
 
   Definition t := (A + B)%type.
   Arguments inl  {A B} _.
@@ -30,11 +30,12 @@ Section Defs.
 (* end snippet Defs *)
 
 (* begin snippet compareDef *)
-Definition compare (alpha beta: t) : comparison :=
+#[global] Instance compare_t : Compare t :=
+fun (alpha beta: t) =>
    match alpha, beta with
      inl _, inr _ => Lt
-   | inl a, inl a' => compareA a a'
-   | inr b, inr b' => compareB b b'
+   | inl a, inl a' => compare a a'
+   | inr b, inr b' => compare b b'
    | inr _, inl _ => Gt
   end.
 (* end snippet compareDef *)
@@ -69,15 +70,14 @@ Lemma compare_reflect alpha beta :
   | Gt => lt beta  alpha
   end.
   destruct alpha, beta; cbn; auto.
-  destruct (compare_correct a a0); (now subst || constructor; auto).
-   - destruct (compare_correct b b0); (now subst || constructor; auto).
+  destruct (comparable_comp_spec a a0); (now subst || constructor; auto).
+   - destruct (comparable_comp_spec b b0); (now subst || constructor; auto).
 Qed.
 
 (* begin snippet compareCorrect:: no-out  *)
 
 Lemma compare_correct alpha beta :
-    CompareSpec (alpha = beta) (lt alpha beta) (lt beta alpha)
-                (compare alpha beta). (* .no-out *)
+    CompSpec eq lt alpha beta (compare alpha beta). (* .no-out *)
 (* end snippet compareCorrect *)
 
 Proof.
@@ -88,7 +88,7 @@ Qed.
 
 (* begin snippet plusComp:: no-out *)
 
-#[global] Instance plus_comp : Comparable lt compare.
+#[global] Instance plus_comp : Comparable lt compare_t.
 Proof.
   split.
   - apply lt_strorder.
@@ -105,8 +105,9 @@ Qed.
 
 
 Lemma lt_wf : well_founded lt.
-Proof. destruct NA, NB.
-       apply wf_disjoint_sum; [apply wf | apply wf0].
+Proof.
+  destruct NA, NB.
+  apply wf_disjoint_sum; [apply ON_wf | apply ON_wf0].
 Qed.
 
 (*||*)
@@ -119,7 +120,7 @@ Qed.
 .. coq:: no-out 
 |*)
 
-#[global] Instance ON_plus : ON lt compare.
+#[global] Instance ON_plus : ON lt compare_t.
 Proof.
   split.
   - apply plus_comp.
@@ -144,8 +145,8 @@ Defined.
 
 End Defs.
 
-Arguments lt_eq_lt_dec {A ltA compareA} _ {B ltB  compareB} _.
-Arguments ON_plus {A ltA compareA} _ {B ltB  compareB}.
+Arguments lt_eq_lt_dec {A ltA cmpA} _ {B ltB  cmpB} _.
+Arguments ON_plus {A ltA cmpA} _ {B ltB cmpB}.
 
 
 

--- a/theories/ordinals/Prelude/Comparable.v
+++ b/theories/ordinals/Prelude/Comparable.v
@@ -1,18 +1,17 @@
 From Coq Require Import Relations RelationClasses Setoid.
 Require Export MoreOrders.
 
-
 (* begin snippet ComparableDef *)
 Class Compare (A:Type) := compare : A -> A -> comparison.
-#[export] Hint Mode Compare ! : typeclass_instances.
-Infix "<?>" := compare (at level 60).
 
 Class Comparable {A:Type} (lt: relation A) (cmp : Compare A) := {
   comparable_sto :> StrictOrder lt;
-  comparable_comp_spec : forall a b : A, CompSpec eq lt a b (compare a b);
+  comparable_comp_spec : forall a b, CompSpec eq lt a b (compare a b);
 }.
-#[export] Hint Mode Comparable ! - - : typeclass_instances.
 (* end snippet ComparableDef *)
+
+#[export] Hint Mode Compare ! : typeclass_instances.
+#[export] Hint Mode Comparable ! - - : typeclass_instances.
 
 Section Comparable.
 

--- a/theories/ordinals/Prelude/DecPreOrder.v
+++ b/theories/ordinals/Prelude/DecPreOrder.v
@@ -27,6 +27,9 @@ Notation EqDecision A := (RelDecision (@eq A)).
 Definition bool_decide (P : Prop) {dec : Decision P} : bool :=
   if dec then true else false.
 
+Instance comparison_eq_dec : EqDecision comparison.
+Proof. intros c1 c2; unfold Decision; decide equality. Defined.
+
 Instance Total_Reflexive{A:Type}{R: relation A}(rt : Total R):
   Reflexive R.
 Proof. intros a ; now destruct (rt a a). Qed.

--- a/theories/ordinals/Prelude/DecPreOrder.v
+++ b/theories/ordinals/Prelude/DecPreOrder.v
@@ -27,6 +27,18 @@ Notation EqDecision A := (RelDecision (@eq A)).
 Definition bool_decide (P : Prop) {dec : Decision P} : bool :=
   if dec then true else false.
 
+Lemma bool_decide_eq_true (P : Prop) `{Decision P} : bool_decide P = true <-> P.
+Proof.
+  unfold bool_decide.
+  destruct H; intuition discriminate.
+Qed.
+
+Lemma bool_decide_eq_false (P : Prop) `{Decision P} : bool_decide P = false <-> ~P.
+Proof.
+  unfold bool_decide.
+  destruct H; intuition discriminate.
+Qed.
+
 Instance comparison_eq_dec : EqDecision comparison.
 Proof. intros c1 c2; unfold Decision; decide equality. Defined.
 

--- a/theories/ordinals/Prelude/First_toggle.v
+++ b/theories/ordinals/Prelude/First_toggle.v
@@ -7,28 +7,26 @@ Computes the first  [l]  between [n] and [p] (excluded) such that
 
 (** Pierre Castéran, Univ. Bordeaux and LaBRI *)
 
-
 From Coq Require Import Arith Lia.
+From hydras Require Import DecPreOrder.
 
 Section Hypos.
-  Variables (P : nat -> bool)
-            (n p : nat).
+  Context (P : nat -> Prop) `{Pdec: forall n, Decision (P n)} (n p : nat).
  
-  Hypotheses (Hnp : n < p)
-             (Hn : P n = true) (Hp : P p = false).
+  Hypotheses (Hnp : n < p) (Hn : P n) (Hp : ~ P p).
 
 (* begin hide *)
   
   Let  search_toggle  (delta : nat)(H : 0 < delta /\ delta <= p - n)
-             (invar : forall i, n <= i -> i <= p - delta -> P i = true) :
+             (invar : forall i, n <= i -> i <= p - delta -> P i) :
     {l : nat | n <= l  /\ l < p /\
-               (forall i: nat, n <= i -> i <= l -> P i = true ) /\ 
-               (P (S l ) = false)}.
+               (forall i: nat, n <= i -> i <= l -> P i) /\ 
+               (~ P (S l ))}.
   
   Proof.
     generalize delta H invar.
     clear delta H invar.
-    intro delta; pattern delta; apply well_founded_induction with lt.
+    intro delta; pattern delta; apply well_founded_induction with Nat.lt.
     apply lt_wf.
     
     intros d Hd.
@@ -38,12 +36,11 @@ Section Hypos.
     destruct H.
     elimtype False. inversion H. intros; subst.
     
-    case_eq (P (p - n0)). 
-    intro.
+    destruct (decide (P (p - n0))) as [H|H].
     destruct (Hd n0).
     auto with arith.
     destruct n0.
-    replace (p - 0) with p in H. rewrite Hp in H; discriminate.
+    replace (p - 0) with p in H. congruence.
     auto with arith.
     split; auto with arith.
     destruct H0; auto with arith.
@@ -71,7 +68,7 @@ Section Hypos.
   Remark R1 : 0 < delta /\ delta <= p - n.
   Proof.   unfold delta.  clear search_toggle; abstract lia.  Qed.
 
-  Remark R2 :  forall i, n <= i -> i <= p - delta -> P i = true.
+  Remark R2 :  forall i, n <= i -> i <= p - delta -> P i.
   Proof.
     clear search_toggle; unfold delta; intros; replace i with n; [trivial | lia].
   Qed.
@@ -80,8 +77,8 @@ Section Hypos.
   
   Definition first_toggle :
   {l : nat |  n <= l /\ l < p /\
-              (forall i : nat, n <= i -> i <= l -> P i = true) /\
-              P (S l) = false}.
+              (forall i : nat, n <= i -> i <= l -> P i) /\
+              ~ P (S l)}.
   (* begin hide *)
   Proof.
     exact  (search_toggle  (p-n) R1 R2).

--- a/theories/ordinals/Schutte/Correctness_E0.v
+++ b/theories/ordinals/Schutte/Correctness_E0.v
@@ -420,7 +420,7 @@ Proof with eauto with T1.
 
      + repeat rewrite inject_rw.
        simpl.
-       destruct (T1.compare alpha1 beta1) eqn:H1;
+       destruct (compare alpha1 beta1) eqn:H1;
        repeat rewrite inject_rw.
        * apply compare_eq_iff in H1 as <-.
           rewrite <- (case_Eq (inject alpha1) (inject alpha2)

--- a/theories/ordinals/solutions_exercises/lt_succ_le.v
+++ b/theories/ordinals/solutions_exercises/lt_succ_le.v
@@ -5,8 +5,8 @@ Section Proofs_of_lt_succ_le.
   
 Context (A:Type)
         (lt  : relation A)
-        (compare : A -> A -> comparison)
-        (On : ON lt compare).
+        (cmp : Compare A)
+        (On : ON lt cmp).
 
 Section Proofs.
   Variables alpha beta : A.

--- a/theories/ordinals/solutions_exercises/predSuccUnicity.v
+++ b/theories/ordinals/solutions_exercises/predSuccUnicity.v
@@ -5,8 +5,8 @@ Section Proofs_of_unicity.
   
 Context (A:Type)
         (lt le : relation A)
-        (compare : A -> A -> comparison)
-        (On : ON lt compare).
+        (cmp : Compare A)
+        (On : ON lt cmp).
 
 Section Proofs.
   Variables alpha beta : A.


### PR DESCRIPTION
Here is an initial draft adding the Compare operational typeclass discussed in #74.

There are some low-level improvements to make, but also some questions to think about:
- Should there be any infix notation at all for the Compare typeclass? I add here `x <?> y`, but I don't use it in the code, since it's such as big change.
- I get rid of some more boolean functions for convenience. I think it looks reasonable, but there are some tradeoffs in that the Decision typeclass shows up in a lot of places.

@Casteran could you give a high-level assessment whether this PR is worth polishing up and merging? Or maybe it should stay an experiment?