### PR TITLE
update metadata and CI for 8.14

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.12.0-coq-8.14'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
         opam_file:
           - 'coq-hydra-battles.opam'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This file was generated from `meta.yml`, please do not edit manually.
 Follow the instructions on https://github.com/coq-community/templates to regenerate.
 --->
-# Hydras, Ordinals  & Co. (_work in progress_)
+# Hydras, Ordinals & Co. (_work in progress_)
 
 [![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
@@ -13,7 +13,7 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 [docker-action-link]: https://github.com/coq-community/hydra-battles/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
-[contributing-link]: https://github.com/coq-community/hydra-battles#contributions-are-welcome-
+[contributing-link]: https://github.com/coq-community/hydra-battles#contributions-are-welcome
 
 [conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
 [conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
@@ -31,8 +31,8 @@ This contribution contains two parts:
   ordinal numbers, and a part of the so-called _Ketonen and Solovay
   machinery_ (combinatorial properties of epsilon0).
 
-  - This project also hosts the formalization by Russel O'Connor of
-    primitive recursive functions and Peano arithmetics (see
+  - This project also hosts the formalization by Russell O'Connor of
+    primitive recursive functions and Peano arithmetic (see
     https://github.com/coq-community/goedel)
 
 - Some algorithms for computing _x^n_ with as few multiplications as
@@ -42,6 +42,12 @@ This contribution contains two parts:
 
 - Author(s):
   - Pierre Castéran
+  - Évelyne Contejean
+  - Jeremy Damour
+  - Russell O'Connor
+  - Karl Palmskog
+  - Clément Pit-Claudel
+  - Théo Zimmermann
 - Coq-community maintainer(s):
   - Pierre Castéran ([**@Casteran**](https://github.com/Casteran))
 - License: [MIT License](LICENSE)
@@ -137,7 +143,7 @@ This contribution contains two parts:
 
 - directory exercises/
 
-## Contributions are welcome !
+## Contributions are welcome
 
 Any suggestion for improving the Coq scripts and/or the documentation will be taken into account.
 

--- a/coq-addition-chains.opam
+++ b/coq-addition-chains.opam
@@ -15,8 +15,8 @@ with the least number of multiplication as possible. We present a few implementa
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.14~") | (= "dev")}
-  "coq-paramcoq" {(>= "1.1.2" & < "1.2~") | (= "dev")}
+  "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
+  "coq-paramcoq" {(>= "1.1.3" & < "1.2~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.13~") | (= "dev")}
   "coq-mathcomp-algebra"
 ]

--- a/coq-hydra-battles.opam
+++ b/coq-hydra-battles.opam
@@ -18,8 +18,8 @@ properties of epsilon0)."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.14~") | (= "dev")}
-  "coq-equations" {(>= "1.2" & < "1.3~") | (= "dev")}
+  "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
+  "coq-equations" {(>= "1.2" & < "1.4~") | (= "dev")}
 ]
 
 tags: [
@@ -32,4 +32,10 @@ tags: [
 ]
 authors: [
   "Pierre Castéran"
+  "Évelyne Contejean"
+  "Jeremy Damour"
+  "Russell O'Connor"
+  "Karl Palmskog"
+  "Clément Pit-Claudel"
+  "Théo Zimmermann"
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -1,5 +1,5 @@
 ---
-fullname: Hydra battles & Co. (_work in progress_)
+fullname: Hydras, Ordinals & Co. (_work in progress_)
 shortname: hydra-battles
 organization: coq-community
 community: true
@@ -16,8 +16,8 @@ description: |-
     ordinal numbers, and a part of the so-called _Ketonen and Solovay
     machinery_ (combinatorial properties of epsilon0).
 
-    - This project also hosts the formalization by Russel O'Connor of
-      primitive recursive functions and Peano arithmetics (see
+    - This project also hosts the formalization by Russell O'Connor of
+      primitive recursive functions and Peano arithmetic (see
       https://github.com/coq-community/goedel)
 
   - Some algorithms for computing _x^n_ with as few multiplications as
@@ -68,6 +68,12 @@ publications:
 
 authors:
 - name: Pierre Castéran
+- name: Évelyne Contejean
+- name: Jeremy Damour
+- name: Russell O'Connor
+- name: Karl Palmskog
+- name: Clément Pit-Claudel
+- name: Théo Zimmermann
 
 maintainers:
 - name: Pierre Castéran
@@ -83,23 +89,25 @@ license:
 
 supported_coq_versions:
   text: 8.13 or later
-  opam: '{(>= "8.13" & < "8.14~") | (= "dev")}'
+  opam: '{(>= "8.13" & < "8.15~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
+- version: '1.12.0-coq-8.14'
+  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 
 dependencies:
 - opam:
     name: coq-equations
-    version: '{(>= "1.2" & < "1.3~") | (= "dev")}'
+    version: '{(>= "1.2" & < "1.4~") | (= "dev")}'
   description: |-
     [Equations](https://github.com/mattam82/Coq-Equations) 1.2 or later
 - opam:
     name: coq-paramcoq
-    version: '{(>= "1.1.2" & < "1.2~") | (= "dev")}'
+    version: '{(>= "1.1.3" & < "1.2~") | (= "dev")}'
   description: |-
     [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.2 or later
 - opam:
@@ -173,7 +181,7 @@ documentation: |-
 
   - directory exercises/
 
-  ## Contributions are welcome !
+  ## Contributions are welcome
 
   Any suggestion for improving the Coq scripts and/or the documentation will be taken into account.
 

--- a/theories/additions/Addition_Chains.v
+++ b/theories/additions/Addition_Chains.v
@@ -7,8 +7,9 @@ Pierre Casteran, LaBRI, University of Bordeaux
 Require Export Monoid_instances Pow Lia List.
 Require Import Relations RelationClasses.
 
-
-Declare ML Module "paramcoq".  
+(* TODO: use Require instead of Declare when paramcoq 1.1.3 packaged in Nix *)
+(*From Param Require Import Param.*)
+Declare ML Module "paramcoq".
  
 Require Import More_on_positive.
 Generalizable Variables A op one Aeq.

--- a/theories/additions/dune
+++ b/theories/additions/dune
@@ -3,3 +3,5 @@
  (package coq-addition-chains)
  (synopsis "Exponentiation algorithms following addition chains")
  (flags -w -notation-overridden -w -ambiguous-paths -w -deprecated-instance-without-locality))
+
+(include_subdirs qualified)


### PR DESCRIPTION
I address some metadata and attribution issues while setting up 8.14 compatibility and CI.

Unfortunately, we can't yet get rid of the annoying:
```coq
Declare ML Module "paramcoq".
```
since Paramcoq 1.1.3 must first be packaged in Nix.