### PR TITLE
Restrict to MathComp 1 to fix CI.

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - 'coqorg/coq:dev'
+          #- 'coqorg/coq:dev'
           - 'mathcomp/mathcomp:1.15.0-coq-8.16'
           - 'mathcomp/mathcomp:1.14.0-coq-8.15'
           - 'mathcomp/mathcomp:1.13.0-coq-8.14'

--- a/coq-addition-chains.opam
+++ b/coq-addition-chains.opam
@@ -19,7 +19,7 @@ depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-paramcoq" {(>= "1.1.3" & < "1.2~") | (= "dev")}
-  "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.16~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.16~")}
   "coq-mathcomp-algebra"
 ]
 

--- a/coq-gaia-hydras.opam
+++ b/coq-gaia-hydras.opam
@@ -18,8 +18,8 @@ depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-hydra-battles" {= version}
-  "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.16~") | (= "dev")}
-  "coq-mathcomp-zify"
+  "coq-mathcomp-ssreflect" {(>= "1.13.0" & < "1.16~")}
+  "coq-mathcomp-zify" {< "2"}
   "coq-gaia-schutte" {(>= "1.14" & < "1.16~") | (= "dev")}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -119,7 +119,7 @@ supported_coq_versions:
   opam: '{(>= "8.14" & < "8.18~") | (= "dev")}'
 
 tested_coq_opam_versions:
-- version: 'dev'
+#- version: 'dev'
 - version: '1.15.0-coq-8.16'
   repo: 'mathcomp/mathcomp'
 - version: '1.14.0-coq-8.15'
@@ -140,7 +140,7 @@ dependencies:
     [Paramcoq](https://github.com/coq-community/paramcoq) 1.1.3 or later
 - opam:
     name: coq-mathcomp-ssreflect
-    version: '{(>= "1.13.0" & < "1.16~") | (= "dev")}'
+    version: '{(>= "1.13.0" & < "1.16~")}'
   description: |-
     [MathComp SSReflect](https://github.com/math-comp/math-comp) 1.13 or later
 - opam:
@@ -154,6 +154,7 @@ dependencies:
     [Gaia's Schütte ordinals](https://github.com/coq-community/gaia) 1.14 or later
 - opam:
     name: coq-mathcomp-zify
+    version: '{(< "2~")}'
   description: |-
     [Mczify](https://github.com/math-comp/mczify)
 - opam:


### PR DESCRIPTION
This is a quick and dirty fix. If it works, we should also update `meta.yml`, the README, etc.