### PR TITLE
Minor changes + vision subsection in the introduction.

### DIFF
--- a/doc/JFLA2022/paper.tex
+++ b/doc/JFLA2022/paper.tex
@@ -86,14 +86,14 @@ Karl Palmskog \inst{3}
 Univ. Bordeaux, CNRS, Bordeaux INP, LaBRI, UMR 5800, F-33400 Talence, France \\
   \email{pierre.casteran@labri.fr}
 \and
-to fill!
+Univ. de Paris, F-75013 Paris, France
 \and
 to fill!
 \and
 MIT CSAIL, Cambridge, Massachusetts, USA
 \and
-to fill!
- }
+Inria, Univ. de Paris, CNRS, IRIF, UMR 8243, F-75013 Paris, France
+}
 
 
 

--- a/doc/JFLA2022/paper.tex
+++ b/doc/JFLA2022/paper.tex
@@ -239,10 +239,10 @@ combinatorial results about ordinal numbers by Jussi Ketonen and Robert Solovay~
   Theorem~\ref{kp:thm1} cannot be proved in Peano Arithmetic. \label{kp:thm2}
 \end{theorem}
 
-The contrast between the simplicity of the statements above and the complexity of their proofs convinced us that it is a good thema for a commented library~\cite{HydraBattles} of formal proofs written for the \textit{Coq} proof assistant~\cite{Coq}. 
+The contrast between the simplicity of the statements above and the complexity of their proofs convinced us that it is a good theme for a commented library~\cite{HydraBattles} of formal proofs written for the \textit{Coq} proof assistant~\cite{Coq}. 
 
 Complex formalisations and proofs are explained in an
-  electronic book~\cite{HydraBook}. Whenever various reasonable choices exist, we try to present and compare the alternatives.
+  electronic book~\cite{HydraBook} (PDF document of over 280 pages). Whenever various reasonable choices exist, we try to present and compare the alternatives.
   For instance, Figures~\ref{fig:Ex42E0} and \ref{fig:Ex42-schutte} show two radically different proofs of the equality
   $\omega+42+\omega^2=\omega^2$. The first one is a simple proof by computation, the second one shows how this equality
   is a consequence of the axioms of the set-theoretic model  by Kurt Schütte~\cite{schutte}. 

--- a/doc/JFLA2022/paper.tex
+++ b/doc/JFLA2022/paper.tex
@@ -123,9 +123,25 @@ Inria, Univ. de Paris, CNRS, IRIF, UMR 8243, F-75013 Paris, France
 %------------------------------------------------------------------------------
 \section{Introduction}
 \label{sect:introduction}
-The \emph{Hydra-battles} project, part of \emph{Coq-Community}~\cite{CoqCommunity}  aims to be an experimental platform for the collaborative development of commented libraries of formal proofs. 
 
+\subsection{Vision}
+The \emph{Hydra-battles} project, part of \emph{Coq-Community}~\cite{CoqCommunity} aims to be an experimental platform for the collaborative development of commented libraries of formal proofs. \emph{Coq-Community} is a community organization that we have founded in 2018 with two goals in mind: providing a solution for the long-term maintenance of interesting Coq packages, and working collaboratively on documentation projects. The \emph{Hydra-battles} project demonstrates that these two goals are not independent: interesting Coq packages can become the basis for new documentation.
+%
+This umbrella project now includes evolved versions of former \emph{contribs} Cantor and Additions (under the new names of Hydra-battles and Addition-chains), the Pocklington library, extracted from Russel O'Connor's Goedel \emph{contrib} and a bridge to the Gaia library (\emph{contrib} of José Grimm).
+%
+By following this approach of commenting interesting Coq packages, we provide new documentation content, that contributes to the diversity of the thriving Coq documentation ecosystem.
 
+We call on the Coq users in the JFLA community and beyond to come and join us in this effort, by bringing new interesting projects which are worth presenting to Coq learners and guiding them in their exploration.
+%
+We also always have project ideas to extend further our explorations and anyone is welcome to join the team by sending small or larger contributions through pull requests.
+%
+The current state of the project is already the result of such evolutions after several of us contributed project solutions and new proposals to the initial version of the first author.
+
+Futhermore, contrary to traditionally published books, the ``book'' that forms part of this project is intended to be forever evolving. As new Coq formalization patterns and proof techniques appear, the book can be adapted to demonstrate their use (in case they fit well with our applications).
+%
+By using modern maintenance techniques such as continuous integration and deployment, we can ensure that this documentation stays up to date with the latest Coq releases. With Alectryon, we ensure that code and documentation are always in sync.
+
+\subsection{Hydra games}
 Hydra games (also known as \emph{Hydra battles}) appear in an article published in 1982 by two mathematicians, 
 Laurie Kirby and Jeff Paris: \emph{Accessible Independence Results for Peano Arithmetic}~\cite{KP82}.
 This article describes a game between two players: Hercules and a hydra.

--- a/doc/JFLA2022/paper.tex
+++ b/doc/JFLA2022/paper.tex
@@ -127,7 +127,7 @@ Inria, Univ. de Paris, CNRS, IRIF, UMR 8243, F-75013 Paris, France
 \subsection{Vision}
 The \emph{Hydra-battles} project, part of \emph{Coq-Community}~\cite{CoqCommunity} aims to be an experimental platform for the collaborative development of commented libraries of formal proofs. \emph{Coq-Community} is a community organization that we have founded in 2018 with two goals in mind: providing a solution for the long-term maintenance of interesting Coq packages, and working collaboratively on documentation projects. The \emph{Hydra-battles} project demonstrates that these two goals are not independent: interesting Coq packages can become the basis for new documentation.
 %
-This umbrella project now includes evolved versions of former \emph{contribs} Cantor and Additions (under the new names of Hydra-battles and Addition-chains), the Pocklington library, extracted from Russel O'Connor's Goedel \emph{contrib} and a bridge to the Gaia library (\emph{contrib} of José Grimm).
+This umbrella project now includes evolved versions of former \emph{contribs} Cantor and Additions (under the new names of Hydra-battles and Addition-chains), the Pocklington library, extracted from Russel O'Connor's Goedel \emph{contrib}\cite{OConnor05, Goedel} and a bridge to the Gaia library (\emph{contrib} of José Grimm~\cite{Gaia,grimm:hal-00911710}).
 %
 By following this approach of commenting interesting Coq packages, we provide new documentation content, that contributes to the diversity of the thriving Coq documentation ecosystem.
 
@@ -139,7 +139,7 @@ The current state of the project is already the result of such evolutions after 
 
 Futhermore, contrary to traditionally published books, the ``book'' that forms part of this project is intended to be forever evolving. As new Coq formalization patterns and proof techniques appear, the book can be adapted to demonstrate their use (in case they fit well with our applications).
 %
-By using modern maintenance techniques such as continuous integration and deployment, we can ensure that this documentation stays up to date with the latest Coq releases. With Alectryon, we ensure that code and documentation are always in sync.
+By using modern maintenance techniques such as continuous integration and deployment, we can ensure that this documentation stays up to date with the latest Coq releases. With Alectryon~\cite{alectryonpaper, alectryongithub}, we ensure that code and documentation are always in sync.
 
 \subsection{Hydra games}
 Hydra games (also known as \emph{Hydra battles}) appear in an article published in 1982 by two mathematicians, 


### PR DESCRIPTION
The second commit reiterates some changes from ad4909d that were accidentally reverted in d5f6a79531dfab9726e52dd17225b0ec6b8ec4dd.