### PR TITLE
update gaia-hydras opam bounds and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ This contribution contains two parts:
 ## Installation
 
 - To get the required dependencies, you can use opam or Nix. With opam:
-  - `opam install coq-hydra-battles.opam --deps-only` to get the _hydra battles_ dependencies;
-  - `opam install coq-addition-chains.opam --deps-only` to get the _addition chains_ dependencies.
+  - `opam install ./coq-hydra-battles.opam --deps-only` to get the _hydra battles_ dependencies;
+  - `opam install ./coq-addition-chains.opam --deps-only` to get the _addition chains_ dependencies.
 
   With Nix, just run `nix-shell` to get all the dependencies
   (including for building the documentation).  If you only want the
@@ -79,9 +79,9 @@ This contribution contains two parts:
   See [`doc/movies/Readme.md`](doc/movies/Readme.md) for details.
 
 - The general Makefile is in the top directory:
-  - make : compilation of the Coq scripts
-  - make pdf : generation of the documentation
-  - make html : generation of coqdoc html files
+  - `make` : compilation of the Coq scripts
+  - `make pdf` : generation of the documentation
+  - `make html` : generation of coqdoc html files
 
 - You may also rely on `dune` to install just one part. Run:
   - `dune build coq-hydra-battles.install` to build only the _hydra battles_ part;

--- a/coq-gaia-hydras.opam
+++ b/coq-gaia-hydras.opam
@@ -15,8 +15,8 @@ This development bridges the different notions."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.14~") | (= "dev")}
-  "coq-hydra-battles" {(>= "0.4" & < "0.5~") | (= "dev")}
+  "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
+  "coq-hydra-battles" {>= "0.4"}
   "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.13~") | (= "dev")}
   "coq-mathcomp-zify"
   "coq-gaia" {(>= "1.12" & < "1.13~") | (= "dev")}

--- a/meta.yml
+++ b/meta.yml
@@ -27,8 +27,8 @@ build: |-
   ## Installation
 
   - To get the required dependencies, you can use opam or Nix. With opam:
-    - `opam install coq-hydra-battles.opam --deps-only` to get the _hydra battles_ dependencies;
-    - `opam install coq-addition-chains.opam --deps-only` to get the _addition chains_ dependencies.
+    - `opam install ./coq-hydra-battles.opam --deps-only` to get the _hydra battles_ dependencies;
+    - `opam install ./coq-addition-chains.opam --deps-only` to get the _addition chains_ dependencies.
 
     With Nix, just run `nix-shell` to get all the dependencies
     (including for building the documentation).  If you only want the
@@ -40,9 +40,9 @@ build: |-
     See [`doc/movies/Readme.md`](doc/movies/Readme.md) for details.
 
   - The general Makefile is in the top directory:
-    - make : compilation of the Coq scripts
-    - make pdf : generation of the documentation
-    - make html : generation of coqdoc html files
+    - `make` : compilation of the Coq scripts
+    - `make pdf` : generation of the documentation
+    - `make html` : generation of coqdoc html files
 
   - You may also rely on `dune` to install just one part. Run:
     - `dune build coq-hydra-battles.install` to build only the _hydra battles_ part;


### PR DESCRIPTION
This is a PR to synchronize opam definitions with `extra-dev` and contains some small README/meta fixes. Will merge once CI passes.