### PR TITLE
require Coq 8.14 later in opam and CI due to CoqPrime

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,10 +19,9 @@ jobs:
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
           - 'mathcomp/mathcomp:1.14.0-coq-8.15'
           - 'mathcomp/mathcomp:1.13.0-coq-8.14'
-          - 'mathcomp/mathcomp:1.13.0-coq-8.13'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
           custom_image: ${{ matrix.image }}
@@ -34,37 +33,37 @@ jobs:
             startGroup "Build hydra-battles dependencies"
               opam pin add -n -y -k path coq-hydra-battles .
               opam update -y
-              opam install -y -j 2 coq-hydra-battles --deps-only
+              opam install -y -j "$(nproc)" coq-hydra-battles --deps-only
             endGroup
             startGroup "Build hydra-battles"
-              opam install -y -v -j 2 coq-hydra-battles
+              opam install -y -v -j "$(nproc)" coq-hydra-battles
               opam list
             endGroup
             startGroup "Build addition-chains dependencies"
               opam pin add -n -y -k path coq-addition-chains .
               opam update -y
-              opam install -y -j 2 coq-addition-chains --deps-only
+              opam install -y -j "$(nproc)" coq-addition-chains --deps-only
             endGroup
             startGroup "Build addition-chains"
-              opam install -y -v -j 2 coq-addition-chains
+              opam install -y -v -j "$(nproc)" coq-addition-chains
               opam list
             endGroup
             startGroup "Build gaia-hydras dependencies"
               opam pin add -n -y -k path coq-gaia-hydras .
               opam update -y
-              opam install -y -j 2 coq-gaia-hydras --deps-only
+              opam install -y -j "$(nproc)" coq-gaia-hydras --deps-only
             endGroup
             startGroup "Build gaia-hydras"
-              opam install -y -v -j 2 coq-gaia-hydras
+              opam install -y -v -j "$(nproc)" coq-gaia-hydras
               opam list
             endGroup
             startGroup "Build goedel dependencies"
               opam pin add -n -y -k path coq-goedel .
               opam update -y
-              opam install -y -j 2 coq-goedel --deps-only
+              opam install -y -j "$(nproc)" coq-goedel --deps-only
             endGroup
             startGroup "Build goedel"
-              opam install -y -v -j 2 coq-goedel
+              opam install -y -v -j "$(nproc)" coq-goedel
               opam list
             endGroup
             startGroup "Uninstallation test"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the proceedings of [JFLA 2022](http://jfla.inria.fr/jfla2022.html).
 - Coq-community maintainer(s):
   - Pierre Castéran ([**@Casteran**](https://github.com/Casteran))
 - License: [MIT License](LICENSE)
-- Compatible Coq versions: 8.13 or later
+- Compatible Coq versions: 8.14 or later
 - Additional dependencies:
   - [Equations](https://github.com/mattam82/Coq-Equations) 1.2 or later
   - [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later

--- a/coq-addition-chains.opam
+++ b/coq-addition-chains.opam
@@ -17,7 +17,7 @@ correctness."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-paramcoq" {(>= "1.1.3" & < "1.2~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.16~") | (= "dev")}
   "coq-mathcomp-algebra"

--- a/coq-gaia-hydras.opam
+++ b/coq-gaia-hydras.opam
@@ -16,7 +16,7 @@ similar concepts in the two projects."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-hydra-battles" {= version}
   "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.16~") | (= "dev")}
   "coq-mathcomp-zify"

--- a/coq-goedel.opam
+++ b/coq-goedel.opam
@@ -16,8 +16,8 @@ without induction) that is complete is inconsistent."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.17~") | (= "dev")}
-  "coq-hydra-battles" {= "dev"}
+  "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
+  "coq-hydra-battles" {= version}
   "coq-coqprime" {= "dev"}
 ]
 

--- a/coq-hydra-battles.opam
+++ b/coq-hydra-battles.opam
@@ -18,7 +18,7 @@ properties of epsilon0)."""
 build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "dune" {>= "2.5"}
-  "coq" {(>= "8.13" & < "8.17~") | (= "dev")}
+  "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-equations" {(>= "1.2" & < "1.4~") | (= "dev")}
   "coq-libhyps"
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -115,8 +115,8 @@ license:
   identifier: MIT
 
 supported_coq_versions:
-  text: 8.13 or later
-  opam: '{(>= "8.13" & < "8.17~") | (= "dev")}'
+  text: 8.14 or later
+  opam: '{(>= "8.14" & < "8.18~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: 'coq-dev'
@@ -126,8 +126,6 @@ tested_coq_opam_versions:
 - version: '1.14.0-coq-8.15'
   repo: 'mathcomp/mathcomp'
 - version: '1.13.0-coq-8.14'
-  repo: 'mathcomp/mathcomp'
-- version: '1.13.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 
 dependencies:


### PR DESCRIPTION
Drop 8.13 as per https://github.com/coq/opam-coq-archive/pull/2413 and https://github.com/thery/coqprime/commit/de61546b6ffbdc9775e48d0c400cdf60e34d329b 