### PR TITLE
fix pdf margin overflow for compare-related definitions

### DIFF
--- a/doc/part-hydras.tex
+++ b/doc/part-hydras.tex
@@ -1718,7 +1718,7 @@ Inductive CompareSpec (Peq Plt Pgt : Prop) : comparison -> Prop :=
   | CompLt : Plt -> CompareSpec Peq Plt Pgt Lt
   | CompGt : Pgt -> CompareSpec Peq Plt Pgt Gt.
 
-Definition CompSpec {A} (eq lt : A->A->Prop)(x y:A) : comparison -> Prop :=
+Definition CompSpec {A} (eq lt : A -> A -> Prop) (x y : A) :=
  CompareSpec (eq x y) (lt x y) (lt y x).
 \end{Coqsrc}
 

--- a/theories/ordinals/Prelude/Comparable.v
+++ b/theories/ordinals/Prelude/Comparable.v
@@ -4,9 +4,11 @@ Require Export MoreOrders.
 (* begin snippet ComparableDef *)
 Class Compare (A:Type) := compare : A -> A -> comparison.
 
-Class Comparable {A:Type} (lt: relation A) (cmp : Compare A) := {
+Class Comparable {A:Type} (lt: relation A) (cmp : Compare A) :=
+{
   comparable_sto :> StrictOrder lt;
-  comparable_comp_spec : forall a b, CompSpec eq lt a b (compare a b);
+  comparable_comp_spec :
+   forall (a b : A), CompSpec eq lt a b (compare a b);
 }.
 (* end snippet ComparableDef *)
 


### PR DESCRIPTION
This very small PR fixes some pdf margin issues following #79.