### PR TITLE
add MathComp 1.13.0 to Docker CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -16,6 +16,8 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.13.0-coq-8.14'
+          - 'mathcomp/mathcomp:1.13.0-coq-8.13'
           - 'mathcomp/mathcomp:1.12.0-coq-8.14'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
         opam_file:

--- a/coq-addition-chains.opam
+++ b/coq-addition-chains.opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
   "coq-paramcoq" {(>= "1.1.3" & < "1.2~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.13~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
   "coq-mathcomp-algebra"
 ]
 

--- a/coq-gaia-hydras.opam
+++ b/coq-gaia-hydras.opam
@@ -17,10 +17,10 @@ build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.13" & < "8.15~") | (= "dev")}
-  "coq-hydra-battles" {>= "0.4"}
-  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.13~") | (= "dev")}
+  "coq-hydra-battles" {= version}
+  "coq-mathcomp-ssreflect" {(>= "1.12.0" & < "1.14~") | (= "dev")}
   "coq-mathcomp-zify"
-  "coq-gaia" {(>= "1.12" & < "1.13~") | (= "dev")}
+  "coq-gaia" {(>= "1.12" & < "1.14~") | (= "dev")}
 ]
 
 tags: [

--- a/meta.yml
+++ b/meta.yml
@@ -104,6 +104,10 @@ supported_coq_versions:
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
+- version: '1.13.0-coq-8.14'
+  repo: 'mathcomp/mathcomp'
+- version: '1.13.0-coq-8.13'
+  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.14'
   repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
@@ -122,7 +126,7 @@ dependencies:
     [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.12.0" & < "1.13~") | (= "dev")}'
+    version: '{(>= "1.12.0" & < "1.14~") | (= "dev")}'
   description: |-
     [MathComp SSReflect](https://github.com/math-comp/math-comp) 1.12 or later
 - opam:
@@ -131,7 +135,7 @@ dependencies:
     MathComp Algebra
 - opam:
     name: coq-gaia
-    version: '{(>= "1.12" & < "1.13~") | (= "dev")}'
+    version: '{(>= "1.12" & < "1.14~") | (= "dev")}'
   description: |-
     [Gaia](https://github.com/coq-community/gaia) 1.12 or later
 - opam:


### PR DESCRIPTION
Since MathComp 1.13.0 is now out, we should test it in Docker CI, and hence we need to modify opam packages for this.