### PR TITLE
Workaround Makefile issue after #59.

### DIFF
--- a/.github/workflows/nix-action-default.yml
+++ b/.github/workflows/nix-action-default.yml
@@ -328,7 +328,7 @@ jobs:
         nix-shell --run "cachedMake"
         nix-shell --run "make -t"
     - name: Build Alectryon snippets
-      run: nix-shell --run "make -C doc/movies -j $(nproc) all"
+      run: nix-shell --run "make -C doc/movies -j $(nproc)"
     - name: Build coqdoc
       run: nix-shell --run "make -j $(nproc) html"
     - name: Compile LaTeX document


### PR DESCRIPTION
I don't really understand why, but it seems that dropping `all` suffices to work around the issue I detected and first reported in https://github.com/coq-community/hydra-battles/pull/71#issuecomment-915407650, then in https://github.com/coq-community/hydra-battles/issues/59#issuecomment-922699835.