### PR TITLE
Use ZornsLemma for def of Countable sets

### DIFF
--- a/.nix/config.nix
+++ b/.nix/config.nix
@@ -45,6 +45,10 @@
     coqPackages.gaia-hydras.override.version = ../.;
     coqPackages.goedel.override.version = ../.;
     coqPackages.coqprime.override.version = "master";
+    coqPackages.zorns-lemma.override.version = builtins.fetchurl {
+      url = "https://github.com/coq-community/topology/archive/v10.2.0.tar.gz";
+      sha256 = "1h8fyaafkc0k7i4y9j1zn5rx55pk7n2n105clfzrwl66ws19j7aj";
+    };
 
     ## In some cases, light overrides are not available/enough
     ## in which case you can use either

--- a/.nix/coq-overlays/hydra-battles-single/default.nix
+++ b/.nix/coq-overlays/hydra-battles-single/default.nix
@@ -1,5 +1,5 @@
 { lib, mkCoqDerivation, coq, version ? null
-, coqprime, equations, gaia, LibHyps, mathcomp-ssreflect, mathcomp-algebra, mathcomp-zify, paramcoq
+, coqprime, equations, gaia, LibHyps, mathcomp-ssreflect, mathcomp-algebra, mathcomp-zify, paramcoq, zorns-lemma
 , python3Packages, serapi, texlive, withMovies ? true, withTex ? true }:
 
 with lib; mkCoqDerivation rec {
@@ -51,6 +51,7 @@ with lib; mkCoqDerivation rec {
     mathcomp-algebra
     mathcomp-zify
     paramcoq
+    zorns-lemma
   ];
 
   meta = {

--- a/.nix/coq-overlays/hydra-battles/default.nix
+++ b/.nix/coq-overlays/hydra-battles/default.nix
@@ -1,0 +1,37 @@
+{ lib, mkCoqDerivation, coq, equations, LibHyps, zorns-lemma
+, version ? null }:
+with lib;
+
+mkCoqDerivation {
+  pname = "hydra-battles";
+  owner = "coq-community";
+
+  release."0.4".sha256 = "1f7pc4w3kir4c9p0fjx5l77401bx12y72nmqxrqs3qqd3iynvqlp";
+  release."0.5".sha256 = "121pcbn6v59l0c165ha9n00whbddpy11npx2y9cn7g879sfk2nqk";
+  release."0.6".sha256 = "1dri4sisa7mhclf8w4kw7ixs5zxm8xyjr034r1377p96rdk3jj0j";
+  releaseRev = (v: "v${v}");
+
+  inherit version;
+  defaultVersion = with versions; switch coq.coq-version [
+    { case = range "8.13" "8.15"; out = "0.6"; }
+    { case = range "8.11" "8.12"; out = "0.4"; }
+  ] null;
+
+  propagatedBuildInputs = [ equations LibHyps zorns-lemma ];
+
+  useDune2 = true;
+
+  meta = {
+    description = "Exploration of some properties of Kirby and Paris' hydra battles, with the help of Coq";
+    longDescription = ''
+      An exploration of some properties of Kirby and Paris' hydra
+      battles, with the help of the Coq Proof assistant. This
+      development includes the study of several representations of
+      ordinal numbers, and a part of the so-called Ketonen and Solovay
+      machinery (combinatorial properties of epsilon0).
+    '';
+    maintainers = with maintainers; [ siraben Zimmi48 ];
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/coq-hydra-battles.opam
+++ b/coq-hydra-battles.opam
@@ -20,6 +20,7 @@ depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-equations" {(>= "1.2" & < "1.4~") | (= "dev")}
+  "coq-zorns-lemma" { = "10.1.0" }
   "coq-libhyps"
 ]
 

--- a/coq-hydra-battles.opam
+++ b/coq-hydra-battles.opam
@@ -20,7 +20,7 @@ depends: [
   "dune" {>= "2.5"}
   "coq" {(>= "8.14" & < "8.18~") | (= "dev")}
   "coq-equations" {(>= "1.2" & < "1.4~") | (= "dev")}
-  "coq-zorns-lemma" { = "10.1.0" }
+  "coq-zorns-lemma" { >= "10.2.0" }
   "coq-libhyps"
 ]
 

--- a/theories/ordinals/Gamma0/Gamma0.v
+++ b/theories/ordinals/Gamma0/Gamma0.v
@@ -1096,7 +1096,7 @@ Module  Gamma0_prec <: Precedence.
     intros s; destruct s; simpl; trivial.
   Qed.
 
-  Lemma prec_transitive : transitive A prec.
+  Lemma prec_transitive : transitive prec.
   Proof.
     intros s1 s2 s3; destruct s1; destruct s2; destruct s3;
       simpl; intros; trivial; contradiction.

--- a/theories/ordinals/Schutte/AP.v
+++ b/theories/ordinals/Schutte/AP.v
@@ -16,6 +16,7 @@ In fact,  #<math> &omega; <sup> &alpha; </sup> </math># , written  [phi0 alpha] 
 
 (* begin hide *)
 From Coq Require Import Arith  Logic.Epsilon  Ensembles  Lia.
+From ZornsLemma Require Import CountableTypes.
 From hydras Require Export Countable  Schutte_basics
      Ordering_Functions.
 Import  PartialFun  MoreEpsilonIota .
@@ -355,7 +356,7 @@ Section AP_closed.
   Variable M : Ensemble Ord.
   Hypothesis OM : Included M AP.
   Hypothesis inhM : Inhabited M.
-  Hypothesis denM : countable M.
+  Hypothesis denM : Countable M.
 
   Remark supM_gt0 : zero < |_| M.
   Proof.
@@ -557,7 +558,7 @@ Qed.
 
 Lemma phi0_sup : forall U: Ensemble Ord,
     Inhabited U ->
-    countable U ->
+    Countable U ->
     phi0 (|_| U) = |_| (image U phi0). (* .no-out *)
 (*| .. coq:: none |*)
 Proof.
@@ -699,11 +700,11 @@ Qed.
 Lemma epsilon0_fxp : phi0 epsilon0 = epsilon0.
 Proof.
   unfold epsilon0, omega_limit; rewrite phi0_sup.
-  assert (D1: countable (image (seq_range omega_tower) phi0)).
+  assert (D1: Countable (image (seq_range omega_tower) phi0)).
   { apply countable_image.
     apply seq_range_countable.
   }
-  assert (D2: countable (seq_range omega_tower)).
+  assert (D2: Countable (seq_range omega_tower)).
   { apply Countable.seq_range_countable. }
   -  apply le_antisym.
      +  apply sup_mono; trivial.

--- a/theories/ordinals/Schutte/AP.v
+++ b/theories/ordinals/Schutte/AP.v
@@ -700,13 +700,8 @@ Lemma epsilon0_fxp : phi0 epsilon0 = epsilon0.
 Proof.
   unfold epsilon0, omega_limit; rewrite phi0_sup.
   assert (D1: countable (image (seq_range omega_tower) phi0)).
-  { exists (fun alpha i =>  alpha = omega_tower i).
-    split.
-    -  red; destruct 1 as [x [H H0]].
-       destruct H as [i [_ H]];   exists (S i);
-         cbn; rewrite H; auto.
-    - red;  destruct 1;  destruct H;  split. 
-    -  red; intros; congruence.
+  { apply countable_image.
+    apply seq_range_countable.
   }
   assert (D2: countable (seq_range omega_tower)).
   { apply Countable.seq_range_countable. }

--- a/theories/ordinals/Schutte/AP.v
+++ b/theories/ordinals/Schutte/AP.v
@@ -354,7 +354,7 @@ Qed.
 Section AP_closed.
   Variable M : Ensemble Ord.
   Hypothesis OM : Included M AP.
-  Hypothesis inhM : Inhabited _ M.
+  Hypothesis inhM : Inhabited M.
   Hypothesis denM : countable M.
 
   Remark supM_gt0 : zero < |_| M.
@@ -556,7 +556,7 @@ Qed.
 
 
 Lemma phi0_sup : forall U: Ensemble Ord,
-    Inhabited _ U ->
+    Inhabited U ->
     countable U ->
     phi0 (|_| U) = |_| (image U phi0). (* .no-out *)
 (*| .. coq:: none |*)

--- a/theories/ordinals/Schutte/AP.v
+++ b/theories/ordinals/Schutte/AP.v
@@ -4,13 +4,13 @@
 
 (** Pierre Casteran, LaBRI, Universite de Bordeaux *)
 
-  
+
 (**
 
 In this library, we define the exponential of basis omega, also called [phi0].
 
-In fact,  #<math> &omega; <sup> &alpha; </sup> </math># , written  [phi0 alpha] in Coq, 
- is defined as the [alpha]-th _additive principal_ ordinal. 
+In fact,  #<math> &omega; <sup> &alpha; </sup> </math># , written  [phi0 alpha] in Coq,
+ is defined as the [alpha]-th _additive principal_ ordinal.
 
  *)
 
@@ -28,13 +28,13 @@ Set Implicit Arguments.
 
 (** ** Main Definitions
 
- *** Additive principal ordinals 
+ *** Additive principal ordinals
  *)
 
 (* begin snippet APDef *)
 
 Definition AP : Ensemble Ord :=
-  fun alpha => 
+  fun alpha =>
     zero < alpha /\
     (forall beta, beta < alpha -> beta + alpha = alpha).
 
@@ -66,7 +66,7 @@ Fixpoint omega_tower (i : nat) : Ord :=
 
 (* end snippet omegaTower *)
 
-(** *** The limit ordinal [epsilon0] 
+(** *** The limit ordinal [epsilon0]
  *)
 (* begin snippet epsilon0Def *)
 
@@ -95,7 +95,7 @@ Lemma least_AP : least_member lt AP 1.
 (* end snippet APOne_least_AP *)
 Proof.
   repeat split.
-  - simpl (F 1). auto with schutte. 
+  - simpl (F 1). auto with schutte.
   - intros beta H;  assert (beta = zero).
     { simpl (F 1) in H; apply le_alpha_zero,  lt_succ_le_2.
       assumption.
@@ -104,8 +104,8 @@ Proof.
   - intros x  H0; tricho x (F 1) H3.
     + simpl (F 1) in H3; assert (x = zero).
     { now apply le_alpha_zero, lt_succ_le_2. }
-     subst x; destruct H0; now case (@lt_irrefl zero). 
-    + subst x; now left.  
+     subst x; destruct H0; now case (@lt_irrefl zero).
+    + subst x; now left.
     + right; auto.
 Qed.
 
@@ -118,7 +118,7 @@ Proof.
     +  simpl (F 1) ; auto with schutte.
     + apply finite_lt_omega.
   - intros beta H; case (@lt_omega_finite _  H).
-    intros;subst beta;apply finite_plus_infinite; auto with schutte. 
+    intros;subst beta;apply finite_plus_infinite; auto with schutte.
 Qed.
 
 
@@ -154,7 +154,7 @@ Proof with auto with schutte.
   - split.
     +  apply finite_lt_omega.
     + apply AP_omega.
-  -  intros x  H0; case (@trichotomy x omega).  
+  -  intros x  H0; case (@trichotomy x omega).
      + intro H1; case (lt_omega_finite  H1).
        intros; subst x.
        destruct  H0 as [H2 H3]; generalize (AP_finite_eq_one _ H3).
@@ -164,7 +164,7 @@ Qed.
 
 (* begin snippet APPlusClosed *)
 
-Lemma AP_plus_closed (alpha beta gamma : Ord): 
+Lemma AP_plus_closed (alpha beta gamma : Ord):
   In AP alpha -> beta < alpha -> gamma < alpha ->
   beta + gamma < alpha. (* .no-out *)
 (*| .. coq:: none |*)
@@ -173,7 +173,7 @@ Proof with auto with schutte.
   generalize (@plus_mono_r  beta gamma alpha); intro H4.
   replace alpha with (beta+alpha) ...
   Qed.
-    
+
 (*||*)
 
 (* end snippet APPlusClosed *)
@@ -199,12 +199,12 @@ Qed.
 
 Section AP_Unbounded.
   Variable alpha : Ord.
-  
-  Let seq := (fix seq (n:nat)  := 
+
+  Let seq := (fix seq (n:nat)  :=
                 match n with 0 => succ alpha
                         | S p => (seq p) + (seq p)
                 end).
-  
+
 
   Let beta := omega_limit seq.
 
@@ -218,7 +218,7 @@ Section AP_Unbounded.
         apply plus_mono_r ...
   Qed.
 
-  
+
   Lemma mono_seq2 : forall i j, (i < j)%nat -> seq i < seq j.
   Proof with auto.
     induction  1.
@@ -233,7 +233,7 @@ Section AP_Unbounded.
     intros i j H; destruct (le_lt_eq_dec _ _ H).
     - right; now apply mono_seq2.
     - subst j;  left ...
-      
+
   Qed.
 
   #[local] Hint Resolve mono_seq mono_seq2 : schutte.
@@ -257,8 +257,8 @@ Section AP_Unbounded.
     Hypothesis lt_ksi : ksi < beta.
 
     Remark lt_beta_exists : exists n, ksi < seq n.
-    Proof. 
-      case (@lt_omega_limit_lt_exists_lt ksi seq mono_seq); auto.   
+    Proof.
+      case (@lt_omega_limit_lt_exists_lt ksi seq mono_seq); auto.
       intros;exists x;auto.
     Qed.
 
@@ -271,19 +271,19 @@ Section AP_Unbounded.
       intros m H; apply le_trans with (seq (S m)).
       -  simpl; apply plus_mono_weak_l.
          +  apply le_trans with (seq n).
-            *  right; unfold n, some;  
+            *  right; unfold n, some;
                  pattern (epsilon InHWit (fun n0 : nat => ksi < seq n0));
                  apply epsilon_ind.
                apply lt_beta_exists.
                elim H;  auto.
             *  destruct (le_lt_eq_dec n m H).
-               right; apply mono_seq2;  auto.  
+               right; apply mono_seq2;  auto.
                subst m;left; split ...
       -  right;apply lt_omega_limit.
          + apply seq_mono_intro ...
     Qed.
 
-    Lemma ksi_plus_seq_n' : forall (m:nat), ksi + seq m <= beta.  
+    Lemma ksi_plus_seq_n' : forall (m:nat), ksi + seq m <= beta.
     Proof.
       intro m ; destruct  (Nat.le_gt_cases n m) as [H | H].
       -  apply ksi_plus_seq_n;auto.
@@ -297,7 +297,7 @@ Section AP_Unbounded.
     Lemma ksi_plus_beta : ksi + beta <= beta.
     Proof.
       unfold beta at 1; unfold omega_limit.
-      rewrite alpha_plus_sup. 
+      rewrite alpha_plus_sup.
       -  apply sup_least_upper_bound; eauto with schutte.
          +  apply R1 with ordinal (ge ksi).
             * apply plus_ordering; auto.
@@ -322,7 +322,7 @@ Section AP_Unbounded.
   Lemma AP_unbounded_0 : alpha < beta /\ AP beta.
   Proof.
     split.
-    -  apply alpha_lt_beta. 
+    -  apply alpha_lt_beta.
     -  split.
        + apply zero_lt_beta.
        +  intros; apply ksi_plus_beta_eq; eauto with schutte.
@@ -337,7 +337,7 @@ End AP_Unbounded.
 Theorem AP_unbounded : Unbounded AP. (* .no-out *)
 Proof. (* .no-out *)
   intro x.
-  
+
   exists (omega_limit
             (fix seq (n : nat) : Ord :=
                match n with
@@ -356,14 +356,14 @@ Section AP_closed.
   Hypothesis OM : Included M AP.
   Hypothesis inhM : Inhabited _ M.
   Hypothesis denM : countable M.
-  
+
   Remark supM_gt0 : zero < |_| M.
   Proof.
     destruct inhM as [x H]; apply lt_le_trans with x.
     -  now  destruct (OM H).
     -  apply sup_upper_bound; auto with schutte.
   Qed.
-  
+
   Lemma AP_sup : In AP (|_| M).
   Proof.
     split.
@@ -394,8 +394,8 @@ Section AP_closed.
              }
        + apply le_plus_r;eauto with schutte.
   Qed.
-  
-End AP_closed.  
+
+End AP_closed.
 
 (* end hide *)
 
@@ -416,10 +416,10 @@ Proof.
   intros;apply segment_unbounded.
   eapply SA2.
   eapply ord_ok;eauto.
-  generalize 
-    (ordering_unbounded_unbounded 
-       (A:=the_ordering_segment AP) 
-       (B:=AP) 
+  generalize
+    (ordering_unbounded_unbounded
+       (A:=the_ordering_segment AP)
+       (B:=AP)
        (f:=phi0)); intro H.
   generalize (H (ord_ok  AP)); intro H0;  rewrite <- H0.
   now  apply AP_unbounded.
@@ -450,7 +450,7 @@ Qed.
 (*| .. coq:: no-out |*)
 
 Lemma phi0_elim : forall P : (Ord->Ord)->Prop,
-    (forall f: Ord->Ord, 
+    (forall f: Ord->Ord,
         ordering_function f ordinal AP -> P f) ->
     P phi0.
 Proof.
@@ -461,7 +461,7 @@ Lemma AP_phi0 (alpha : Ord) : In AP (phi0 alpha). (* .no-out *)
 Proof. (* .no-out *)
   pattern phi0; apply phi0_elim.
   destruct 1 as [H H0 H1 H2];  apply H0;auto; split.
-Qed. 
+Qed.
 
 
 Lemma phi0_zero : phi0 zero =  1. (* .no-out *)
@@ -501,7 +501,7 @@ Proof.
 Qed.
 (*||*)
 
-Lemma phi0_mono_R_weak (alpha beta: Ord): 
+Lemma phi0_mono_R_weak (alpha beta: Ord):
     phi0 alpha <= phi0 beta -> alpha <= beta. (* .no-out *)
 (*| .. coq:: none |*)
 Proof.
@@ -537,9 +537,9 @@ Lemma plus_lt_phi0 (ksi alpha: Ord):
 Proof.
   pattern (phi0 alpha);  apply phi0_elim;  intros f Hf;
     assert (H: AP (f alpha)).
-  {  destruct Hf as [H0 H1 H2 H3]. 
+  {  destruct Hf as [H0 H1 H2 H3].
      apply H1 ; split. }
-  destruct H;  auto. 
+  destruct H;  auto.
 Qed.
 (*||*)
 
@@ -580,7 +580,7 @@ Proof.
   - intro; split.
   - exists zero; tricho zero alpha HH; auto.
     +  subst alpha; destruct H as [H _]; now destruct H.
-    + destruct (not_lt_zero HH). 
+    + destruct (not_lt_zero HH).
   - apply countable_members;auto.
 Qed.
 (*||*)
@@ -590,14 +590,14 @@ Lemma AP_to_phi0 (alpha : Ord) :
 (*| .. coq:: none |*)
 Proof.
   intro H; pattern phi0;apply phi0_elim.
-  destruct 1 as [H0 H1 H2 H3].  
+  destruct 1 as [H0 H1 H2 H3].
   case (H2 _ H); intros x [_ H4]; exists x; now rewrite H4.
 Qed.
 (*||*)
 
 
 Lemma AP_plus_AP (alpha beta gamma : Ord) :
-  zero < beta -> 
+  zero < beta ->
   phi0 alpha + beta = phi0 gamma ->
   alpha < gamma /\  beta = phi0 gamma. (* .no-out *)
 (*| .. coq:: none |*)
@@ -634,7 +634,7 @@ Proof.
     apply lt_le_trans with alpha;auto.
     rewrite <- H0;  pattern phi0; apply phi0_elim.
     intros f H1; eapply ordering_le; [ eauto |].
-    split. 
+    split.
   - intro H0; destruct H0 as [x H0].
     generalize (@AP_phi0 alpha).
     intro H1; destruct H1 as [H1 H2]; rewrite H0 in H2.
@@ -643,7 +643,7 @@ Proof.
       assert (H5 :zero < x).
     { tricho zero x H8.
       -  auto.
-      -  subst x;  replace (succ zero) with (F 1) in H0. 
+      -  subst x;  replace (succ zero) with (F 1) in H0.
          + rewrite <- phi0_zero in H0.
            case (@lt_irrefl (phi0 zero)).
            pattern (phi0 zero) at 2; rewrite <- H0.
@@ -658,15 +658,15 @@ Proof.
     generalize (succ_mono  H6);  rewrite <- H4.
     intros H7; apply lt_irrefl with (succ (x+x));  auto.
     now rewrite plus_of_succ in H7.
-Qed. 
+Qed.
 (*||*)
 
 
 Lemma omega_eqn : omega = phi0 1. (* .no-out *)
 (*| .. coq:: none |*)
-Proof. 
+Proof.
   destruct (AP_to_phi0 (AP_omega)) as [beta Hbeta]; rewrite Hbeta;
-    tricho beta (F 1) H. 
+    tricho beta (F 1) H.
   -   destruct (finite_lt_inv 1 H ) as [i [H0 H1]].
       inversion H0.
       +  subst i beta; simpl in Hbeta; rewrite  phi0_zero in Hbeta.
@@ -716,7 +716,7 @@ Proof.
        exists alpha; split; auto.
        * exists i; auto.
        * apply le_phi0.
-  - exists (phi0 zero), 0; simpl; rewrite phi0_zero; split; auto. 
+  - exists (phi0 zero), 0; simpl; rewrite phi0_zero; split; auto.
   - apply Countable.seq_range_countable.
 Qed.
 
@@ -755,7 +755,7 @@ Proof.
   - assert (H2 : omega_tower j <= alpha).
     {
       tricho  alpha (omega_tower j) H2.
-      -   specialize (H1 _ H2);  assert False 
+      -   specialize (H1 _ H2);  assert False
           by (destruct H1; abstract lia); contradiction.
       -   left; auto.
       -   right;auto.
@@ -794,5 +794,5 @@ Qed.
 Lemma phi0_lt_epsilon0_R (alpha : Ord):
   phi0 alpha < epsilon0  -> alpha < epsilon0.
 Proof.
-  intro H; rewrite <- epsilon0_fxp in H; now  apply phi0_mono_R.     
+  intro H; rewrite <- epsilon0_fxp in H; now  apply phi0_mono_R.
 Qed.

--- a/theories/ordinals/Schutte/Addition.v
+++ b/theories/ordinals/Schutte/Addition.v
@@ -3,7 +3,7 @@ From Coq Require Import Arith  Logic.Epsilon  Ensembles.
 From hydras Require Export Schutte_basics  Ordering_Functions
      PartialFun  Countable  MoreEpsilonIota.
 Set Implicit Arguments.
-Require Export STDPP_compat. 
+Require Export STDPP_compat.
 
 (** * Definitions *)
 
@@ -19,7 +19,7 @@ Infix "+"  := plus : schutte_scope.
 
 (** returns [alpha * (S n)]
 *)
-                       
+
 (* begin snippet multFin *)
 
 Fixpoint mult_Sn (alpha:Ord)(n:nat){struct n} :Ord :=
@@ -38,7 +38,7 @@ Infix "*" := mult_fin_r : schutte_scope.
 
 (* end snippet multFin *)
 
-(** * Proofs, proofs, proofs 
+(** * Proofs, proofs, proofs
 *)
 
 
@@ -60,17 +60,17 @@ Proof.
   intros;apply segment_unbounded.
   - pattern  (the_ordering_segment (ge alpha)); apply iota_ind.
     +  generalize  (ordering_segment_ex_unique (ge alpha));
-         intros. destruct  H. 
+         intros. destruct  H.
        destruct H.
        exists x; split;auto.
     +  destruct 1;eapply ordering_function_seg;eauto.
-  -     generalize 
-          (ordering_unbounded_unbounded 
-             (A:=the_ordering_segment (ge alpha)) 
-             (B:=ge alpha) 
+  -     generalize
+          (ordering_unbounded_unbounded
+             (A:=the_ordering_segment (ge alpha))
+             (B:=ge alpha)
              (f:=plus alpha));  intros H.
         apply H.
-        unfold plus; intros;  apply ord_ok. 
+        unfold plus; intros;  apply ord_ok.
         apply Unbounded_ge;auto.
 Qed.
 
@@ -86,7 +86,7 @@ Qed.
 (* begin snippet plusElim:: no-out  *)
 Lemma plus_elim (alpha : Ord) :
   forall P : (Ord->Ord)->Prop,
-    (forall f: Ord->Ord, 
+    (forall f: Ord->Ord,
         ordering_function f ordinal (ge alpha)-> P f) ->
     P (plus alpha).
 Proof.
@@ -94,11 +94,11 @@ Proof.
 Qed.
 (* end snippet plusElim *)
 
-Lemma normal_plus_alpha (alpha : Ord) : 
+Lemma normal_plus_alpha (alpha : Ord) :
   normal (plus alpha) (ge alpha).
 Proof.
  unfold plus;pattern (ord (ge alpha)).
- unfold ord, some;apply epsilon_ind. 
+ unfold ord, some;apply epsilon_ind.
  -  rewrite ge_o_segment; trivial.
    +  exists (plus alpha);apply (plus_ordering alpha); auto.
 -  intros a H0; rewrite ge_o_segment in H0; trivial.
@@ -106,10 +106,10 @@ Proof.
    apply Th_13_5_2; trivial.
 +   intros M H1 H2 H3;  destruct H2; apply le_trans with x;auto.
        *  specialize (H1 _ H);  apply H1.
-       *  apply sup_upper_bound;auto. 
+       *  apply sup_upper_bound;auto.
 Qed.
 
-(** ** Basic properties of addition 
+(** ** Basic properties of addition
  *)
 
 (* begin snippet alphaPlusZero *)
@@ -133,7 +133,7 @@ Remark ge_zero : (ge zero : Ensemble Ord) = ordinal.
 Proof with eauto with schutte.
   apply Extensionality_Ensembles.
   split.
-   +  red; split.  
+   +  red; split.
    + unfold ge ...
 Qed.
 
@@ -151,7 +151,7 @@ Proof with auto with schutte.
  }
  rewrite ge_zero in H0.
  generalize (ordering_function_unicity H0 H1); destruct 1.
- apply H2; split. 
+ apply H2; split.
 Qed.
 (*||*)
 
@@ -174,7 +174,7 @@ Proof.
 Qed.
 (*||*)
 
-Lemma plus_mono_r (alpha beta gamma : Ord) : 
+Lemma plus_mono_r (alpha beta gamma : Ord) :
   beta < gamma -> alpha + beta < alpha + gamma. (* .no-out *)
 (*||*) (*| .. coq:: none |*)
 Proof.
@@ -191,35 +191,35 @@ Proof with trivial.
  intros plus_alpha Hp;
    assert (H1 :plus_alpha beta < plus_alpha (succ beta)).
  {  eapply ordering_function_mono.
-    apply Hp. 
+    apply Hp.
     split.
     split.
     apply lt_succ; auto.
  }
  generalize (@lt_succ_le (plus_alpha  beta) (plus_alpha  (succ beta))).
  intros H2.
- generalize (H2 H1);  intro H5; case (le_disj H5) ; auto. 
+ generalize (H2 H1);  intro H5; case (le_disj H5) ; auto.
  intro H6;case Hp;intros H H3 H4 H7.
  case (H4 (succ (plus_alpha beta))).
  -  red; apply le_trans with (plus_alpha  beta).
    +  generalize (H beta );  unfold In,  ge.
       intro H9; apply H3. split.
-   +  right; apply lt_succ. 
+   +  right; apply lt_succ.
  -  intros x [Hx Ex].  absurd ( beta < x /\ x < succ beta).
     + intro H8; decompose [and] H8;clear H8.
       assert (H8: succ beta <= x) by (apply lt_succ_le; eauto with schutte).
       case (@lt_irrefl (succ beta)).
       eapply le_lt_trans. apply H8. assumption.
     +  split.
-   *  eapply ordering_function_monoR. apply Hp. 
+   *  eapply ordering_function_monoR. apply Hp.
       split.
-      assumption. 
+      assumption.
       rewrite Ex.  auto with schutte.
    *  rewrite <- Ex in H6; eapply ordering_function_monoR.
-      apply Hp. 
+      apply Hp.
       assumption.
       split.
-      assumption. 
+      assumption.
 Qed.
 (*||*)
 
@@ -229,7 +229,7 @@ Lemma plus_mono_r_weak (alpha beta gamma : Ord) :
   beta <= gamma -> alpha + beta <= alpha + gamma.
 Proof.
   intros  H;  case (le_disj H).
- - intros; subst gamma; auto with schutte.    
+ - intros; subst gamma; auto with schutte.
  - right;  apply plus_mono_r;auto.
 Qed.
 
@@ -247,10 +247,10 @@ Qed.
 
 
 Lemma succ_is_plus_1 alpha :  succ alpha = alpha + 1.
-Proof. 
+Proof.
    rewrite  <- alpha_plus_zero  at 1; change (F 1) with (succ zero).
    rewrite   plus_of_succ;   now repeat rewrite alpha_plus_zero.
-Qed. 
+Qed.
 
 
 Lemma alpha_plus_sup (alpha : Ord) (A : Ensemble Ord) :
@@ -270,7 +270,7 @@ Lemma plus_limit (alpha beta : Ord)
 Proof.
  intros H ; generalize (is_limit_sup_members H);intro e.
  generalize (@normal_plus_alpha alpha ); intro H2.
- pattern beta at 1;rewrite e; destruct H2 as [H0 [H1 [H2 H3]]].  
+ pattern beta at 1;rewrite e; destruct H2 as [H0 [H1 [H2 H3]]].
  rewrite <- H3;auto.
  -  red;split.
  - case H. exists zero.
@@ -284,7 +284,7 @@ Qed.
 
 
 Lemma plus_FF : forall i j, F (i + j) = F i + F j.
-Proof. 
+Proof.
  induction i.
  -  simpl.
      intros;rewrite zero_plus_alpha;auto with schutte.
@@ -306,23 +306,23 @@ Proof.
  -  apply le_antisym; auto with schutte.
   +    unfold omega_limit;  apply sup_mono;auto with schutte.
    *   apply Ordering_Functions.R1 with ordinal (ge (F 1)).
-       apply plus_ordering.  
+       apply plus_ordering.
        apply    countable_members;auto with schutte.
-       red; split. 
-   *      intros x [a [H1 H2]]. 
+       red; split.
+   *      intros x [a [H1 H2]].
           red in H1; case (@lt_omega_finite _  H1).
           intros n e; exists (F (S n)).
           subst x; split;auto with schutte.
           exists (S n); trivial.
           subst a. split;auto.
-        subst a. left;  now rewrite <- plus_FF . 
+        subst a. left;  now rewrite <- plus_FF .
   + unfold omega_limit; apply sup_mono.
   *    apply seq_range_countable; auto with schutte.
   *  simpl; auto with schutte.
      apply Ordering_Functions.R1 with ordinal (ge (succ zero)).
      apply plus_ordering; auto with schutte.
      apply countable_members; auto with schutte.
-     red; split. 
+     red; split.
   *  intros x [x0 [_ Hx]]; subst x.
      exists (F (S x0));split;auto with schutte.
      exists (F x0);split;auto with schutte.
@@ -345,7 +345,7 @@ Qed.
 
 Section proof_of_associativity.
   Variables alpha beta : Ord.
-  
+
   Lemma plus_assoc1 (gamma : Ord) :
     alpha + beta <= alpha + (beta + gamma) .
   Proof.
@@ -404,7 +404,7 @@ Section proof_of_associativity.
   Lemma plus_assoc3 (gamma : Ord) :
     f_alpha_beta  gamma =  g_alpha_beta gamma.
   Proof.
-    case of_u; intros H0 H1; apply H1. 
+    case of_u; intros H0 H1; apply H1.
     split.
   Qed.
 
@@ -425,7 +425,7 @@ Proof.
 Qed.
 
 Lemma one_plus_infinite (alpha : Ord) :
-  omega <= alpha ->  1 + alpha = alpha. 
+  omega <= alpha ->  1 + alpha = alpha.
 Proof.
  intros  H.
  generalize (minus_exists H); intros [gamma e];  subst alpha .
@@ -442,8 +442,8 @@ Proof.
  - simpl; intros;rewrite zero_plus_alpha;trivial.
  -  intros; simpl; replace (succ (F n)) with (F 1 + F n).
     + rewrite <- plus_assoc.
-      rewrite IHn. 
-      * apply one_plus_infinite; assumption. 
+      rewrite IHn.
+      * apply one_plus_infinite; assumption.
       * assumption.
   + now   rewrite <- plus_FF.
 Qed.
@@ -468,14 +468,14 @@ Proof.
  apply le_plus_r.
 Qed.
 
-Lemma plus_mono_bi : forall alpha beta gamma delta, 
+Lemma plus_mono_bi : forall alpha beta gamma delta,
                         alpha <= gamma ->
-                        beta < delta -> 
+                        beta < delta ->
                         alpha + beta < gamma + delta.
 Proof.
  intros alpha beta gamma delta H H0; apply le_lt_trans with (gamma+beta).
  now apply plus_mono_weak_l.
- now apply plus_mono_r. 
+ now apply plus_mono_r.
 Qed.
 
 Lemma mult_fin_r_one : forall n, (F 1) * S n = F (S n).
@@ -486,16 +486,16 @@ Lemma mult_fin_r_one : forall n, (F 1) * S n = F (S n).
       rewrite alpha_plus_zero;auto with schutte.
  Qed.
 
- 
-Lemma mult_fin_r_mono : forall alpha beta , alpha < beta -> 
+
+Lemma mult_fin_r_mono : forall alpha beta , alpha < beta ->
    forall n,  alpha * S n <  beta * S n.
 Proof.
- induction n; simpl; [assumption|].  
+ induction n; simpl; [assumption|].
  apply plus_mono_bi; [ right; assumption | assumption].
 Qed.
- 
-Lemma le_a_mult_Sn_a : forall alpha n, ordinal alpha -> 
-                                       alpha <= alpha * S n.                           
+
+Lemma le_a_mult_Sn_a : forall alpha n, ordinal alpha ->
+                                       alpha <= alpha * S n.
 Proof.
  intros alpha n H;  case n.
  -  simpl;auto with schutte.
@@ -515,7 +515,7 @@ Proof with auto with schutte.
 Qed.
 
 Lemma mult_Sn_mono3 : forall alpha, zero < alpha ->
-                         forall n p, (n < p)%nat -> alpha * S n + alpha 
+                         forall n p, (n < p)%nat -> alpha * S n + alpha
                                                     <=  alpha * S p.
 Proof with auto with schutte.
  intros a Ha; induction 1 .
@@ -527,6 +527,6 @@ Qed.
 
 
 
-  
- 
-  
+
+
+

--- a/theories/ordinals/Schutte/Addition.v
+++ b/theories/ordinals/Schutte/Addition.v
@@ -254,7 +254,7 @@ Qed.
 
 
 Lemma alpha_plus_sup (alpha : Ord) (A : Ensemble Ord) :
-    Inhabited _ A ->
+    Inhabited A ->
     countable A ->
     alpha + |_| A = |_| (image A (plus alpha)).
 Proof.
@@ -523,10 +523,3 @@ Proof with auto with schutte.
  - simpl; apply plus_mono_weak_l.
    apply lt_le; apply  mult_Sn_mono2 ...
 Qed.
-
-
-
-
-
-
-

--- a/theories/ordinals/Schutte/Addition.v
+++ b/theories/ordinals/Schutte/Addition.v
@@ -1,5 +1,6 @@
 
 From Coq Require Import Arith  Logic.Epsilon  Ensembles.
+From ZornsLemma Require Import CountableTypes.
 From hydras Require Export Schutte_basics  Ordering_Functions
      PartialFun  Countable  MoreEpsilonIota.
 Set Implicit Arguments.
@@ -255,7 +256,7 @@ Qed.
 
 Lemma alpha_plus_sup (alpha : Ord) (A : Ensemble Ord) :
     Inhabited A ->
-    countable A ->
+    Countable A ->
     alpha + |_| A = |_| (image A (plus alpha)).
 Proof.
  intros  H0 H1 ;  generalize (@normal_plus_alpha alpha ).

--- a/theories/ordinals/Schutte/CNF.v
+++ b/theories/ordinals/Schutte/CNF.v
@@ -13,12 +13,12 @@ Require Export  Classical.
 
 Set Implicit Arguments.
 
-(** A Cantor normal form for a countable ordinal [alpha] is just a sorted 
+(** A Cantor normal form for a countable ordinal [alpha] is just a sorted
 list [l] (in decreasing order) such that  [alpha]  is equal to the sum of the terms [phi0 beta], for every term [beta] in [l].
 
 
-Note that, if [alpha] is greater or equal than [epsilon0], the members of [l] 
-are less _or equal_ than [alpha]. 
+Note that, if [alpha] is greater or equal than [epsilon0], the members of [l]
+are less _or equal_ than [alpha].
 
 For instance, the Cantor Normal Form of [epsilon0] is just [epsilon0 :: nil].
 
@@ -67,12 +67,12 @@ Proof.
    + apply phi0_mono;auto.
 Qed.
 
-  
+
 Lemma sorted_tail  alpha l:
   sorted (cons alpha l) -> sorted l.
 Proof.  inversion 1; auto with schutte. Qed.
 
-Lemma nf_bounded : forall beta  l alpha, 
+Lemma nf_bounded : forall beta  l alpha,
                         alpha <= phi0 beta  ->
                         is_cnf_of alpha l -> exponents_le beta l.
 Proof.
@@ -101,7 +101,7 @@ Proof.
  intros H0 H1 H2 H3; destruct (H2 alpha H) as [x [Hx Ex]].
  subst alpha;  exists (cons  x nil); split.
  - constructor.
- - simpl; now  rewrite alpha_plus_zero. 
+ - simpl; now  rewrite alpha_plus_zero.
 Qed.
 
 
@@ -126,15 +126,15 @@ Qed.
 
 
  Lemma sorted_lt_lt_2 l alpha :
-   sorted (cons alpha l) -> 
+   sorted (cons alpha l) ->
    eval (cons alpha l) < phi0 (succ alpha).
 Proof.
  intros;apply (sorted_lt_lt H).
- inversion H;intros;eauto with schutte. 
+ inversion H;intros;eauto with schutte.
 Qed.
 
 
-Lemma cnf_head_eq alpha beta ol ol': 
+Lemma cnf_head_eq alpha beta ol ol':
                          sorted (cons alpha ol) ->
                          sorted (cons beta ol') ->
                          eval (cons alpha ol) = eval (cons beta ol') ->
@@ -151,7 +151,7 @@ Proof.
     + rewrite <- H1; simpl;  apply le_plus_l.
 Qed.
 
-Lemma cnf_eq  alpha beta ol ol': 
+Lemma cnf_eq  alpha beta ol ol':
   sorted (cons alpha ol) ->
   sorted (cons beta ol') ->
   eval (cons alpha ol) = eval (cons beta ol') ->
@@ -164,11 +164,11 @@ Qed.
 
 
 Lemma cnf_plus1 (ol : cnf_t) :
- sorted ol ->  forall alpha, 
+ sorted ol ->  forall alpha,
     exists ol',  is_cnf_of (phi0 alpha + eval ol) ol'.
 Proof.
  induction ol.
- -  inversion_clear  1 . 
+ -  inversion_clear  1 .
     intros alpha;  simpl;  exists  (cons alpha nil).
     split.
     + constructor.
@@ -185,10 +185,10 @@ Proof.
       * now simpl.
 Qed.
 
- 
+
 Lemma cnf_plus2 : forall ol, sorted ol ->
                     forall ol', sorted ol' ->
-                     exists ol'', is_cnf_of (eval ol + eval ol') ol''. 
+                     exists ol'', is_cnf_of (eval ol + eval ol') ol''.
 Proof.
  induction ol.
  - simpl; intros; rewrite zero_plus_alpha;auto.
@@ -196,7 +196,7 @@ Proof.
  -  intros; simpl; assert (sorted ol).
     {  inversion H;auto with schutte. }
    destruct  (IHol H1 _ H0) as [x [H3 H4]].
-   destruct  (@cnf_plus1 _ H3 a) as [x0 H5]. 
+   destruct  (@cnf_plus1 _ H3 a) as [x0 H5].
    exists x0; rewrite <- H4 in H5; now  rewrite <- plus_assoc.
 Qed.
 
@@ -212,7 +212,7 @@ Qed.
 
 (* begin hide *)
 
-Lemma not_AP_inv_0 : forall alpha, 
+Lemma not_AP_inv_0 : forall alpha,
                     zero < alpha ->
                     ~ (AP alpha) ->
                     exists beta,zero < beta /\
@@ -225,13 +225,13 @@ Proof with eauto with schutte.
   - case (@lt_irrefl alpha).
     apply le_lt_trans with (beta+alpha) ...
     apply le_plus_r ...
-  -  case H1; exists beta; split ; auto. 
+  -  case H1; exists beta; split ; auto.
      tricho zero beta H4; auto with schutte.
      +  subst beta; rewrite zero_plus_alpha in H3;
           case (@lt_irrefl alpha);auto.
-     +   now   case (@not_lt_zero beta).     
+     +   now   case (@not_lt_zero beta).
 Qed.
- 
+
 Lemma not_AP_inv2 : forall alpha, zero < alpha -> ~AP alpha ->
                                exists beta, exists gamma,
                                      zero < beta /\ zero < gamma /\
@@ -245,7 +245,7 @@ Proof with eauto with schutte.
   - intros eta  H2; exists eta; split ; auto.
     split;auto.
     + tricho zero eta H3; trivial.
-      *  subst eta; rewrite alpha_plus_zero in H2; trivial. 
+      *  subst eta; rewrite alpha_plus_zero in H2; trivial.
          decompose [and] H'khi; subst alpha; case (@lt_irrefl khi);auto.
       *  case (@not_lt_zero eta) ...
     +  decompose [and] H'khi; split;auto.
@@ -282,11 +282,11 @@ Proof.
     intros a H0 H1; case (classic (AP a)).
     + intros H2;  apply cnf_of_ap; auto.
     +  intros H2; case (not_AP_inv2 H1 H2).
-       intros x H3; destruct H3 as [z [H4' [H5' H6]]]. 
+       intros x H3; destruct H3 as [z [H4' [H5' H6]]].
        case (H0 x).
        * case H6;auto.
        * auto.
-       * intros x0 H; case (H0 z). 
+       * intros x0 H; case (H0 z).
         --  tauto.
         --  auto.
         --  intros x1 H4;  decompose [and] H6;  subst a.
@@ -310,7 +310,7 @@ Qed.
 
 
 
-(** *** Unicity of cnf 
+(** *** Unicity of cnf
 
 (Proof by induction on lists)
 
@@ -349,7 +349,7 @@ Proof.
           split;auto.
           inversion H3; auto with schutte.
           rewrite H6;split;auto with schutte.
-          inversion H1; auto with schutte. 
+          inversion H1; auto with schutte.
 Qed.
 (*||*)
 (* end snippet cnfUnicity *)
@@ -361,7 +361,7 @@ Qed.
 
 (*| .. coq:: no-out |*)
 Theorem cnf_exists_unique (alpha:Ord) :
-  exists! l: cnf_t, is_cnf_of alpha l. 
+  exists! l: cnf_t, is_cnf_of alpha l.
 Proof.
     destruct (cnf_exists alpha) as [l Hl]; exists l; split; auto.
     now apply cnf_unicity.
@@ -383,11 +383,11 @@ Proof.
   induction l.
   - constructor.
   - unfold is_cnf_of.
-    destruct 1 as [H e]. 
+    destruct 1 as [H e].
     intro H0; simpl.
-    assert (Hlt : a < phi0 a).   
+    assert (Hlt : a < phi0 a).
     {
-      apply lt_phi0;  simpl in e;  subst alpha; 
+      apply lt_phi0;  simpl in e;  subst alpha;
        apply le_lt_trans with (phi0 a); auto with schutte.
       - apply le_phi0.
       - apply le_lt_trans with (2 := H0);  apply le_plus_l.
@@ -408,7 +408,7 @@ Qed.
 
 (* end snippet cnfLtEpsilon0 *)
 
-(** The normal form of [epsilon0] is just [phi0 epsilon0] 
+(** The normal form of [epsilon0] is just [phi0 epsilon0]
  *)
 
 (* begin snippet cnfOfEpsilon0 *)
@@ -418,7 +418,7 @@ Qed.
 Lemma cnf_of_epsilon0 : is_cnf_of epsilon0 (epsilon0 :: nil).
 Proof.
   split.
-  - constructor.  
+  - constructor.
   - simpl; now rewrite alpha_plus_zero, epsilon0_fxp.
 Qed.
 (*||*)

--- a/theories/ordinals/Schutte/Correctness_E0.v
+++ b/theories/ordinals/Schutte/Correctness_E0.v
@@ -4,18 +4,18 @@
 
   Pierre Castéran, Univ. Bordeaux and LaBRI
 
-   This is intented to be a validation of main constructions and functions 
+   This is intented to be a validation of main constructions and functions
    designed for the type [T1].
 
 *)
 
-(*  Pierre Casteran 
+(*  Pierre Casteran
     LaBRI, Université Bordeaux 1
 *)
 
 
 
-From hydras Require Import Epsilon0.Epsilon0 ON_Generic. 
+From hydras Require Import Epsilon0.Epsilon0 ON_Generic.
 From hydras Require Import Schutte_basics  Schutte.Addition  AP CNF.
 
 
@@ -40,14 +40,14 @@ Proof.
     + repeat rewrite phi0_zero.
       rewrite alpha_plus_zero; auto with schutte.
       * rewrite <- succ_is_plus_1.
-             f_equal. 
-    + rewrite alpha_plus_zero. 
+             f_equal.
+    + rewrite alpha_plus_zero.
      *  rewrite alpha_plus_zero in IHn.
-        rewrite IHn. 
+        rewrite IHn.
         replace (AP._phi0 zero) with (F 1).
         rewrite <- succ_is_plus_1; auto with schutte.
-        symmetry; auto with schutte. 
-        apply phi0_zero. 
+        symmetry; auto with schutte.
+        apply phi0_zero.
 Qed.
 
 
@@ -134,7 +134,7 @@ Proof.
        apply le_plus_r;auto with schutte.
 Qed.
 
-Lemma zero_lt alpha n beta : 
+Lemma zero_lt alpha n beta :
   zero < mult_Sn (AP._phi0 alpha) n + beta.
 Proof.
  apply lt_le_trans with (AP._phi0 alpha).
@@ -144,7 +144,7 @@ Proof.
    +  apply le_plus_r;auto.
    +  apply  le_plus_l;auto with schutte.
 Qed.
- 
+
 
 Lemma head_lt :  forall a a' n n' b b',
     a  < a' -> b < AP._phi0 a'  ->
@@ -169,14 +169,14 @@ Proof.
  -  apply lt_le_trans with (mult_Sn (AP._phi0 a) n + AP._phi0 a).
    +  apply plus_mono_r; auto.
    +  apply mult_Sn_mono3; auto.
-     *  apply  phi0_positive; auto. 
- - apply le_plus_l. 
-Qed. 
+     *  apply  phi0_positive; auto.
+ - apply le_plus_l.
+Qed.
 
 Lemma inject_mono_0 : forall alpha,
     T1.nf alpha ->
-    forall beta gamma, 
-      T1.lt  beta gamma -> 
+    forall beta gamma,
+      T1.lt  beta gamma ->
       T1.lt gamma alpha ->
       T1.nf beta -> T1.nf gamma ->
       (inject beta < inject gamma)%sch.
@@ -184,38 +184,38 @@ Proof with eauto with T1.
   intros alpha;  T1.transfinite_induction alpha.
   intros x Indx Nx;  induction beta; destruct gamma.
   {  intros H H0;  T1.T1_inversion H. }
-  { intros H H0 H1 H2;  simpl; 
+  { intros H H0 H1 H2;  simpl;
       apply lt_le_trans with (AP._phi0 (inject gamma1))%sch.
     -  apply phi0_positive;auto with schutte.
-    - eapply le_trans. 
+    - eapply le_trans.
       2:eapply le_plus_l; auto with schutte.
       apply le_a_mult_Sn_a; auto with schutte.
   }
   intros H H0 H1 H2;  T1.T1_inversion H.
   intros H H0 H1 H2; simpl;  destruct (T1.lt_inv H).
-  -   apply head_lt.    
+  -   apply head_lt.
       +  eapply IHbeta1 ...
 
          * apply T1.lt_trans with  (T1.cons gamma1 n0 gamma2) ...
-      +  apply lt_trans with (inject (T1.phi0 beta1)). 
+      +  apply lt_trans with (inject (T1.phi0 beta1)).
          *   eapply IHbeta2 ...
              apply T1.nf_helper_phi0.
-             apply T1.nf_helper_intro with n; auto. 
+             apply T1.nf_helper_intro with n; auto.
              apply Comparable.le_lt_trans with (T1.cons beta1 n beta2); auto with T1.
              apply T1.le_phi0 ; eauto with T1.
              eapply T1.lt_trans ...
          * simpl; rewrite alpha_plus_zero.
-           apply phi0_mono,  IHbeta1; auto. 
+           apply phi0_mono,  IHbeta1; auto.
            apply T1.lt_trans with (T1.cons gamma1 n0 gamma2) ...
            eauto with T1.
            eauto with T1.
   -     decompose [or and] H3.
-        subst;  apply coeff_lt. 
+        subst;  apply coeff_lt.
         + replace  (AP._phi0 (inject gamma1)) with (inject (T1.phi0 gamma1)).
           *  apply IHbeta2.
              apply T1.nf_helper_phi0.
              eapply T1.nf_helper_intro; eauto.
-             apply Comparable.le_lt_trans with (T1.cons gamma1 n0 gamma2); auto. 
+             apply Comparable.le_lt_trans with (T1.cons gamma1 n0 gamma2); auto.
              destruct n0.
              apply T1.le_tail ...
              apply Comparable.lt_incl_le.
@@ -230,15 +230,15 @@ Proof with eauto with T1.
            2: eapply H0.
            auto with T1.
            apply T1.tail_lt_cons; auto.
-Qed. 
+Qed.
 
 (* end hide *)
 
 Theorem inject_mono (beta gamma : T1) :
-  T1.lt  beta gamma -> 
-  T1.nf beta -> T1.nf gamma -> 
+  T1.lt  beta gamma ->
+  T1.nf beta -> T1.nf gamma ->
   inject beta < inject gamma.
-Proof.  
+Proof.
   intros H H0 H1; apply inject_mono_0 with (T1.succ gamma);auto.
   -  apply T1.succ_nf;auto.
   -  apply T1.lt_succ;auto.
@@ -247,24 +247,24 @@ Qed.
 Theorem inject_injective (beta gamma : T1) : nf beta -> nf gamma ->
                                              inject beta = inject gamma -> beta = gamma.
 Proof.
-  intros H H0 H1. 
+  intros H H0 H1.
   destruct (LT_eq_LT_dec H H0) as [[H2 | H2] | H2]; auto.
-  destruct H2 as [H3 [H4 H5]].   apply inject_mono in H4; auto.    
+  destruct H2 as [H3 [H4 H5]].   apply inject_mono in H4; auto.
   rewrite H1 in H4; auto.
   destruct (lt_irrefl H4); auto.
-  destruct H2 as [H3 [H4 H5]].   apply inject_mono in H4; auto.    
+  destruct H2 as [H3 [H4 H5]].   apply inject_mono in H4; auto.
   rewrite H1 in H4; auto.
   destruct (lt_irrefl H4); auto.
 Qed.
 
-Theorem inject_monoR (beta gamma : T1) : 
-  T1.nf beta -> T1.nf gamma -> 
-  inject beta < inject gamma -> 
+Theorem inject_monoR (beta gamma : T1) :
+  T1.nf beta -> T1.nf gamma ->
+  inject beta < inject gamma ->
   (beta  t1< gamma)%t1.
-Proof.  
-  intros H H0 H1; 
+Proof.
+  intros H H0 H1;
   destruct (T1.lt_eq_lt_dec beta gamma) as [[H2 | H2] | H2].
-  -  now split.  
+  -  now split.
   -  subst ;  case (lt_irrefl  H1).
   -  destruct (@lt_irrefl (inject beta)).
      eapply lt_trans with (inject gamma); auto.
@@ -298,7 +298,7 @@ Section Equations_for_addition.
         (n : nat) : alpha + mult_Sn (AP._phi0 beta) n = mult_Sn (AP._phi0 beta) n.
   Proof.
     induction n.
-    - simpl;    destruct (AP_phi0 beta ) as [ _ H1];   apply  (H1 _ H).  
+    - simpl;    destruct (AP_phi0 beta ) as [ _ H1];   apply  (H1 _ H).
     - simpl;  rewrite plus_assoc; now rewrite IHn.
   Qed.
 
@@ -306,10 +306,10 @@ Section Equations_for_addition.
     mult_Sn alpha (S (n + p)) = mult_Sn alpha p + mult_Sn alpha n.
   Proof.
     induction n; simpl.
-    - reflexivity. 
+    - reflexivity.
     - rewrite  plus_assoc;  f_equal.
       now   rewrite <- IHn.
-  Qed. 
+  Qed.
 
 
 
@@ -331,7 +331,7 @@ Section Equations_for_addition.
 where "alpha + beta" := (plus alpha beta) : t1_scope.
    *)
 
-  
+
 
   Variables (a b c d : Ord) (n p : nat).
 
@@ -353,7 +353,7 @@ where "alpha + beta" := (plus alpha beta) : t1_scope.
       assert (b < AP._phi0 c).
       { apply lt_trans with (AP._phi0 a); auto with schutte.
         now apply phi0_mono.
-      }   
+      }
       rewrite (plus_assoc b (mult_Sn (AP._phi0 c) p) d).
       rewrite (plus_alpha_mult_phi0 _ _ H p).
       rewrite  plus_assoc .
@@ -364,15 +364,15 @@ where "alpha + beta" := (plus alpha beta) : t1_scope.
       now apply phi0_mono.
     Qed.
 
-    
+
   End case1.
 
   Section case2.
     Hypothesis Hac : c < a.
 
     Lemma case_gt : alpha + beta = mult_Sn (AP._phi0 a) n +
-                                   (b + beta). 
-    Proof. 
+                                   (b + beta).
+    Proof.
       unfold alpha;  now  rewrite plus_assoc.
     Qed.
 
@@ -413,7 +413,7 @@ Proof with eauto with T1.
   - simpl;  now rewrite zero_plus_alpha.
   -  intros H H0;  destruct beta.
      + simpl (inject (T1.cons  alpha1 n alpha2));
-         rewrite <- plus_assoc; simpl (inject T1.zero); 
+         rewrite <- plus_assoc; simpl (inject T1.zero);
            now rewrite alpha_plus_zero.
 
      + repeat rewrite inject_rw.
@@ -423,19 +423,19 @@ Proof with eauto with T1.
        * apply compare_eq_iff in H1 as <-.
           rewrite <- (case_Eq (inject alpha1) (inject alpha2)
                               (inject alpha1) (inject  beta2) n n0) ...
-          -- assert (H1 : (alpha2 t1< T1.phi0  alpha1)%t1). 
+          -- assert (H1 : (alpha2 t1< T1.phi0  alpha1)%t1).
              {  rewrite nf_LT_iff in H;  tauto. }
           rewrite <- inject_of_phi0.
           apply inject_mono ...
           -- rewrite <- inject_of_phi0; apply inject_mono ...
              rewrite nf_LT_iff in H0 ...
-             decompose [and] H0 ... 
+             decompose [and] H0 ...
         * rewrite compare_lt_iff in H1.
           { repeat rewrite inject_rw; rewrite case_lt; auto.
             rewrite <- inject_of_phi0;  apply inject_mono ...
             -  rewrite nf_LT_iff in H; decompose [and] H ...
             -  apply inject_mono; eauto with T1.
-          }  
+          }
         * rewrite compare_gt_iff in H1.
           repeat rewrite inject_rw; rewrite case_gt.
           f_equal; rewrite IHalpha2 ...
@@ -462,10 +462,10 @@ Proof.
         destruct alpha; auto.
         destruct alpha1.
         *   f_equal;  destruct n; simpl; auto.
-            assert (alpha2 = T1.zero).  
+            assert (alpha2 = T1.zero).
             {  eapply nf_of_finite; eauto. }
             -- subst. f_equal; ring.
-            -- assert (alpha2 = T1.zero).  
+            -- assert (alpha2 = T1.zero).
             {  eapply nf_of_finite; eauto. }
             subst.
             replace (n * 1)%nat with n; auto with arith.
@@ -478,8 +478,8 @@ Proof.
                 reflexivity.
                 auto with arith.
             -- reflexivity.
-         * 
-           { 
+         *
+           {
              clear IHn; induction n; simpl.
              destruct alpha;  auto.
              destruct alpha1.
@@ -488,11 +488,11 @@ Proof.
              destruct alpha; auto with T1.
              destruct alpha1.
               apply nf_of_finite in H; subst; apply nf_FS.
-             eapply nf_coeff_irrelevance. eauto. 
+             eapply nf_coeff_irrelevance. eauto.
            }
          *   auto with arith.
          * auto.
-Qed. 
+Qed.
 (*||*)
 (* end snippet injectMultFinR *)
 
@@ -504,13 +504,13 @@ Lemma inject_lt_epsilon0_ex_cnf  (alpha : Ord) :
 Proof.
   pattern alpha; apply well_founded_induction with (R:=lt).
   { exact all_ord_acc. }
-  { clear alpha; intros alpha IHalpha H. 
+  { clear alpha; intros alpha IHalpha H.
     destruct l.
     -  exists T1.zero;  simpl;   unfold nf; split; auto.
     - inversion_clear   1.
       pose (H3 := IHalpha o).
       assert (H0 : o < alpha).
-      { simpl in H2; 
+      { simpl in H2;
           subst alpha; apply lt_le_trans with (AP._phi0 o).
         - apply lt_phi0; apply le_lt_trans with (AP._phi0 o).
           + apply le_phi0.
@@ -531,7 +531,7 @@ Proof.
         * split; trivial.
           eapply sorted_tail; eauto.
         *   destruct H10 as [H10 H11];  exists (T1.phi0 x0 + x1)%t1.
-            split.    
+            split.
             -- apply plus_nf ; eauto with T1.
             -- simpl eval;  rewrite <- H11;  rewrite inject_plus; auto with T1.
                simpl (inject (T1.phi0 x0)); rewrite H9;  destruct H5.

--- a/theories/ordinals/Schutte/Countable.v
+++ b/theories/ordinals/Schutte/Countable.v
@@ -6,12 +6,18 @@ From Coq Require Import Ensembles  Arith ArithRing (* Even Div2 *)
      Wellfounded Relations  Wf_nat  Finite_sets
      Logic.Epsilon  Sets.Image Lia.
 
+From ZornsLemma Require Import Classical_Wf CountableTypes Families.
+
 From hydras Require Import MoreEpsilonIota PartialFun  GRelations
      Prelude.More_Arith.
 
 Import Nat.
 
 Set Implicit Arguments.
+
+(** A is countable if there exists an injection from [A] to
+  [Full_set nat]. *)
+Notation countable := ZornsLemma.CountableTypes.Countable.
 
 Section Countable.
 
@@ -25,592 +31,85 @@ Section Countable.
   are not required to be functional (injectivity is only needed to ensure that
   A is countable). *)
 
-
-
     Definition rel_numbers (R: GRelation U nat) := rel_injection A Full_set R.
 
     (** Predicate for relations which enumerate A. *)
     Definition rel_enumerates (R : GRelation nat U) := rel_surjection Full_set A R.
 
-     (** A is countable if there exists an injection from [A] to
-        [Full_set nat]. *)
-
-    Definition countable : Prop := exists R, rel_numbers R.
-
-    Section Equivalence_with_surjection.
-
-      Theorem countable_surj :
-        countable <-> exists R, rel_enumerates R.
-      Proof.
+    Theorem countable_surj :
+      countable A <-> exists R, rel_enumerates R.
+    Proof.
+      split.
+      - intros [f Hf].
+        exists (fun (n : nat) (x : U) =>
+             exists H : In A x,
+               f (exist _ x H) = n).
         split.
-        - intros   (R, R_enum).
-          exists (rel_inv A Full_set R).
-          red; apply R_inv_surj; trivial.
-        - destruct 1 as [R R_surj].
-        exists (rel_inv Full_set A R); red;  apply R_inv_inj; trivial.
-      Qed.
-    End Equivalence_with_surjection.
+        + intros n x _ [Hx0 Hx1].
+          apply Hx0.
+        + intros n x y _ [Hx0 Hx1] [Hy0 Hy1].
+          subst. apply Hf in Hy1.
+          inversion Hy1; subst; clear Hy1.
+          reflexivity.
+        + intros x H.
+          exists (f (exist _ x H)).
+          split; [constructor|].
+          exists H. reflexivity.
+      - intros [R HR].
+        (* send each [p] to the least [n : nat] for which [R n (proj1_sig p)] *)
+        assert (
+            forall p : { x : U | In A x },
+            exists ! x : nat,
+              R x (proj1_sig p) /\
+                (forall m : nat, R m (proj1_sig p) -> (x <= m)%nat))
+          as Hrel.
+        { destruct HR as [HR0 HR1 HR2].
+          intros p.
+          pose proof
+            (WF_implies_MEP nat _ lt_wf_0
+               (fun n : nat => R n (proj1_sig p))
+            ) as Hwf.
+          specialize (HR2 (proj1_sig p) (proj2_sig p))
+            as [n' [_ Hn']].
+          destruct Hwf as [n [Hn0 Hn1]].
+          { exists n'. assumption. }
+          clear n' Hn'.
+          exists n. split; [split|].
+          * assumption.
+          * intros m Hm.
+            specialize (Hn1 m Hm).
+            lia.
+          * intros m [Hm0 Hm1].
+            specialize (Hn1 m Hm0).
+            specialize (Hm1 n Hn0).
+            lia.
+        }
+        exists (fun p : { x : U | In A x } =>
+             proj1_sig
+               (constructive_definite_description
+                  _ (Hrel p))).
+        intros p0 p1 Hp.
+        pose proof
+          (proj2_sig
+             (constructive_definite_description
+                _ (Hrel p0))) as [Hp0 _].
+        pose proof
+          (proj2_sig
+             (constructive_definite_description
+                _ (Hrel p1))) as [Hp1 _].
+        rewrite Hp in Hp0.
+        destruct HR as [_ HR _].
+        specialize (HR _ _ _ ltac:(constructor) Hp0 Hp1).
+        clear Hp Hp0 Hp1 Hrel.
+        destruct p0 as [? H0], p1 as [? H1].
+        simpl in HR. subst.
+        destruct (proof_irrelevance _ H0 H1).
+        reflexivity.
+    Qed.
 
   End Definitions.
 
   Variable U : Type.
-
-  (** [Union _ A B] is countable if [A] and [B] are countable. *)
-
-  Section Countable_union.
-
-    Section Countable_union_lemmas.
-
-      Variables E F : Ensemble U.
-      Variables RE RF : U -> nat -> Prop.
-
-      Hypothesis RE_enum : rel_numbers E RE.
-      Hypothesis RF_enum : rel_numbers F RF.
-
-      Inductive R_union (x : U) : nat -> Prop :=
-        from_E : forall n : nat, In E x -> RE x n -> R_union x (double n)
-      | from_F : forall n : nat, In F x -> RF x n -> R_union x (S (double n)).
-
-      Lemma R_union_domain : rel_domain (Union E F) R_union.
-      Proof.
-        intros a aInUnion.
-        induction aInUnion.
-        - red in RE_enum; destruct RE_enum as (Hdomain, _, _).
-          destruct (Hdomain x).
-          + assumption.
-          + exists (double x0); apply from_E; assumption.
-         - destruct RF_enum as (Hdomain, _ , _);  destruct (Hdomain x).
-           + assumption.
-           + exists (S (double x0)); apply from_F; assumption.
-      Qed.
-
-      Lemma R_union_codomain :
-        rel_codomain (Union E F) Full_set R_union.
-      Proof.
-        split.
-      Qed.
-
-      Remark R_union_double:
-        forall (x : U) (n : nat), R_union x (double n) -> RE x n.
-      Proof.
-        intros x n R_x_2n; inversion R_x_2n.
-        - replace n with n0; trivial.
-          apply double_inj; assumption.
-        - destruct (not_double_is_s_double _ _ H).
-      Qed.
-
-      Remark R_union_S_double :
-        forall (x : U) (n : nat), R_union x (S (double n)) -> RF x n.
-      Proof.
-        intros x n R_x_s2n; inversion R_x_s2n.
-        - symmetry in H;  case (not_double_is_s_double _ _ H).
-        - replace n with n0.
-         + assumption.
-         + apply double_inj; assumption.
-      Qed.
-
-      Lemma R_union_inj : rel_inj (Union E F) R_union.
-      Proof.
-        intros a a' b a_In_Union a'_In_Union a_R_b a'_R_b.
-        inversion a_R_b as [na a_In_E a_RE_na dna_b |
-                            na a_In_F a_RF_na sdna_b].
-        - inversion a'_R_b as
-            [na' a'_In_E a'_RE_na' dna'_b |
-             na' a'_In_F a'_RF_na' sdna'_b].
-          + destruct RE_enum as (_, _, RE_inj);
-              apply RE_inj with na'; try assumption.
-            replace na' with na; try assumption.
-            apply double_inj.
-            symmetry in dna'_b; transitivity b; assumption.
-          + rewrite <- dna_b in sdna'_b.
-            case not_double_is_s_double with na' na; assumption.
-        - inversion a'_R_b as
-              [na' a'_In_E a'_RE_na' dna'_b |
-               na' a'_In_F a'_RF_nb sdna'_b].
-          + rewrite <- sdna_b in dna'_b.
-            symmetry in dna'_b.
-            case not_double_is_s_double with na na'; assumption.
-          + destruct RF_enum as (_, _, RF_inj).
-            apply RF_inj with na'; try assumption.
-            replace na' with na; try assumption.
-            apply double_inj.
-            symmetry in sdna'_b;  rewrite <- sdna_b in sdna'_b.
-            injection sdna'_b; trivial.
-      Qed.
-
-      Lemma R_union_enumerates : rel_numbers (Union E F) R_union.
-      Proof.
-        split.
-        - apply R_union_domain.
-        - apply R_union_codomain.
-        - apply R_union_inj.
-      Qed.
-
-    End Countable_union_lemmas.
-
-    Theorem countable_union (E : Ensemble U) (F : Ensemble U) :
-      countable E -> countable F -> countable (Union E F).
-    Proof.
-      intros E_den F_den;  destruct E_den as (RE, RE_enum);
-       destruct F_den as (RF, RF_enum).
-      exists (R_union E F RE RF); apply R_union_enumerates; assumption.
-    Qed.
-
-  End Countable_union.
-
-  Section Countable_inclusion.
-
-    Variables E F : Ensemble U.
-
-    Section Countable_inclusion_lemmas.
-
-      Variable RE : U -> nat -> Prop.
-      Hypothesis RE_enum : rel_numbers E RE.
-      Hypothesis F_in_E : Included F E.
-
-      Lemma R_inclusion_domain : rel_domain F RE.
-      Proof.
-        intros a a_In_F; destruct RE_enum as (RE_domain, _, _).
-        apply RE_domain, F_in_E; assumption.
-      Qed.
-
-      Lemma R_inclusion_codomain : rel_codomain F Full_set RE.
-      Proof.
-        split.
-      Qed.
-
-      Lemma R_inclusion_inj : rel_inj F RE.
-      Proof.
-        intros a a' b a_In_F a'_In_F a_R_B a_'R_b;
-        destruct RE_enum as (_, _, RE_inj);
-        apply (RE_inj a a' b); try apply F_in_E; assumption.
-      Qed.
-
-      Lemma R_inclusion_enumerates : rel_numbers F RE.
-      Proof.
-        split.
-        - apply R_inclusion_domain.
-        - apply R_inclusion_codomain.
-        - apply R_inclusion_inj.
-      Qed.
-
-    End Countable_inclusion_lemmas.
-
-    Theorem countable_inclusion :
-      countable E -> Included F E -> countable F.
-    Proof.
-      intros E_denum F_in_E; destruct E_denum as (RE, RE_enum).
-      exists RE; apply R_inclusion_enumerates; assumption.
-    Qed.
-
-  End Countable_inclusion.
-
-  (* Union of all sets B with B in A. *)
-  Section Infinite_union.
-
-    Variable A : Ensemble (Ensemble U).
-
-    Definition Infinite_union (x : U) : Prop :=
-      exists b, In A b /\ In b x.
-
-    Section Infinite_union_lemmas.
-
-      Variable R : Ensemble U -> nat -> Prop.
-      Variable R_n : nat -> U -> nat -> Prop.
-
-      Hypothesis R_enums : rel_numbers A R.
-      Hypothesis R_n_enums :
-        forall n : nat, forall b : Ensemble U,
-	    In A b -> R b n -> rel_numbers b (R_n n).
-
-      Fixpoint K (n : nat) : nat * nat :=
-        match n with
-          0 => (0, 0)
-        | S n => match K n with
-                   (0, m) => (S m, 0)
-                 | (S n, m) => (n, S m)
-                 end
-        end.
-
-      Definition K_1 : nat * nat -> nat :=
-        fun couple =>
-          let (p, q) := couple in
-          div2 ((p+q+1)*(p+q)) + q.
-
-      Let K_rel (p1 : nat*nat) (p2 : nat*nat) : Prop :=
-        let (p, q) := p1 in
-        let (p', q') := p2 in
-        (p + q < p' + q') \/ (p + q = p' + q' /\ p' < p).
-
-      Let f : nat * nat -> sigT (fun _ : nat => nat) :=
-        fun cpl =>
-          let (p, q) := cpl in
-          existT (fun _ : nat => nat) (p + q) q.
-
-      Let R_K :=
-        (fun x y => (lexprod _ (fun _ => nat) lt (fun _ => lt)) (f x) (f y)).
-
-      Lemma lexof_wf :
-        well_founded R_K.
-      Proof.
-        unfold R_K;
-        apply wf_inverse_image with
-            (R := lexprod _ (fun _ => nat) lt (fun _ => lt)).
-        apply wf_lexprod; intros; apply Wf_nat.lt_wf.
-      Qed.
-
-      Lemma K_rel_wf :  well_founded K_rel.
-      Proof.
-        apply wf_incl with R_K.
-        - intros (p, q) (p', q') HK_rel.
-          case HK_rel.
-          + intros Hin; unfold R_K; unfold f; apply left_lex; assumption.
-          + intros (Hdiag, Hin).
-            unfold R_K, f; rewrite Hdiag; apply right_lex.
-            case (le_lt_dec q' q).
-            * intros Hqin; case (lt_irrefl (p + q)).
-              pattern (p + q) at 1; rewrite Hdiag.
-              apply Nat.add_lt_le_mono ; assumption.
-            * trivial.
-        - apply lexof_wf.
-      Qed.
-
-      Remark double_K_1 :
-        forall p q, double (K_1 (p, q)) = ((p+q+1)*(p+q)) + double q.
-      Proof.
-        intros p q; unfold K_1. (* Here *)
-
-        rewrite double_plus.  f_equal.
-        rewrite div2_of_Even; trivial.
-        apply even_prod.
-      Qed.
-
-      Lemma K_bij :
-        forall p q, K (K_1 (p, q)) = (p, q).
-      Proof.
-        intros p q;  generalize (p, q);
-        intros p0; pattern p0; apply (well_founded_ind K_rel_wf).
-        clear p q p0; intros (p, q) IH.
-        induction q.
-        - induction p.
-          + trivial.
-          + replace (K_1 (S p, 0)) with (S (K_1 (0, p))).
-            simpl K; replace (K (div2 ((p + 1) * p) + p)) with (0, p).
-            trivial.
-            symmetry; unfold K_1 in IH; apply (IH (0, p)).
-            left; auto with arith.
-            apply double_inj.
-            rewrite (double_S (K_1 (0, p))).
-            rewrite (double_K_1 0 p).
-            rewrite (double_K_1 (S p) 0).
-            rewrite <- (plus_n_O (S p)).
-            rewrite (plus_O_n p).
-            unfold double.
-            rewrite (plus_O_n 0); rewrite <- (plus_n_O ((S p + 1) * S p)).
-            replace (S p) with (p + 1).
-            rewrite (plus_2 ((p + 1) * p + (p + p))).
-            ring.
-            lia.
-        - replace (K_1 (p, S q)) with (S (K_1 (S p, q))).
-          unfold K; fold K.
-          replace (K (K_1 (S p, q))) with (S p, q).
-          + trivial.
-          + symmetry; apply IH.
-            right; split; lia.
-          + apply double_inj.
-            rewrite (double_S (K_1 (S p, q))).
-            rewrite (double_K_1 (S p) q).
-            rewrite (double_K_1 p (S q)).
-            rewrite (plus_2 ((S p + q + 1) * (S p + q) + double q)).
-            replace (S q) with (q + 1).
-            replace (S p) with (p + 1).
-            unfold double.
-            ring.
-            lia.
-            lia.
-      Qed.
-
-      Lemma K_rel_dec :
-        forall x y, {K_rel x y} + {x = y} + {K_rel y x}.
-      Proof.
-        intros (p, q) (p', q').
-        case lt_eq_lt_dec with (p + q) (p' + q').
-        - intros Hcp; case Hcp.
-
-        (* p + q < p' + q' *)
-        + intros Hlt; repeat left; assumption.
-
-        (* p + q = p' + q' *)
-        + intros Heq; case lt_eq_lt_dec with p p'.
-          intros Hcpp; case Hcpp.
-          intros Hlt; repeat right; split; [symmetry |]; assumption.
-          intros Heqp; left; right; apply injective_projections; compute.
-          assumption.
-          erewrite <- (Nat.add_cancel_l _ _ p').
-          rewrite Heqp in Heq; assumption.
-          intros Hlt; left; left; right; split; assumption.
-
-        (* p' + q' < p + q *)
-        - intros Hlt; right; left; assumption.
-      Qed.
-
-      Remark K_S_O :
-        forall n, K (S n) <> (0, 0).
-      Proof.
-        intros n Heq; simpl in Heq; symmetry in Heq.
-        case_eq (K n); intros p q Kn_pq.
-        rewrite Kn_pq in Heq.
-        case_eq p.
-        (* p = 0 *)
-        - intros p_eq; rewrite p_eq in Heq.
-          case O_S with q.
-          replace 0 with (fst (0, 0)); replace (S q) with (fst (S q, 0));
-          try (compute; trivial; fail).
-          apply (f_equal (fst (A := nat) (B := nat))); assumption.
-
-        (* p = S r *)
-        - intros r p_eq; rewrite p_eq in Heq.
-          case O_S with q.
-          replace 0 with (snd (0, 0)); replace (S q) with (snd (r, S q));
-          try (compute; trivial; fail).
-          apply (f_equal (snd (A := nat) (B := nat))); assumption.
-      Qed.
-
-      Lemma K_inj :
-        forall n m, K n = K m -> n = m.
-      Proof.
-        intros n m; pattern n, m.
-        apply nat_double_ind; clear n m.
-        - intros n Heq; simpl in Heq; case_eq n.
-        (* n = 0 *)
-          + trivial.
-        (* n = S m *)
-          + intros m n_Sm; rewrite n_Sm in Heq; symmetry in Heq;
-              case K_S_O with m; assumption.
-
-        - intros n Heq; simpl in Heq; case K_S_O with n; assumption.
-        - intros n m Hin Heq; apply eq_S; apply Hin.
-          case_eq (K n); case_eq (K m).
-          intros p' q' Km p q Kn.
-          simpl in Heq; rewrite Km in Heq; rewrite Kn in Heq.
-          case_eq p; case_eq p'.
-        (* p = 0 ; p' = 0 *)
-          + intros p'_eq p_eq; rewrite p_eq in Heq; rewrite p'_eq in Heq.
-            apply injective_projections; compute; auto.
-            injection Heq; auto.
-
-        (* p = 0 ; p' = S r *)
-          + intros r p'_eq p_eq; rewrite p_eq in Heq; rewrite p'_eq in Heq.
-            case O_S with q'.
-            replace 0 with (snd (S q, 0));
-              replace (S q') with (snd (r, S q'));
-          try (compute; trivial; fail).
-            apply (f_equal (snd (A := nat) (B := nat))); assumption.
-
-        (* p = S r ; p' = 0 *)
-          + intros p'_eq r p_eq; rewrite p_eq in Heq; rewrite p'_eq in Heq.
-            case O_S with q;  symmetry;  replace 0 with (snd (S q', 0));
-              replace (S q) with (snd (r, S q));
-              try (compute; trivial; fail).
-            apply (f_equal (snd (A := nat) (B := nat))); assumption.
-
-        (* p = S r ; p' = S r' *)
-          + intros r' p'_eq r p_eq; rewrite p_eq in Heq;
-              rewrite p'_eq in Heq.
-        injection Heq; auto.
-      Qed.
-
-      Definition R_union_qcq (x : U) (n : nat) :=
-        match K n with
-	  (p, q) => exists b, (In A b /\ R b p) /\ (In b x /\ R_n p x q)
-        end.
-
-      Lemma R_union_qcq_domain :
-        rel_domain Infinite_union R_union_qcq.
-      Proof.
-        intros a a_In_Union; elim a_In_Union.
-        intros b (b_In_A, a_In_b).
-        assert (ex_p: exists p, R b p).
-        { destruct R_enums as (R_domain, _, _).
-          now apply R_domain.
-        }
-        elim ex_p; intros p b_R_p.
-
-        assert (ex_q : exists q, R_n p a q).  {
-          destruct (R_n_enums b_In_A b_R_p) as (R_n_domain, _, _).
-          apply R_n_domain.
-          assumption...
-        }
-        elim ex_q; intros q a_Rn_q.
-        exists (K_1 (p, q)).
-        red; replace (K (K_1 (p, q))) with (p, q).
-        exists b.
-        repeat split; assumption...
-        symmetry; apply K_bij...
-      Qed.
-
-      Lemma R_union_qcq_codomain :
-        rel_codomain Infinite_union Full_set R_union_qcq.
-      Proof.
-        split.
-      Qed.
-
-      Lemma R_union_qcq_inj :
-        rel_inj Infinite_union R_union_qcq.
-      Proof.
-        intros a a' n a_In_Union a'_In_Union a_Ru_n a'_Ru_n.
-        red in a_Ru_n; generalize a_Ru_n; case_eq (K n).
-        intros p q K_eq ex_b.
-        red in a'_Ru_n; generalize a'_Ru_n; case_eq (K n).
-        intros p' q' K'_eq.
-        assert (p_eq : p = p').
-        { transitivity (fst (K n));
-          [rewrite K_eq | rewrite K'_eq]; compute; trivial.
-        }
-        assert (q_eq : q = q'). {
-          transitivity (snd (K n));
-          [rewrite K_eq | rewrite K'_eq]; compute; trivial.
-        }
-        rewrite <- p_eq; rewrite <- q_eq.
-        intro ex_b';elim ex_b;
-          intros b ((b_In_A, b_R_p), (b_In_a, a_Rnp_q)).
-        elim ex_b'; intros b' ((b'_In_A, b'_R_p), (b'_In_a', a'_Rnp_q)).
-        assert (b_eq : b = b'). {
-          destruct R_enums as (_, _, R_inj).
-          apply R_inj with p; assumption.
-        }
-        rewrite <- b_eq in b'_In_a'.
-        destruct (R_n_enums b_In_A b_R_p) as (_, _, Rn_inj).
-        apply Rn_inj with q; assumption.
-      Qed.
-
-      Lemma R_union_qcq_numbers :
-        rel_numbers Infinite_union R_union_qcq.
-      Proof.
-        split.
-        - apply R_union_qcq_domain.
-        - apply R_union_qcq_codomain.
-        - apply R_union_qcq_inj.
-      Qed.
-
-    End Infinite_union_lemmas.
-
-    Section Indexed_union_lemmas_2.
-
-      Variable R : GRelation (Ensemble U) nat.
-      Hypothesis R_enum : rel_numbers A R.
-      Hypothesis all_b_denum : forall b : Ensemble U, In A b -> countable b.
-
-
-
-      Remark inh_U_sets : inhabited (Ensemble U).
-      Proof inhabits  Empty_set.
-
-
-      Let b_n (n : nat) :=
-        epsilon inh_U_sets (fun b => In A b /\ R b n).
-
-      Remark bn_R_n :
-        forall n, (exists b, In A b /\ R b n) -> R (b_n n) n.
-      Proof.
-        intros n ex_b; pattern (b_n n); epsilon_elim.
-        intros a (_, a_R_n); assumption.
-      Qed.
-
-      Remark inh_grel_U_nat : inhabited (GRelation U nat).
-      Proof inhabits  (fun (u:U)(n:nat) => True).
-
-      Let R_b (b : Ensemble U) :=
-        epsilon inh_grel_U_nat (fun R => rel_numbers b R).
-
-      Remark Rb_numbers_b :
-        forall b, In A b -> rel_numbers b (R_b b).
-      Proof.
-        intros b b_In_A;
-        pattern (R_b b);  epsilon_elim.
-        apply all_b_denum.
-        assumption.
-      Qed.
-
-      Let R_n (n : nat) (x : U) (m : nat) :=
-        (exists b, R b n) /\ R_b (b_n n) x m.
-
-      Remark Rn_numbers_bn :
-        forall n : nat, In A (b_n n) -> R (b_n n) n ->
-                        rel_numbers (b_n n) (R_n n).
-      Proof.
-        intros n bn_In_A; split.
-        intros x x_In_b.
-        destruct (Rb_numbers_b bn_In_A) as (Rb_dom, _, _).
-        - elim (Rb_dom x); try assumption.
-          intros m x_Rb_m; exists m.
-          split; [exists (b_n n) | idtac]; assumption.
-        - split.
-        - intros x x' m x_In_bn x'_In_bn (ex_b, x_Rb_m) (_, x'_Rb_m).
-          destruct (Rb_numbers_b bn_In_A) as (_, _, Rb_inj).
-          apply Rb_inj with m; assumption.
-      Qed.
-
-
-      Let b_p (b : Ensemble U) :=
-        epsilon (inhabits 0) (fun p => b = b_n p).
-
-      Remark b_is_nth :
-        forall b : Ensemble U, In A b -> b = b_n (b_p b).
-      Proof.
-        intros b b_In_A;  pattern (b_p b); epsilon_elim.
-        destruct R_enum as (R_dom, _, R_inj); elim (R_dom b b_In_A).
-        intros p b_R_p; exists p; pattern (b_n p); epsilon_elim.
-        exists b; split; assumption.
-        intros a (a_In_A, a_R_p); apply R_inj with p; assumption.
-      Qed.
-
-      Lemma all_b_relation :
-        exists R_n : nat -> U -> nat -> Prop,
-        forall n : nat, forall b : Ensemble U,
-            In A b -> R b n -> rel_numbers b (R_n n).
-      Proof.
-        exists R_n; intros n b b_In_A b_R_n.
-        assert (b = b_n n). {
-          pattern (b_n n); epsilon_elim.
-          exists b; split; assumption.
-          destruct R_enum as (_, _, R_inj).
-          intros a (a_In_A, a_R_p).
-          apply R_inj with n; assumption.
-        }
-        rewrite H; rewrite H in b_In_A; rewrite H in b_R_n.
-        apply Rn_numbers_bn; assumption.
-      Qed.
-
-    End Indexed_union_lemmas_2.
-
-    Theorem countable_union_qcq :
-      countable A ->
-      (forall b : Ensemble U, In A b -> countable b) ->
-      countable Infinite_union.
-    Proof.
-      intros A_denum all_b_denum; elim A_denum; intros R R_enum.
-      elim all_b_relation with R; try assumption.
-      intros R_n R_n_enum; exists (R_union_qcq R R_n).
-      apply R_union_qcq_numbers; assumption.
-    Qed.
-
-  End Infinite_union.
-
-  Section Countable_empty.
-
-    Lemma countable_empty :
-      countable (@Empty_set U).
-    Proof.
-      (* Any relation would fit here... *)
-      pose (R := fun (_ : U) (_ : nat) => False).
-      exists R; split.
-      - intros x; destruct 1.
-      -  split.
-      - intros x x' n x_In_empty; case x_In_empty.
-    Qed.
-
-  End Countable_empty.
 
   Section Countable_singleton.
 
@@ -619,23 +118,17 @@ Section Countable.
     Lemma countable_singleton :
       countable (Singleton x).
     Proof.
-      pose (R := fun (y : U) (n : nat) => y = x).
-      exists R; split.
-      - intros y y_In_s; exists 0.
-        inversion y_In_s.
-        rewrite <- H; unfold R; reflexivity.
-      - split.
-      - intros y y' n y_In_s y'_In_s _ _.
-        inversion y_In_s.
-        inversion y'_In_s.
-        subst y; auto.
+      exists (fun _ => 0%nat).
+      intros [y0 H0] [y1 H1] _.
+      inversion H0; subst.
+      inversion H1; subst.
+      destruct (proof_irrelevance _ H0 H1).
+      reflexivity.
     Qed.
 
   End Countable_singleton.
 
   Section Countable_seq_range.
-
-
 
     Definition seq_range (f : nat -> U) : Ensemble U :=
       image Full_set f.
@@ -643,15 +136,12 @@ Section Countable.
     Lemma seq_range_countable :
       forall f, countable (seq_range f).
     Proof.
-      intros f; pose (R := fun (x : U) (n : nat) => f n = x).
-      exists R; split.
-      - intros x; destruct 1.
-        exists x0; unfold R. tauto.
-      - split.
-      -  intros x x' n x_In_sr x'_In_sr x_R_n x'_R_n.
-         unfold R in x_R_n.
-         unfold R in x'_R_n.
-         subst x; auto.
+      intros f.
+      unfold seq_range.
+      rewrite image_as_Im.
+      apply countable_img.
+      apply countable_type_ensemble.
+      apply nat_countable.
     Qed.
 
   End Countable_seq_range.
@@ -669,89 +159,32 @@ Section Countable.
     Lemma countable_bij_fun :
       countable A -> countable B.
     Proof.
-      intro A_denum; red in A_denum.
-      elim A_denum; intros Ru Ru_num.
-      pose (Rv := fun (y : V) (n : nat) =>
-                    exists x : U, In A x /\ g x = y /\ Ru x n).
-      exists Rv.
-      split.
-      - intros y y_In_B; destruct Ru_num as (Ru_dom, _, _).
-        unfold Rv; destruct g_bij as (_, g_onto, _).
-        elim g_onto with y; try assumption.
-        intros x (x_In_A, gx_eq_y).
-        elim Ru_dom with x; try assumption.
-        intros b x_Ru_b.
-        exists b; exists x; repeat split; assumption.
-      - split.
-      - intros y y' n y_In_B y'_In_B y_Rv_n y'_Rv_n.
-        unfold Rv in y_Rv_n; unfold Rv in y'_Rv_n.
-        elim y_Rv_n; intros x (x_In_A, (gx_eq_y, x_Ru_n)).
-        elim y'_Rv_n; intros x' (x'_In_A, (gx'_eq_y', x'_Ru_n)).
-        assert (x_eq : x = x'). {
-          destruct Ru_num as (_, _, Ru_inj).
-          apply Ru_inj with n; assumption.
-        }
-        rewrite <- gx_eq_y; rewrite x_eq; assumption.
+      intros H.
+      apply surj_countable
+        with (f := fun_restr (fun_bijection_codomain g_bij));
+        auto.
+      apply fun_bijection_is_ZL_bijection.
     Qed.
 
     Lemma countable_bij_funR :
       countable B -> countable A.
     Proof.
-      intro B_denum; elim B_denum; intros Rv Rv_num.
-      pose (Ru := fun (x : U) (n : nat) => Rv (g x) n).
-      exists Ru; split.
-      - intros x x_In_A; unfold Ru.
-        destruct Rv_num.
-        apply H.
-        destruct g_bij.
-        apply H2; assumption.
-      - split.
-      - intros x x' n x_In_A x'_In_A x_Ru_n x'_Ru_n.
-        unfold Ru in x_Ru_n; unfold Ru in x'_Ru_n.
-        destruct Rv_num.
-        destruct g_bij; auto.
-        apply H4; auto.
-        apply H1 with n; auto.
+      intros H.
+      apply inj_countable
+        with (f := fun_restr (fun_bijection_codomain g_bij));
+        auto.
+      apply fun_bijection_is_ZL_bijection.
     Qed.
 
   End Countable_bijection.
-
-  Section Countable_finite.
-
-
-
-    Variable A : Ensemble U.
-    Hypothesis A_finite : Finite _ A.
-
-    Theorem countable_finite : countable A.
-    Proof.
-      elim A_finite.
-      - apply countable_empty.
-      - intros A0 A0_finite A0_denum x x_nIn_A0.
-        unfold Add; apply countable_union.
-        assumption.
-        apply countable_singleton.
-    Qed.
-
-  End Countable_finite.
 
 End Countable.
 
 Lemma countable_image : forall (U V:Type)(DA : Ensemble U)(f:U->V),
     countable DA -> countable (image DA f).
 Proof.
-  intros U V DA f H; case H; intros R HR.
-  case HR; intros H0 H1 H2.
-  exists (fun y n => exists x, DA x /\ R x n /\ f x = y).
-  split.
-  -   intros a (a0,(Ha0,H'a0)); case (H0 a0).
-      auto.
-      intros; exists x.
-      exists a0;auto.
-  - split.
-  -  intros a a' b (a0,(Ha0,H'a0)) (a1,(Ha1,H'a1)) (x,(Hx,(H'x,H''x)))
-         (y,(Hy,(H'y,H''y))).
-     generalize (H2 x y b Hx Hy H'x H'y);auto.
-     intro;subst y.
-     transitivity (f x);auto.
+  intros.
+  rewrite image_as_Im.
+  apply countable_img.
+  assumption.
 Qed.

--- a/theories/ordinals/Schutte/Countable.v
+++ b/theories/ordinals/Schutte/Countable.v
@@ -13,9 +13,6 @@ Import Nat.
 
 Set Implicit Arguments.
 
-Arguments rel_injection {A B}.
-Arguments rel_surjection {A B}.
-
 Section Countable.
 
   Section Definitions.

--- a/theories/ordinals/Schutte/Countable.v
+++ b/theories/ordinals/Schutte/Countable.v
@@ -18,7 +18,6 @@ Section Countable.
   Section Definitions.
     Variable U : Type.
     Variable A : Ensemble U.
-    Let Dnat : Ensemble nat := Full_set nat.
 
     (** Predicate for relations which number the elements of A.
 
@@ -28,10 +27,10 @@ Section Countable.
 
 
 
-    Definition rel_numbers (R: GRelation U nat) := rel_injection A Dnat R.
+    Definition rel_numbers (R: GRelation U nat) := rel_injection A Full_set R.
 
     (** Predicate for relations which enumerate A. *)
-    Definition rel_enumerates (R : GRelation nat U) := rel_surjection Dnat A R.
+    Definition rel_enumerates (R : GRelation nat U) := rel_surjection Full_set A R.
 
      (** A is countable if there exists an injection from [A] to
         [Full_set nat]. *)
@@ -45,10 +44,10 @@ Section Countable.
       Proof.
         split.
         - intros   (R, R_enum).
-          exists (rel_inv A Dnat R).
+          exists (rel_inv A Full_set R).
           red; apply R_inv_surj; trivial.
         - destruct 1 as [R R_surj].
-        exists (rel_inv Dnat A R); red;  apply R_inv_inj; trivial.
+        exists (rel_inv Full_set A R); red;  apply R_inv_inj; trivial.
       Qed.
     End Equivalence_with_surjection.
 
@@ -72,7 +71,7 @@ Section Countable.
         from_E : forall n : nat, In E x -> RE x n -> R_union x (double n)
       | from_F : forall n : nat, In F x -> RF x n -> R_union x (S (double n)).
 
-      Lemma R_union_domain : rel_domain (Union U E F) R_union.
+      Lemma R_union_domain : rel_domain (Union E F) R_union.
       Proof.
         intros a aInUnion.
         induction aInUnion.
@@ -86,7 +85,7 @@ Section Countable.
       Qed.
 
       Lemma R_union_codomain :
-        rel_codomain (Union U E F) (Full_set nat) R_union.
+        rel_codomain (Union E F) Full_set R_union.
       Proof.
         split.
       Qed.
@@ -110,7 +109,7 @@ Section Countable.
          + apply double_inj; assumption.
       Qed.
 
-      Lemma R_union_inj : rel_inj (Union U E F) R_union.
+      Lemma R_union_inj : rel_inj (Union E F) R_union.
       Proof.
         intros a a' b a_In_Union a'_In_Union a_R_b a'_R_b.
         inversion a_R_b as [na a_In_E a_RE_na dna_b |
@@ -139,7 +138,7 @@ Section Countable.
             injection sdna'_b; trivial.
       Qed.
 
-      Lemma R_union_enumerates : rel_numbers (Union U E F) R_union.
+      Lemma R_union_enumerates : rel_numbers (Union E F) R_union.
       Proof.
         split.
         - apply R_union_domain.
@@ -150,7 +149,7 @@ Section Countable.
     End Countable_union_lemmas.
 
     Theorem countable_union (E : Ensemble U) (F : Ensemble U) :
-      countable E -> countable F -> countable (Union U E F).
+      countable E -> countable F -> countable (Union E F).
     Proof.
       intros E_den F_den;  destruct E_den as (RE, RE_enum);
        destruct F_den as (RF, RF_enum).
@@ -167,7 +166,7 @@ Section Countable.
 
       Variable RE : U -> nat -> Prop.
       Hypothesis RE_enum : rel_numbers E RE.
-      Hypothesis F_in_E : Included _ F E.
+      Hypothesis F_in_E : Included F E.
 
       Lemma R_inclusion_domain : rel_domain F RE.
       Proof.
@@ -175,7 +174,7 @@ Section Countable.
         apply RE_domain, F_in_E; assumption.
       Qed.
 
-      Lemma R_inclusion_codomain : rel_codomain F (Full_set nat) RE.
+      Lemma R_inclusion_codomain : rel_codomain F Full_set RE.
       Proof.
         split.
       Qed.
@@ -198,7 +197,7 @@ Section Countable.
     End Countable_inclusion_lemmas.
 
     Theorem countable_inclusion :
-      countable E -> Included _ F E -> countable F.
+      countable E -> Included F E -> countable F.
     Proof.
       intros E_denum F_in_E; destruct E_denum as (RE, RE_enum).
       exists RE; apply R_inclusion_enumerates; assumption.
@@ -451,7 +450,7 @@ Section Countable.
       Qed.
 
       Lemma R_union_qcq_codomain :
-        rel_codomain Infinite_union (Full_set nat) R_union_qcq.
+        rel_codomain Infinite_union Full_set R_union_qcq.
       Proof.
         split.
       Qed.
@@ -505,7 +504,7 @@ Section Countable.
 
 
       Remark inh_U_sets : inhabited (Ensemble U).
-      Proof inhabits  (Empty_set U).
+      Proof inhabits  Empty_set.
 
 
       Let b_n (n : nat) :=
@@ -601,7 +600,7 @@ Section Countable.
   Section Countable_empty.
 
     Lemma countable_empty :
-      countable (Empty_set U).
+      countable (@Empty_set U).
     Proof.
       (* Any relation would fit here... *)
       pose (R := fun (_ : U) (_ : nat) => False).
@@ -618,7 +617,7 @@ Section Countable.
     Variable x : U.
 
     Lemma countable_singleton :
-      countable (Singleton _ x).
+      countable (Singleton x).
     Proof.
       pose (R := fun (y : U) (n : nat) => y = x).
       exists R; split.
@@ -639,7 +638,7 @@ Section Countable.
 
 
     Definition seq_range (f : nat -> U) : Ensemble U :=
-      image (Full_set nat) f.
+      image Full_set f.
 
     Lemma seq_range_countable :
       forall f, countable (seq_range f).
@@ -756,4 +755,3 @@ Proof.
      intro;subst y.
      transitivity (f x);auto.
 Qed.
-

--- a/theories/ordinals/Schutte/Countable.v
+++ b/theories/ordinals/Schutte/Countable.v
@@ -26,16 +26,16 @@ Section Countable.
   are not required to be functional (injectivity is only needed to ensure that
   A is countable). *)
 
-   
-    
+
+
     Definition rel_numbers (R: GRelation U nat) := rel_injection A Dnat R.
 
     (** Predicate for relations which enumerate A. *)
     Definition rel_enumerates (R : GRelation nat U) := rel_surjection Dnat A R.
 
-     (** A is countable if there exists an injection from [A] to 
+     (** A is countable if there exists an injection from [A] to
         [Full_set nat]. *)
-    
+
     Definition countable : Prop := exists R, rel_numbers R.
 
     Section Equivalence_with_surjection.
@@ -57,7 +57,7 @@ Section Countable.
   Variable U : Type.
 
   (** [Union _ A B] is countable if [A] and [B] are countable. *)
-  
+
   Section Countable_union.
 
     Section Countable_union_lemmas.
@@ -149,7 +149,7 @@ Section Countable.
 
     End Countable_union_lemmas.
 
-    Theorem countable_union (E : Ensemble U) (F : Ensemble U) : 
+    Theorem countable_union (E : Ensemble U) (F : Ensemble U) :
       countable E -> countable F -> countable (Union U E F).
     Proof.
       intros E_den F_den;  destruct E_den as (RE, RE_enum);
@@ -247,7 +247,7 @@ Section Countable.
         fun cpl =>
           let (p, q) := cpl in
           existT (fun _ : nat => nat) (p + q) q.
-      
+
       Let R_K :=
         (fun x y => (lexprod _ (fun _ => nat) lt (fun _ => lt)) (f x) (f y)).
 
@@ -257,7 +257,7 @@ Section Countable.
         unfold R_K;
         apply wf_inverse_image with
             (R := lexprod _ (fun _ => nat) lt (fun _ => lt)).
-        apply wf_lexprod; intros; apply Wf_nat.lt_wf.  
+        apply wf_lexprod; intros; apply Wf_nat.lt_wf.
       Qed.
 
       Lemma K_rel_wf :  well_founded K_rel.
@@ -282,9 +282,9 @@ Section Countable.
         intros p q; unfold K_1. (* Here *)
 
         rewrite double_plus.  f_equal.
-        rewrite div2_of_Even; trivial. 
-        apply even_prod. 
-      Qed. 
+        rewrite div2_of_Even; trivial.
+        apply even_prod.
+      Qed.
 
       Lemma K_bij :
         forall p q, K (K_1 (p, q)) = (p, q).
@@ -347,7 +347,7 @@ Section Countable.
           intros Hlt; repeat right; split; [symmetry |]; assumption.
           intros Heqp; left; right; apply injective_projections; compute.
           assumption.
-          erewrite <- (Nat.add_cancel_l _ _ p').  
+          erewrite <- (Nat.add_cancel_l _ _ p').
           rewrite Heqp in Heq; assumption.
           intros Hlt; left; left; right; split; assumption.
 
@@ -436,7 +436,7 @@ Section Countable.
           now apply R_domain.
         }
         elim ex_p; intros p b_R_p.
-        
+
         assert (ex_q : exists q, R_n p a q).  {
           destruct (R_n_enums b_In_A b_R_p) as (R_n_domain, _, _).
           apply R_n_domain.
@@ -503,7 +503,7 @@ Section Countable.
       Hypothesis all_b_denum : forall b : Ensemble U, In A b -> countable b.
 
 
-      
+
       Remark inh_U_sets : inhabited (Ensemble U).
       Proof inhabits  (Empty_set U).
 
@@ -526,7 +526,7 @@ Section Countable.
 
       Remark Rb_numbers_b :
         forall b, In A b -> rel_numbers b (R_b b).
-      Proof. 
+      Proof.
         intros b b_In_A;
         pattern (R_b b);  epsilon_elim.
         apply all_b_denum.
@@ -551,7 +551,7 @@ Section Countable.
           destruct (Rb_numbers_b bn_In_A) as (_, _, Rb_inj).
           apply Rb_inj with m; assumption.
       Qed.
-      
+
 
       Let b_p (b : Ensemble U) :=
         epsilon (inhabits 0) (fun p => b = b_n p).
@@ -647,7 +647,7 @@ Section Countable.
       intros f; pose (R := fun (x : U) (n : nat) => f n = x).
       exists R; split.
       - intros x; destruct 1.
-        exists x0; unfold R. tauto. 
+        exists x0; unfold R. tauto.
       - split.
       -  intros x x' n x_In_sr x'_In_sr x_R_n x'_R_n.
          unfold R in x_R_n.

--- a/theories/ordinals/Schutte/Countable.v
+++ b/theories/ordinals/Schutte/Countable.v
@@ -17,7 +17,6 @@ Set Implicit Arguments.
 
 (** A is countable if there exists an injection from [A] to
   [Full_set nat]. *)
-Notation countable := ZornsLemma.CountableTypes.Countable.
 
 Section Countable.
 
@@ -37,7 +36,7 @@ Section Countable.
     Definition rel_enumerates (R : GRelation nat U) := rel_surjection Full_set A R.
 
     Theorem countable_surj :
-      countable A <-> exists R, rel_enumerates R.
+      Countable A <-> exists R, rel_enumerates R.
     Proof.
       split.
       - intros [f Hf].
@@ -116,7 +115,7 @@ Section Countable.
     Variable x : U.
 
     Lemma countable_singleton :
-      countable (Singleton x).
+      Countable (Singleton x).
     Proof.
       exists (fun _ => 0%nat).
       intros [y0 H0] [y1 H1] _.
@@ -134,7 +133,7 @@ Section Countable.
       image Full_set f.
 
     Lemma seq_range_countable :
-      forall f, countable (seq_range f).
+      forall f, Countable (seq_range f).
     Proof.
       intros f.
       unfold seq_range.
@@ -157,7 +156,7 @@ Section Countable.
     Hypothesis g_bij : fun_bijection A B g.
 
     Lemma countable_bij_fun :
-      countable A -> countable B.
+      Countable A -> Countable B.
     Proof.
       intros H.
       apply surj_countable
@@ -167,7 +166,7 @@ Section Countable.
     Qed.
 
     Lemma countable_bij_funR :
-      countable B -> countable A.
+      Countable B -> Countable A.
     Proof.
       intros H.
       apply inj_countable
@@ -181,7 +180,7 @@ Section Countable.
 End Countable.
 
 Lemma countable_image : forall (U V:Type)(DA : Ensemble U)(f:U->V),
-    countable DA -> countable (image DA f).
+    Countable DA -> Countable (image DA f).
 Proof.
   intros.
   rewrite image_as_Im.

--- a/theories/ordinals/Schutte/Countable.v
+++ b/theories/ordinals/Schutte/Countable.v
@@ -110,23 +110,6 @@ Section Countable.
 
   Variable U : Type.
 
-  Section Countable_singleton.
-
-    Variable x : U.
-
-    Lemma countable_singleton :
-      Countable (Singleton x).
-    Proof.
-      exists (fun _ => 0%nat).
-      intros [y0 H0] [y1 H1] _.
-      inversion H0; subst.
-      inversion H1; subst.
-      destruct (proof_irrelevance _ H0 H1).
-      reflexivity.
-    Qed.
-
-  End Countable_singleton.
-
   Section Countable_seq_range.
 
     Definition seq_range (f : nat -> U) : Ensemble U :=

--- a/theories/ordinals/Schutte/Critical.v
+++ b/theories/ordinals/Schutte/Critical.v
@@ -320,7 +320,7 @@ Section Proof_of_Lemma5.
                                        (members alpha)
                                        (fun x =>  phi x (gamma_ n))).
           intros H;
-            apply countable_inclusion with
+            apply CountableTypes.countable_downward_closed with
                 (image (members alpha)
                        (fun x =>  phi x  (gamma_ n))).
           apply H.

--- a/theories/ordinals/Schutte/Critical.v
+++ b/theories/ordinals/Schutte/Critical.v
@@ -441,7 +441,7 @@ Section Proof_of_Lemma5.
 
     Section closedness.
       Variable M : Ensemble Ord.
-      Hypothesis HM : Inhabited _ M.
+      Hypothesis HM : Inhabited M.
       Hypothesis CM : countable M.
       Hypothesis IM : Included  M (Cr alpha).
 
@@ -554,5 +554,3 @@ Proof.
   - intros; apply Lemma5.
   - auto with schutte.
 Qed.
-
-

--- a/theories/ordinals/Schutte/Critical.v
+++ b/theories/ordinals/Schutte/Critical.v
@@ -13,6 +13,7 @@
 
 
 From Coq Require Import Arith Logic.Epsilon  Ensembles Classical.
+From ZornsLemma Require Import CountableTypes.
 From hydras Require Export Schutte_basics  Ordering_Functions
      Countable  Schutte.Addition AP CNF Well_Orders MoreEpsilonIota.
 
@@ -320,7 +321,7 @@ Section Proof_of_Lemma5.
                                        (members alpha)
                                        (fun x =>  phi x (gamma_ n))).
           intros H;
-            apply CountableTypes.countable_downward_closed with
+            apply countable_downward_closed with
                 (image (members alpha)
                        (fun x =>  phi x  (gamma_ n))).
           apply H.

--- a/theories/ordinals/Schutte/Critical.v
+++ b/theories/ordinals/Schutte/Critical.v
@@ -1,15 +1,15 @@
 (* Pierre Casteran, LaBRI,  University of  Bordeaux *)
 
-(** 
+(**
 
  We  adapt Schutte's definition of critical ordinals :
-   
+
    - Cr(zero) = AP   (the set of additive principal ordinals )
-  
+
    - if zero < alpha, then
-       Cr(alpha) is the   intersection of all the sets of fixpoints 
+       Cr(alpha) is the   intersection of all the sets of fixpoints
        of the ordering functions of Cr(beta) for beta < alpha.
-*) 
+*)
 
 
 From Coq Require Import Arith Logic.Epsilon  Ensembles Classical.
@@ -25,19 +25,19 @@ Set Implicit Arguments.
 
 Definition Cr_fun : forall alpha : Ord,
     (forall beta : Ord, beta < alpha -> Ensemble Ord) ->
-    Ensemble Ord 
-  := 
+    Ensemble Ord
+  :=
     fun (alpha :Ord)
-        (Cr : forall beta, 
-            beta < alpha -> Ensemble Ord) 
+        (Cr : forall beta,
+            beta < alpha -> Ensemble Ord)
         (x : Ord) => (
         (alpha = zero /\ AP x) \/
         (zero < alpha /\
-         forall beta (H:beta < alpha), 
+         forall beta (H:beta < alpha),
            In (the_ordering_segment (Cr beta H)) x /\
            ord (Cr beta H) x = x)).
 
-Definition Cr (alpha : Ord) : Ensemble Ord := 
+Definition Cr (alpha : Ord) : Ensemble Ord :=
   (Fix  all_ord_acc
         (fun (_:Ord) => Ensemble Ord) Cr_fun) alpha.
 
@@ -60,7 +60,7 @@ Definition Gamma0 := the_least strongly_critical.
 
 (* begin snippet phiDef *)
 
-Definition phi (alpha : Ord) : Ord -> Ord 
+Definition phi (alpha : Ord) : Ord -> Ord
     :=  ord (Cr alpha).
 
 Definition A_ (alpha : Ord) : Ensemble Ord :=
@@ -70,7 +70,7 @@ Definition A_ (alpha : Ord) : Ensemble Ord :=
 
 
 Lemma Cr_extensional :
-  forall (x:Ord) 
+  forall (x:Ord)
          (f g : forall y : Ord, y < x -> (fun _ : Ord => Ensemble Ord) y),
     (forall (y : Ord) (p : y < x), f y p = g y p) ->
     ((Cr_fun  f  :Ensemble Ord) =  (Cr_fun  g :Ensemble Ord)).
@@ -93,7 +93,7 @@ Qed.
 
 Lemma Cr_equation (alpha : Ord) :
   Cr  alpha =
-  Cr_fun 
+  Cr_fun
     (fun (y : Ord) (h : y < alpha) =>  Cr y).
 
 Proof.
@@ -103,8 +103,8 @@ Proof.
 Qed.
 
 
-Lemma Cr_inv (alpha x : Ord): 
-  Cr alpha x -> 
+Lemma Cr_inv (alpha x : Ord):
+  Cr alpha x ->
   ((alpha = zero /\ (Cr  alpha x <-> AP x)) \/
    (zero < alpha /\
     (forall beta (H:beta < alpha),
@@ -129,7 +129,7 @@ Qed.
 
 Lemma Cr_pos : forall alpha,
     zero < alpha ->
-    forall x : Ord , 
+    forall x : Ord ,
       (forall beta (H:beta < alpha),
           A_  beta  x /\   ord (Cr  beta) x = x) ->
       Cr alpha x.
@@ -160,24 +160,24 @@ Qed.
 
 Lemma Cr_pos_inv (alpha : Ord) :
   zero < alpha ->
-  forall x, 
+  forall x,
     Cr alpha x ->
     (forall beta (H:beta < alpha), In (A_ beta) x /\ phi beta x = x).
 Proof.
   intros H x H0 beta H1; case (Cr_inv alpha x H0).
-  - destruct 1; subst alpha; case (@not_lt_zero beta);  auto. 
-  - destruct 1;  eauto. 
+  - destruct 1; subst alpha; case (@not_lt_zero beta);  auto.
+  - destruct 1;  eauto.
 Qed.
 
 Lemma Cr_pos_iff (alpha : Ord) :
   zero < alpha ->
-  forall x, 
+  forall x,
     (Cr alpha x <->
      (forall beta (H:beta < alpha), In (A_ beta) x /\ phi beta x = x)).
 Proof.
   split.
   - intros; apply Cr_pos_inv with alpha; auto.
-  - intros; apply Cr_pos; auto. 
+  - intros; apply Cr_pos; auto.
 Qed.
 
 Lemma A_Cr (alpha beta:Ord) : In (A_ alpha) beta ->  phi alpha beta = beta ->
@@ -202,7 +202,7 @@ Lemma Cr_incl (alpha beta : Ord) (H :beta <= alpha) :
 Proof.
   case (le_disj H).
   -  intro;subst beta; auto with schutte.
-  -  red; intros; apply Cr_lt with alpha; auto. 
+  -  red; intros; apply Cr_lt with alpha; auto.
 Qed.
 
 
@@ -314,7 +314,7 @@ Section Proof_of_Lemma5.
         intros xi Hxi.
         assert (forall n,  phi xi (gamma_ n) <= gamma).
         {
-          intro n; apply le_trans with (gamma_ (S n)).        
+          intro n; apply le_trans with (gamma_ (S n)).
           cbn; apply sup_upper_bound.
           generalize (@countable_image _ _
                                        (members alpha)
@@ -348,8 +348,8 @@ Section Proof_of_Lemma5.
         assert (phi xi gamma <= gamma).
         { unfold gamma at 1; unfold omega_limit.
           assert (continuous (phi xi) ordinal (Cr xi)).
-          { apply Th_13_5_2.  
-            
+          { apply Th_13_5_2.
+
             replace ordinal with (the_ordering_segment (Cr xi)).
             apply ord_ok.
             apply segment_unbounded.
@@ -361,7 +361,7 @@ Section Proof_of_Lemma5.
               (@ ordering_unbounded_unbounded (A_ xi) (Cr xi) (phi xi)) in H1.
             auto.
             apply ord_ok.
-            destruct (IHalpha Hxi); auto. 
+            destruct (IHalpha Hxi); auto.
           }
           destruct H1.
           destruct H2.
@@ -372,11 +372,11 @@ Section Proof_of_Lemma5.
              intros y [x [H4 H5]].
              destruct H4 as [z [_ H6]].  subst x y; apply H.
           -  split.
-          -  exists (gamma_ 0), 0;auto. 
+          -  exists (gamma_ 0), 0;auto.
           -  apply seq_range_countable.
         }
         assert (gamma <= phi xi gamma).
-        {  
+        {
           eapply ordering_le.
          -  apply ord_ok.
          -  assert (Unbounded (Cr xi)) by ( now destruct (IHalpha  Hxi)).
@@ -410,12 +410,12 @@ Section Proof_of_Lemma5.
       Qed.
 
       Remark A_full : forall xi, xi < alpha -> A_ xi = ordinal.
-        unfold A_; intros.      
+        unfold A_; intros.
         replace (the_ordering_segment (Cr xi)) with ordinal .
         split.
         symmetry; apply segment_unbounded.
         eapply ordering_function_seg with (Cr xi).
-        unfold the_ordering_segment, the. 
+        unfold the_ordering_segment, the.
         apply iota_ind.
         apply ordering_segment_ex_unique.
         destruct 1; auto.
@@ -445,9 +445,9 @@ Section Proof_of_Lemma5.
       Hypothesis CM : countable M.
       Hypothesis IM : Included  M (Cr alpha).
 
-      
 
-      
+
+
       Lemma Lemma5_2 : forall xi eta,  xi < alpha ->
                                         In M eta  ->
                                         phi xi eta = eta.
@@ -460,7 +460,7 @@ Section Proof_of_Lemma5.
         now destruct (H1 _ H).
       Qed.
 
-      
+
 
       Lemma Lemma5_7 : In (Cr alpha) (sup M).
       Proof.
@@ -468,26 +468,26 @@ Section Proof_of_Lemma5.
         intros xi H; split.
         rewrite (A_full H). split.
         assert (continuous (phi xi) ordinal (Cr xi)).
-        { apply Th_13_5_2.  
+        { apply Th_13_5_2.
           replace ordinal with (the_ordering_segment (Cr xi)).
           apply ord_ok.
           apply segment_unbounded.
           eapply ordering_function_seg with (Cr xi).
           exists (phi xi); apply ord_ok.
-          assert (Unbounded (Cr xi)). 
+          assert (Unbounded (Cr xi)).
           now destruct (IHalpha  H).
           rewrite (@ ordering_unbounded_unbounded (A_ xi) (Cr xi) (phi xi))
             in H0.
           auto.
           apply ord_ok.
-          destruct (IHalpha H); auto. 
+          destruct (IHalpha H); auto.
         }
         destruct H0.
         destruct H1.
         unfold phi in H2.
         rewrite <- H2.
         f_equal; apply Extensionality_Ensembles.
-        split. 
+        split.
         intro x.
         destruct 1.
         destruct H3.
@@ -496,10 +496,10 @@ Section Proof_of_Lemma5.
         fold (phi xi x); rewrite Lemma5_2; auto.
         split.
         auto.
-        auto. 
+        auto.
       Qed.
 
-      
+
     End closedness.
 
 
@@ -552,7 +552,7 @@ Proof.
   destruct Th13_8 with alpha.
   eapply A_full with (succ alpha).
   - intros; apply Lemma5.
-  - auto with schutte. 
+  - auto with schutte.
 Qed.
 
 

--- a/theories/ordinals/Schutte/Critical.v
+++ b/theories/ordinals/Schutte/Critical.v
@@ -443,7 +443,7 @@ Section Proof_of_Lemma5.
     Section closedness.
       Variable M : Ensemble Ord.
       Hypothesis HM : Inhabited M.
-      Hypothesis CM : countable M.
+      Hypothesis CM : Countable M.
       Hypothesis IM : Included  M (Cr alpha).
 
 

--- a/theories/ordinals/Schutte/GRelations.v
+++ b/theories/ordinals/Schutte/GRelations.v
@@ -161,3 +161,6 @@ Section General_Relations.
   End elagage.
 
 End General_Relations.
+
+Arguments rel_injection {A B}.
+Arguments rel_surjection {A B}.

--- a/theories/ordinals/Schutte/GRelations.v
+++ b/theories/ordinals/Schutte/GRelations.v
@@ -7,7 +7,7 @@
 From Coq Require Import Ensembles Classical  Lia Arith.
 From hydras Require Import PartialFun.
 
-      
+
 Section General_Relations.
 
   Section Definitions.
@@ -26,15 +26,15 @@ Section General_Relations.
     Variable R : GRelation.
 
     Inductive rel_injection : Prop :=
-     rel_inj_i : rel_domain DA R -> 
-          rel_codomain DA DB R -> 
-          rel_inj DA R -> 
+     rel_inj_i : rel_domain DA R ->
+          rel_codomain DA DB R ->
+          rel_inj DA R ->
           rel_injection.
 
     Inductive  rel_surjection : Prop :=
-     rel_surj_i : rel_codomain DA DB R -> 
+     rel_surj_i : rel_codomain DA DB R ->
           rel_functional DA R ->
-          rel_onto DA DB R -> 
+          rel_onto DA DB R ->
           rel_surjection.
   End Definitions.
 
@@ -97,7 +97,7 @@ Section General_Relations.
 
     intros b b' a b_in_DB b'_in_DB b_Ri_a b'_Ri_a.
     destruct R_surj as (_, R_fun, _).
-    red in R_fun.    
+    red in R_fun.
     apply R_fun with a.
     destruct b_Ri_a as [a_In_DA _]; assumption.
     destruct b_Ri_a as [_ [_  a_R_b]]; assumption.
@@ -129,7 +129,7 @@ Section General_Relations.
         forall y n, R y n -> exists p, R_nat_elaguee y p.
       Proof.
         (* on pourrait faire une induction bien fondée, mais bon ... *)
-        assert (forall (n : nat) (y : A), (exists q:nat, q <= n /\ R y q) -> 
+        assert (forall (n : nat) (y : A), (exists q:nat, q <= n /\ R y q) ->
                  exists p : nat, R_nat_elaguee y p).
         induction n.
         intros y (q,(H1,H2)).

--- a/theories/ordinals/Schutte/MoreEpsilonIota.v
+++ b/theories/ordinals/Schutte/MoreEpsilonIota.v
@@ -2,7 +2,7 @@
 
   Complements to Coq.Logic.Epsilon
 
-              
+
   Pierre Casteran,
   LaBRI, University of Bordeaux
 *)
@@ -20,9 +20,9 @@ Check constructive_indefinite_description.
 (* end snippet epsilonDef *)
 
 (* begin snippet iotaDef *)
-Check iota_statement. 
+Check iota_statement.
 
-Print iota. 
+Print iota.
 
 Print iota_spec.
 (* end snippet iotaDef *)
@@ -48,7 +48,7 @@ Proof.
 Qed.
 
 Ltac epsilon_elim_aux :=
-  match goal with [ |- (?P (epsilon (A:=?X) ?a ?Q))] => 
+  match goal with [ |- (?P (epsilon (A:=?X) ?a ?Q))] =>
            apply epsilon_ind; auto
   end.
 
@@ -70,7 +70,7 @@ Section On_Iota.
   Variables (A:Type)(P: A -> Prop).
   Hypothesis  inhA : inhabited A.
   Hypothesis unique_P : exists ! x, P x.
- 
+
   Lemma iota_spec_1 : unique P (iota inhA P).
   Proof.
     generalize  (iota_spec inhA P unique_P).
@@ -92,7 +92,7 @@ Section On_Iota.
   Proof.
     intro H;apply H; now apply iota_spec_1.
   Qed.
-  
+
 End On_Iota.
 
 Ltac iota_elim :=

--- a/theories/ordinals/Schutte/Ordering_Functions.v
+++ b/theories/ordinals/Schutte/Ordering_Functions.v
@@ -13,7 +13,7 @@ Schutte's definitions.
 
 *)
 
-
+From ZornsLemma Require Import CountableTypes.
 From hydras Require Export Schutte_basics.
 Import Ensembles  Well_Orders  Countable  PartialFun.
 Import Classical  MoreEpsilonIota  Epsilon.
@@ -118,7 +118,7 @@ Qed.
 
 
 Lemma countable_segment_proper : forall A : Ensemble Ord,
-           segment A -> countable A -> proper_segment A.
+           segment A -> Countable A -> proper_segment A.
 Proof.
  intros A H H0; split;[auto|idtac].
  intro H1; generalize (Extensionality_Ensembles _ _ H1).
@@ -463,14 +463,14 @@ Section building_ordering_function_1.
 
 
 
- Remark Bbeta_denum : countable (proper_segment_of B beta).
+ Remark Bbeta_denum : Countable (proper_segment_of B beta).
  Proof.
   apply AX2; exists beta;  destruct 1;tauto.
  Qed.
 
  #[local] Hint Resolve of_beta': schutte.
 
-Remark A_denum : countable _A.
+Remark A_denum : Countable _A.
 Proof.
  eapply countable_bij_funR.
  - eapply Ordering_bijection;   eauto with schutte.
@@ -839,7 +839,7 @@ Section Th13_5.
  Variable M : Ensemble Ord.
  Hypothesis inc : Included M B.
  Hypothesis ne : Inhabited M.
- Hypothesis den : countable M.
+ Hypothesis den : Countable M.
 
  Let U := fun u => In A u /\ In M ( f u).
 
@@ -866,7 +866,7 @@ Qed.
  Remark Inc_U_A : Included U A.
  Proof. now destruct 1. Qed.
 
- Remark den_U : countable U.
+ Remark den_U : Countable U.
  eapply countable_bij_funR with Ord M f;auto.
  apply restrict.
  Qed.
@@ -945,12 +945,12 @@ Section verso.
  Section U_fixed.
  Variable U : Ensemble Ord.
  Hypothesis U_non_empty : Inhabited U.
- Hypothesis U_den : countable U.
+ Hypothesis U_den : Countable U.
  Hypothesis U_inc_A : Included U A.
 
  (* apply Virgile's technique ? *)
 
- Remark R1_aux : countable (image U f).
+ Remark R1_aux : Countable (image U f).
  Proof.
  apply countable_bij_fun with Ord U f.
  - case (Ordering_bijection f_ord); intros H H0 H1;  split.
@@ -1142,13 +1142,13 @@ Lemma ordering_unbounded_unbounded :
 Proof with auto with schutte.
   intros A B f  H0;split.
   - intro; apply not_countable_unbounded.
-    intro H2;  assert (H3 : countable B).
+    intro H2;  assert (H3 : Countable B).
     {  apply countable_bij_fun with Ord A  f ...
        apply Ordering_bijection;auto.
     }
     case (countable_not_Unbounded  H3);auto.
   - intro H1;  apply not_countable_unbounded ...
-    intro H2;  assert (H3 : countable A).
+    intro H2;  assert (H3 : Countable A).
     { apply countable_bij_funR with Ord   B  f;auto.
       apply Ordering_bijection;auto.
     }

--- a/theories/ordinals/Schutte/Ordering_Functions.v
+++ b/theories/ordinals/Schutte/Ordering_Functions.v
@@ -121,7 +121,7 @@ Lemma countable_segment_proper : forall A : Ensemble Ord,
            segment A -> countable A -> proper_segment A.
 Proof.
  intros A H H0; split;[auto|idtac].
- intro H1; generalize (Extensionality_Ensembles _ _ _ H1).
+ intro H1; generalize (Extensionality_Ensembles _ _ H1).
  intros; subst A ; now case Non_denum.
 Qed.
 
@@ -591,7 +591,7 @@ Proof with eauto with schutte.
  generalize (g_lemma H);intro.
  generalize (ordering_function_unicity B5 H2).
  destruct 1.
- generalize (Extensionality_Ensembles _ _ _ H3).
+ generalize (Extensionality_Ensembles _ _ H3).
  intros;  generalize (members_eq   H5).
  intro; subst alpha;auto.
 Qed.
@@ -651,7 +651,7 @@ Proof.
      generalize (g_lemma (beta:=beta0));intros.
      case H9;intros H7 H8.   generalize (H0 H7).
      intros H12; generalize (ordering_function_unicity B5 H12).
-     destruct 1;  generalize (Extensionality_Ensembles _ _ _ H11).
+     destruct 1;  generalize (Extensionality_Ensembles _ _ H11).
      intros H14; generalize (members_eq (alpha:=alpha)(beta:=g beta0)   H14 ).
      exists beta0;split;auto.
 Qed.
@@ -838,7 +838,7 @@ Section Th13_5.
  Section M_fixed.
  Variable M : Ensemble Ord.
  Hypothesis inc : Included M B.
- Hypothesis ne : Inhabited _ M.
+ Hypothesis ne : Inhabited M.
  Hypothesis den : countable M.
 
  Let U := fun u => In A u /\ In M ( f u).
@@ -872,7 +872,7 @@ Qed.
  Qed.
 
 
- Remark inh_U : Inhabited _ U.
+ Remark inh_U : Inhabited U.
  Proof.
    case ne;intros.
    exists (inv_fun inh_Ord A B f x).
@@ -944,7 +944,7 @@ Section verso.
 
  Section U_fixed.
  Variable U : Ensemble Ord.
- Hypothesis U_non_empty : Inhabited _ U.
+ Hypothesis U_non_empty : Inhabited U.
  Hypothesis U_den : countable U.
  Hypothesis U_inc_A : Included U A.
 

--- a/theories/ordinals/Schutte/Ordering_Functions.v
+++ b/theories/ordinals/Schutte/Ordering_Functions.v
@@ -1,12 +1,12 @@
 (** Ordering functions (after Schutte) *)
 
 
-(**   Pierre Casteran, LaBRI, University of Bordeaux  
+(**   Pierre Casteran, LaBRI, University of Bordeaux
 
-Every subset [A] of [Ord] can be enumerated in an unique way 
+Every subset [A] of [Ord] can be enumerated in an unique way
  by a segment of [Ord].
 
-Thus it makes sense to consider the [alpha]-th element of [A] 
+Thus it makes sense to consider the [alpha]-th element of [A]
 
 This module shows the construction of the _ordering function_  of [A], following
 Schutte's definitions.
@@ -43,7 +43,7 @@ Class ordering_function (f : Ord -> Ord)
       OF_total : forall a, In A a -> In B (f a);
       OF_onto : forall b, In B b -> exists a, In A a /\ f a = b;
       OF_mono : forall a b, In A a -> In A b -> a < b -> f a < f b
-    }. 
+    }.
 
 Definition ordering_segment (A B : Ensemble Ord) :=
   exists f : Ord -> Ord, ordering_function f A B.
@@ -55,7 +55,7 @@ Definition ordering_segment (A B : Ensemble Ord) :=
 Definition the_ordering_segment (B : Ensemble Ord) :=
   the  (fun x => ordering_segment x B).
 
-Definition ord   (B : Ensemble Ord) := 
+Definition ord   (B : Ensemble Ord) :=
   some (fun f => ordering_function f (the_ordering_segment B) B).
 (* end snippet ordDef *)
 
@@ -66,13 +66,13 @@ Definition  normal (f : Ord -> Ord)(B : Ensemble Ord): Prop :=
  ordering_function f ordinal B /\ continuous f ordinal B.
 
 Definition fun_equiv (f g : Ord -> Ord)(A B : Ensemble Ord) :=
-  Same_set A B /\ forall a, In A a -> f a = g a. 
+  Same_set A B /\ forall a, In A a -> f a = g a.
 
 (**  **  Properties of  segments *)
 
 Lemma ordinal_segment : segment ordinal.
 Proof.
- split; eauto with schutte. 
+ split; eauto with schutte.
 Qed.
 
 
@@ -94,7 +94,7 @@ Proof with eauto with schutte.
     +  unfold Included; split; auto.
     +  intros x H2; apply NNPP; intro H3.
        apply (H1 x); split;auto.
-  -  intros x H1; case (@well_order _  lt AX1 (fun x => ordinal x /\ ~ A x) x). 
+  -  intros x H1; case (@well_order _  lt AX1 (fun x => ordinal x /\ ~ A x) x).
      + auto.
      +  intros y Hy.
         case Hy;intros H2 H3; destruct H2.
@@ -109,7 +109,7 @@ Proof with eauto with schutte.
           specialize (H a y H6 T).
           contradiction.
         *  red; unfold In;intros; apply NNPP.
-          case Hy;  intros H7 H8 H10.  
+          case Hy;  intros H7 H8 H10.
           case (H8 x0 ).
           { red; split ... }
           { intro; subst. destruct (lt_irrefl H4). }
@@ -130,7 +130,7 @@ Lemma ordering_function_In f A B a :
    ordering_function f A B -> In A a -> In B (f a).
 Proof. destruct 1; auto. Qed.
 
-  
+
 Lemma ordering_function_mono (f : Ord -> Ord) (A B: Ensemble Ord) :
   ordering_function f A B ->
   forall alpha beta,
@@ -139,7 +139,7 @@ Proof.  now destruct 1. Qed.
 
 #[global] Hint Resolve ordering_function_mono : schutte.
 
-Lemma  ordering_function_mono_weak (f : Ord -> Ord) (A B: Ensemble Ord) : 
+Lemma  ordering_function_mono_weak (f : Ord -> Ord) (A B: Ensemble Ord) :
  ordering_function f A B ->
    forall a b, In A a -> In A b -> a <= b -> f a <= f b.
 Proof.
@@ -176,7 +176,7 @@ Proof.
 Qed.
 
 
-Lemma  ordering_function_mono_weakR : 
+Lemma  ordering_function_mono_weakR :
   forall f A B, ordering_function f A B ->
                 forall a b, In A a -> In A b ->  f a <= f b -> a <= b.
 Proof with auto with schutte.
@@ -203,8 +203,8 @@ Proof.
   intros B H; split.
   -  intros a b H0 H1;  destruct (not_lt_zero H0);auto.
   - intros b H0 ; now destruct (not_lt_zero H0).
-  -  intros x Hx; now destruct (H x). 
-  -  intros a b Hb; case (@not_lt_zero a); assumption. 
+  -  intros x Hx; now destruct (H x).
+  -  intros a b Hb; case (@not_lt_zero a); assumption.
 Qed.
 
 
@@ -213,14 +213,14 @@ Proof.
  intros A a b H0  H1 H2; now apply H0 with a.
 Qed.
 
-Theorem segment_unbounded : forall A:Ensemble Ord, segment A -> 
+Theorem segment_unbounded : forall A:Ensemble Ord, segment A ->
                                         Unbounded A ->
                                         A = ordinal.
 Proof with eauto with schutte.
  intros A H H0; red in H0; apply Extensionality_Ensembles; split.
- - intros; split. 
+ - intros; split.
  -  intros x Hx; destruct (H0 x) as [x0 H1]...
-    destruct H1; now apply H with x0. 
+    destruct H1; now apply H with x0.
 Qed.
 
 (* begin snippet orderingLe *)
@@ -234,7 +234,7 @@ Theorem ordering_le : forall f A B,
 Proof with auto with schutte.
   intros f A B H alpha H0; generalize H0;
     pattern alpha; apply transfinite_induction.
-  - clear alpha H0; destruct H as [H1 H2 H3 H4].  
+  - clear alpha H0; destruct H as [H1 H2 H3 H4].
     unfold progressive;   intros alpha H6 H7 .
     tricho alpha (f alpha) H' ...
     +   assert (f (f alpha) < f alpha).
@@ -249,21 +249,21 @@ Qed.
 (*||*)
 (* end snippet orderingLe *)
 
-(* begin hide *)  
+(* begin hide *)
 Section ordering_function_unicity_1.
-  
+
  Variables B A1 A2 : Ensemble Ord.
  Variables f1 f2 : Ord -> Ord.
  Hypothesis O1 : ordering_function f1 A1 B.
  Hypothesis O2 : ordering_function f2 A2 B.
 
- 
+
  Remark SA1 : segment A1.
  Proof.   case O1;intuition.  Qed.
 
  Remark SA2 : segment A2.
  Proof.  case O2;intuition.  Qed.
- 
+
  #[local] Hint Resolve SA2 SA1 : schutte.
 
   Lemma A1_A2 :forall a, In A1 a -> A2 a /\ f1 a = f2 a.
@@ -283,12 +283,12 @@ Section ordering_function_unicity_1.
        }
 
        assert (forall y, A2 y -> f1 y < f1 a).
-       {   intros y H4;  case O1;intros H5 H6 H7 H8.  
-           apply H8 ... 
-       }  
+       {   intros y H4;  case O1;intros H5 H6 H7 H8.
+           apply H8 ...
+       }
 
        case O2;intros H5 H6 H7 H8;  case (H7 (f1 a)).
-       - case O1;intros H9 H10 H11 H12. 
+       - case O1;intros H9 H10 H11 H12.
          apply H10;  auto.
        -  destruct 1.   generalize (H3 x H4).
           intro;  case (H0 x)...
@@ -298,7 +298,7 @@ Section ordering_function_unicity_1.
      }
      {   split; trivial.
          assert (H01 : least_member  lt
-                                        (fun x => B x /\ 
+                                        (fun x => B x /\
                                                   forall y, y < a ->
                                                             f1 y <> x)
                                         (f1 a)).
@@ -307,7 +307,7 @@ Section ordering_function_unicity_1.
             +  case O1;intros;  unfold In; intuition.
                apply OF_total0; auto.
                specialize (OF_mono0  y a ).
-               assert (In A1 y) by (eapply OF_segment0 with a ; auto). 
+               assert (In A1 y) by (eapply OF_segment0 with a ; auto).
                specialize (OF_mono0 H3  Ha H1).
                rewrite H2 in OF_mono0; now apply (@lt_irrefl (f1 a)).
             + destruct 1;   destruct O1 as [H3 H4 H5 H6].
@@ -315,8 +315,8 @@ Section ordering_function_unicity_1.
               destruct H7; subst x;  tricho a x0 H9.
               *  right.   apply H6;auto.
               *  subst x0; now left.
-              * now destruct  (H2  _ H9). 
-         } 
+              * now destruct  (H2  _ H9).
+         }
 
          assert (H02 : least_member  lt
                                      (fun x => B x /\ forall y, y < a ->
@@ -327,16 +327,16 @@ Section ordering_function_unicity_1.
            +  case O2;intros  H2 H3 H4 H5.   unfold In; intuition.
               apply H3; auto.
               specialize (H5 y a ).
-              assert (In A2 y)  by ( eapply H2 with a ; auto). 
+              assert (In A2 y)  by ( eapply H2 with a ; auto).
               specialize (H5 H7 H H1).
               rewrite H6 in H5; now apply (@lt_irrefl (f2 a)).
-           + destruct 1; case O2; intros  H3 H4 H5 H6.  
+           + destruct 1; case O2; intros  H3 H4 H5 H6.
             destruct (H5 x H1).
              destruct H7; subst x; tricho a x0 H9.
              *  right;   apply H6;auto.
              *  subst x0; now left.
              * specialize (H2 _ H9); now destruct H2.
-         } 
+         }
          refine (least_member_of_eq AX1 _ _ H01 H02).
 
          - intros x Hx; split.
@@ -356,10 +356,10 @@ Section ordering_function_unicity_1.
 End ordering_function_unicity_1.
 
 (* end hide *)
- 
+
 
 Section ordering_function_unicity.
-  
+
  Variables B A1 A2 : Ensemble Ord.
 
  Variables f1 f2 : Ord -> Ord.
@@ -367,17 +367,17 @@ Section ordering_function_unicity.
  Hypothesis O2 : ordering_function f2 A2 B.
 
  (* begin hide *)
- 
+
  Lemma A2_A1 :forall a, A2 a -> A1 a /\ f2 a = f1 a.
  Proof.
-  intros; eapply A1_A2.   
+  intros; eapply A1_A2.
   - eapply O2.
   - apply O1.
   - auto.
  Qed.
 
  (* end hide *)
- 
+
 Theorem ordering_function_unicity  : fun_equiv f1 f2 A1 A2.
 Proof.
  split.
@@ -389,11 +389,11 @@ Qed.
 
 End ordering_function_unicity.
 
-Lemma ordering_function_seg_unicity : forall A1 A2 B, 
+Lemma ordering_function_seg_unicity : forall A1 A2 B,
            ordering_segment A1 B ->
            ordering_segment A2 B -> A1 = A2.
 Proof.
- destruct 1 as [f1 Hf1];  destruct 1 as [f2 Hf2]; 
+ destruct 1 as [f1 Hf1];  destruct 1 as [f2 Hf2];
  apply Extensionality_Ensembles.
  assert (H : fun_equiv f1 f2 A1 A2)
    by (eapply ordering_function_unicity;eauto); now destruct H.
@@ -403,7 +403,7 @@ Qed.
 
 (** Let us build now an ordering function, and the associated ordering segment
  of any subset B composed of ordinals *)
-    
+
 
 Lemma proper_of_proper : forall B beta beta',
                            ordinal beta -> In B beta ->
@@ -412,7 +412,7 @@ Lemma proper_of_proper : forall B beta beta',
                            proper_segment_of (proper_segment_of B beta) beta'.
 Proof with  eauto with schutte.
  intros; apply Extensionality_Ensembles; split.
- - red; destruct 1; split. 
+ - red; destruct 1; split.
    + split;auto.
      destruct H3; split.
      * apply lt_trans with beta'...
@@ -423,7 +423,7 @@ Proof with  eauto with schutte.
    split.
    +  case H2;auto.
    +  split.
-    * tauto.  
+    * tauto.
     * destruct  H3, H4 ...
 Qed.
 
@@ -434,19 +434,19 @@ Section building_ordering_function_1.
                                exists! A : Ensemble Ord,
                                     ordering_segment A
                                              (proper_segment_of B beta).
-  
+
  Section beta_fixed.
 
  Variable beta : Ord.
  Hypothesis beta_B : In B beta.
 
  (** Let us build an ordering function for (proper_segment_of B beta) *)
-  
+
  Definition _A := the  (fun E =>
                           ordering_segment E  (proper_segment_of B beta)).
- 
- 
- Definition _f := some  (fun f => 
+
+
+ Definition _f := some  (fun f =>
                            ordering_function f _A
 			                     (proper_segment_of B beta)).
 
@@ -487,7 +487,7 @@ Qed.
 Lemma g_def1  : exists g_beta: Ord,  ordinal g_beta /\ _A = members g_beta.
 Proof.
  generalize (proper_members Proper_A); intros (a,Ha);exists a;split.
- - now destruct Ha. 
+ - now destruct Ha.
  - eapply Extensionality_Ensembles; tauto.
 Qed.
 
@@ -504,10 +504,10 @@ Proof.
   case H2; unfold Included, members; intros; apply le_antisym.
  - apply not_gt_le; auto with schutte.
    intro H5; generalize (H4 g_beta'); intros H6; unfold In in H6.
-   case (@lt_irrefl g_beta');  now apply H6. 
+   case (@lt_irrefl g_beta');  now apply H6.
  - apply not_gt_le; auto with schutte.
    intro H5;  generalize (H3 g_beta);intros H6;
-     destruct  (@lt_irrefl g_beta);  now apply H6.   
+     destruct  (@lt_irrefl g_beta);  now apply H6.
 Qed.
 
 Definition g := iota inh_Ord (fun o => ordinal o /\ _A = members o).
@@ -524,7 +524,7 @@ Proof.
 Qed.
 
 
-Lemma g_lemma : 
+Lemma g_lemma :
   forall beta, In B beta ->
        ordering_function (_f beta) (members (g beta))
                                        (proper_segment_of B beta).
@@ -549,7 +549,7 @@ Proof with eauto with schutte.
  { destruct B2; case (H3 beta1) ... }
 
  case B4; intros alpha (Ha2,Ha3).
- assert (B5 : ordering_function (_f beta2) (members alpha) 
+ assert (B5 : ordering_function (_f beta2) (members alpha)
                                 (proper_segment_of B beta1)).
  { repeat split ...
    - red;  intros;   apply lt_trans with alpha0;eauto.
@@ -557,7 +557,7 @@ Proof with eauto with schutte.
       + generalize (H3 a); intros H4;  clear H3;  case H4.
         * red; apply lt_trans with alpha; auto.
         *  auto.
-   -  case (g_lemma H0). 
+   -  case (g_lemma H0).
       intros H3 H4; decompose [and] H4; clear H4.
       replace beta1 with (_f beta2 alpha).
       intros.
@@ -565,7 +565,7 @@ Proof with eauto with schutte.
       +   red;  apply lt_trans with alpha;auto.
    -  destruct 1;  case (g_lemma H0).
       intros H4 H5;  decompose [and] H4;  clear H4;  decompose [and] H5.
-       intros. case (OF_onto0 b). 
+       intros. case (OF_onto0 b).
       + split;auto.
         split;auto.
         eapply lt_trans;eauto.
@@ -578,18 +578,18 @@ Proof with eauto with schutte.
            case (@lt_irrefl _ H33).
          *  assert (beta1 < b).
            { rewrite <- Ha3; rewrite <- Ha'.
-             case (g_lemma H0); intros.   
+             case (g_lemma H0); intros.
              apply OF_mono1; auto.
            }
            case (@lt_irrefl beta1);  apply lt_trans with b;auto.
            case H3;auto.
-   - intros; case (g_lemma H0); intros.   
+   - intros; case (g_lemma H0); intros.
      apply OF_mono0; auto.
      red;  apply lt_trans with alpha;auto.
     red;  red; apply lt_trans with alpha;auto.
  }
  generalize (g_lemma H);intro.
- generalize (ordering_function_unicity B5 H2). 
+ generalize (ordering_function_unicity B5 H2).
  destruct 1.
  generalize (Extensionality_Ensembles _ _ _ H3).
  intros;  generalize (members_eq   H5).
@@ -599,18 +599,18 @@ Qed.
 
 Lemma L3a : segment (image B g).
 Proof.
-  intros gbeta alpha  (beta,(H1,H2)) H3;  subst gbeta. 
+  intros gbeta alpha  (beta,(H1,H2)) H3;  subst gbeta.
      generalize (g_lemma H1);intro.
-     case H; intros  H2 H4 H5 H6. 
-     assert (exists beta0, In (proper_segment_of B beta) beta0 
+     case H; intros  H2 H4 H5 H6.
+     assert (exists beta0, In (proper_segment_of B beta) beta0
                       /\ _f beta alpha=beta0).
      {  exists (_f beta alpha); split;auto.
      }
      case H0;intros beta0 (H9,H10); clear H0.
-     assert (B5 : ordering_function (_f beta) (members alpha) 
+     assert (B5 : ordering_function (_f beta) (members alpha)
                  (proper_segment_of B beta0)).
-     { 
-       repeat split;  auto with schutte. 
+     {
+       repeat split;  auto with schutte.
        - red;  red; intros.  apply lt_trans with alpha0;eauto.
        - assert( B2 : fun_bijection (members (g beta))
                                   (proper_segment_of B beta) (_f beta)) .
@@ -619,13 +619,13 @@ Proof.
          intros H13;  clear H77;  case H13.
          2:auto.
         red;  apply lt_trans with alpha; auto.
- 
-       -  case (g_lemma H1); intros.  
+
+       -  case (g_lemma H1); intros.
           replace beta0 with (_f beta alpha).
         apply OF_mono0; auto.
         red;  red;  apply lt_trans with alpha;auto.
        -  case H9;  auto.
-       - destruct 1; case (g_lemma H1); intros.  
+       - destruct 1; case (g_lemma H1); intros.
           case (OF_onto0 b).
          split;auto.
          split;auto.
@@ -643,14 +643,14 @@ Proof.
           case (@lt_irrefl beta0).
           apply lt_trans with b;auto.
           case H7;auto.
-        - intros; case (g_lemma H1); intros.  
+        - intros; case (g_lemma H1); intros.
           apply OF_mono0; auto.
           red;  apply lt_trans with alpha;auto.
           red; red;  apply lt_trans with alpha;auto.
        }
      generalize (g_lemma (beta:=beta0));intros.
      case H9;intros H7 H8.   generalize (H0 H7).
-     intros H12; generalize (ordering_function_unicity B5 H12). 
+     intros H12; generalize (ordering_function_unicity B5 H12).
      destruct 1;  generalize (Extensionality_Ensembles _ _ _ H11).
      intros H14; generalize (members_eq (alpha:=alpha)(beta:=g beta0)   H14 ).
      exists beta0;split;auto.
@@ -666,7 +666,7 @@ Qed.
  - red;intros a b; tricho a b Hab; trivial.
    intros H H0 ; generalize (g_mono H H0 Hab); auto.
    + intros H1 H2.   rewrite H2 in H1;  case (@lt_irrefl _ H1); auto.
-   + intros H H0 H1; generalize (g_mono H0 H Hab); intro; rewrite H1 in H2; 
+   + intros H H0 H1; generalize (g_mono H0 H Hab); intro; rewrite H1 in H2;
       case (@lt_irrefl _ H2).
  Qed.
 
@@ -687,7 +687,7 @@ Lemma g_1_of : ordering_function g_1 (image B g) B.
 Proof.
  split.
  -  apply L3a.
- - 
+ -
    destruct 1 as [x [H0 H1]]. rewrite <- H1.
       replace (g_1 (g x)) with x;  auto.
       symmetry;unfold g_1;eapply inv_compose;eauto.
@@ -733,11 +733,11 @@ Proof.
    apply image_B_g_seg.
 Qed.
 
- 
+
 End building_ordering_function_1.
 
-(** For any set [B], we build by transfinite induction the ordering segment of 
-  [B] and the (unique upto extensionnality) ordering function of B 
+(** For any set [B], we build by transfinite induction the ordering segment of
+  [B] and the (unique upto extensionnality) ordering function of B
  *)
 
 
@@ -756,11 +756,11 @@ Section building_ordering_function_by_induction.
       rewrite <- (proper_of_proper (B:=B) (beta:=a) (beta':=beta0))...
       apply H0...
         *  destruct H1 ; tauto.
-        *  destruct H1; tauto.  
+        *  destruct H1; tauto.
 Qed.
 
 
- 
+
  Theorem ordering_segment_ex_unique : exists! S, ordering_segment S B.
  Proof.
    apply L3_u,  ordering_segments_of_B.
@@ -776,11 +776,11 @@ Proof with eauto.
      eapply ordering_function_seg_unicity...
 Qed.
 
- 
+
 Lemma ord_ok :
   ordering_function (ord  B) (the_ordering_segment B) B.
 Proof.
-  pattern (ord  B);  apply epsilon_spec. 
+  pattern (ord  B);  apply epsilon_spec.
   pattern (the_ordering_segment B);
     apply iota_spec,  ordering_segment_ex_unique.
 Qed.
@@ -821,7 +821,7 @@ Lemma of_image : forall f A B, ordering_function f A B ->
 Proof.
  intros f A B O; case O; intros H H0;  decompose [and] H0.
  repeat split;auto.
- intros; exists a; auto. 
+ intros; exists a; auto.
 Qed.
 
 
@@ -834,7 +834,7 @@ Section Th13_5.
 
  Hypothesis f_cont : continuous f A B.
  (* begin hide *)
- 
+
  Section M_fixed.
  Variable M : Ensemble Ord.
  Hypothesis inc : Included M B.
@@ -847,7 +847,7 @@ Section Th13_5.
   apply Ordering_bijection; auto.
  Qed.
 
- 
+
  Remark restrict : fun_bijection U M f.
  Proof.
    split.
@@ -862,10 +862,10 @@ Section Th13_5.
       destruct 1.
       intros H3; case fbij;intros; now  apply H6.
 Qed.
- 
+
  Remark Inc_U_A : Included U A.
  Proof. now destruct 1. Qed.
- 
+
  Remark den_U : countable U.
  eapply countable_bij_funR with Ord M f;auto.
  apply restrict.
@@ -873,12 +873,12 @@ Qed.
 
 
  Remark inh_U : Inhabited _ U.
- Proof.  
+ Proof.
    case ne;intros.
    exists (inv_fun inh_Ord A B f x).
    red; unfold U; rewrite inv_composeR.
    -  split;auto.
-      generalize (Ordering_bijection f_ord); 
+      generalize (Ordering_bijection f_ord);
       intros;    generalize (inv_fun_bij inh_Ord H0).
       intros;  destruct H1.
       apply H1.
@@ -887,7 +887,7 @@ Qed.
    -   apply inc;auto.
  Qed.
 
- 
+
  Remark im_U_f : (image U f : Ensemble Ord)  = M.
  Proof.
    eapply Extensionality_Ensembles;    split.
@@ -898,7 +898,7 @@ Qed.
    exists (inv_fun inh_Ord A B f x);  split.
    red;red;  generalize (Ordering_bijection f_ord).
    intros;   split.
-   case (inv_fun_bij inh_Ord H0).  
+   case (inv_fun_bij inh_Ord H0).
    auto.
    intros;   destruct H0.
    rewrite inv_composeR; auto with schutte.
@@ -909,7 +909,7 @@ Qed.
    apply inc;auto.
  Qed.
 
- 
+
  Lemma sup_M_in_B : In B (|_| M).
  Proof.
   rewrite <- im_U_f.   case f_cont.  intros H [H0 H1].
@@ -927,7 +927,7 @@ Qed.
 End M_fixed.
 
  (* end hide *)
- 
+
  Lemma Th_13_5_1 : Closed B.
  Proof.
     red.
@@ -941,10 +941,10 @@ Section verso.
  Hypothesis B_closed : Closed B.
 
  (* begin hide *)
- 
+
  Section U_fixed.
  Variable U : Ensemble Ord.
- Hypothesis U_non_empty : Inhabited _ U. 
+ Hypothesis U_non_empty : Inhabited _ U.
  Hypothesis U_den : countable U.
  Hypothesis U_inc_A : Included U A.
 
@@ -966,14 +966,14 @@ Section verso.
  Opaque R1.
 
 
- Remark R2 : In B (|_| (image U f)). 
+ Remark R2 : In B (|_| (image U f)).
  Proof.
    apply  B_closed.
    -  red;red;  destruct 1.
-      case f_ord. intros H0 H1 H2 H3. 
+      case f_ord. intros H0 H1 H2 H3.
       case H;intros; subst x; destruct f_ord.
       decompose [and] H3.
-      apply OF_total0. apply U_inc_A;auto. 
+      apply OF_total0. apply U_inc_A;auto.
    -  case U_non_empty;intros x H;  exists (f x);auto.
       exists x;auto.
    - apply R1_aux.
@@ -994,11 +994,11 @@ Let alpha_ : Ord :=
 Lemma alpha_A :   In A alpha_.
 Proof.
   unfold alpha_;  apply epsilon_ind.
-  - apply R3. 
+  - apply R3.
   -  tauto.
 Qed.
 
-Lemma alpha_sup : f alpha_ = |_| (image U f). 
+Lemma alpha_sup : f alpha_ = |_| (image U f).
 Proof.
  pattern alpha_; epsilon_elim.
  - apply R3.
@@ -1009,15 +1009,15 @@ Remark R5 : forall khi, In U khi -> f khi <= f alpha_.
 Proof.
  intros; rewrite alpha_sup;  apply sup_upper_bound.
  -  apply R1.
- -  exists khi; tauto. 
+ -  exists khi; tauto.
 Qed.
 
 
 Remark R6 : forall khi, In U khi ->  khi <=  alpha_ .
 Proof with eauto with schutte.
  intros khi H; case (R5 H).
- -  left.  
-   +  case (Ordering_bijection f_ord). 
+ -  left.
+   +  case (Ordering_bijection f_ord).
       intros H1 H2 H3; apply H3.
     *  apply U_inc_A;auto.
     * apply alpha_A.
@@ -1033,14 +1033,14 @@ Qed.
 
 
 #[local] Hint Resolve  alpha_A : schutte.
- 
+
 Remark R7 : |_| U <= alpha_ .
-Proof. 
+Proof.
  apply sup_least_upper_bound; trivial.
  - intros;now apply R6.
 Qed.
- 
- 
+
+
 Remark R4 : forall khi, In U khi -> khi <= sup U.
 Proof.
  intros;  apply sup_upper_bound;auto.
@@ -1060,7 +1060,7 @@ Qed.
 
 Remark R4' : forall khi, In U khi -> f khi <= f (sup U).
 Proof.
- intros khi H ; case f_ord;intros H0 H1 H2 H3 . 
+ intros khi H ; case f_ord;intros H0 H1 H2 H3 .
  case (R4 H).
  - intro;  subst khi;left;auto with schutte.
  -  right;auto.
@@ -1097,7 +1097,7 @@ Lemma f_sup_commutes : f (|_| U) = |_| (image U f).
 Proof.
  apply le_antisym.
  -  apply R42.
- -  apply R4''. 
+ -  apply R4''.
 Qed.
 
 End U_fixed.
@@ -1109,7 +1109,7 @@ End U_fixed.
    split.
    - red.
      case f_ord;tauto.
-   - split. red. intros. 
+   - split. red. intros.
      eapply A_closed;auto.
      intros;symmetry;apply f_sup_commutes;auto.
  Qed.
@@ -1129,21 +1129,21 @@ Proof with eauto with schutte.
  -  intros x;  generalize (Ordering_bijection H).
     destruct 1 as [H3 H4 H5].
     exists (f (succ x));  split.
-    +  apply H3 ... 
+    +  apply H3 ...
     +  apply le_lt_trans with (f x).
-       * eapply ordering_le ... 
+       * eapply ordering_le ...
        *  eapply ordering_function_mono ...
 Qed.
 
 
-Lemma ordering_unbounded_unbounded : 
+Lemma ordering_unbounded_unbounded :
   forall A B f,  ordering_function f A B ->
                  (Unbounded B <-> Unbounded A).
 Proof with auto with schutte.
   intros A B f  H0;split.
   - intro; apply not_countable_unbounded.
     intro H2;  assert (H3 : countable B).
-    {  apply countable_bij_fun with Ord A  f ... 
+    {  apply countable_bij_fun with Ord A  f ...
        apply Ordering_bijection;auto.
     }
     case (countable_not_Unbounded  H3);auto.
@@ -1156,7 +1156,7 @@ Proof with auto with schutte.
 Qed.
 
 
-Theorem TH_13_6R (A B : Ensemble Ord) (f : Ord -> Ord) : 
+Theorem TH_13_6R (A B : Ensemble Ord) (f : Ord -> Ord) :
   ordering_function f A B ->
   Closed B ->    Unbounded B ->   normal f B.
 Proof with auto with schutte.
@@ -1171,7 +1171,7 @@ Qed.
 (** If [f] is the ordering function of [B], then [f 0] is the least element of
    [B] *)
 
-Lemma ordering_function_least_least : 
+Lemma ordering_function_least_least :
  forall B f  , ordering_function f ordinal B ->
      least_member  lt B (f zero).
 Proof with auto with schutte.
@@ -1184,23 +1184,23 @@ Proof with auto with schutte.
    intro H6;  apply H6 ...
 Qed.
 
-Lemma segment_lt_closed : forall A a b, segment A -> 
-                                          In A b -> 
-                                          a < b -> 
-                                          In A a. 
+Lemma segment_lt_closed : forall A a b, segment A ->
+                                          In A b ->
+                                          a < b ->
+                                          In A a.
 Proof.
- intros A a b H H0 H1; apply H with b;  auto. 
+ intros A a b H H0 H1; apply H with b;  auto.
 Qed.
 
 Lemma th_In A  alpha : In (the_ordering_segment A) alpha ->
-                             In A (ord A alpha). 
+                             In A (ord A alpha).
 Proof.
   unfold ord;  intro H;   red;  unfold some;  apply epsilon_ind.
-  - destruct   (ordering_function_ex A) as [X [[f Hf] H0]];  exists f. 
+  - destruct   (ordering_function_ex A) as [X [[f Hf] H0]];  exists f.
    rewrite <-  (H0 (the_ordering_segment A) );  auto.
    exists (ord A); apply ord_ok.
   -   intros beta H0;  eapply ordering_function_In; [ eexact H0 | trivial].
-Qed. 
+Qed.
 
 (* begin snippet Th1352 *)
 

--- a/theories/ordinals/Schutte/PartialFun.v
+++ b/theories/ordinals/Schutte/PartialFun.v
@@ -4,7 +4,7 @@
 (** Pierre Casteran, Univ. Bordeaux and LaBRI  *)
 
 
-(**  We study the relationship between  two representations of partial 
+(**  We study the relationship between  two representations of partial
    functions : relational presentation, and with the  [iota] description operator *)
 
 
@@ -22,12 +22,12 @@ Section AB_given.
             (DB : Ensemble B).
 
   (** ** Transformation of a functional relation into a function *)
-  
+
 Definition iota_fun (R:A->B-> Prop) : A -> B :=
   fun a =>  iota Hb (fun b':B => In DA a /\ R a b'  /\ In DB b').
 
-Lemma iota_fun_e (R:A->B-> Prop): 
-  forall (a:A), In DA a -> 
+Lemma iota_fun_e (R:A->B-> Prop):
+  forall (a:A), In DA a ->
    (exists ! b, R a b /\ In DB b) ->
    unique (fun b => (R a b /\ In DB b)) (iota_fun   R a).
 Proof.
@@ -60,7 +60,7 @@ Lemma iota_fun_ind (P:A -> Prop)
    (forall b,  unique (fun b => R a b /\  In DB b) b -> Q a b) ->
    Q x (iota_fun   R a).
 Proof.
- intros a x H H0 H1 H2 H3;  subst x;  apply H3. 
+ intros a x H H0 H1 H2 H3;  subst x;  apply H3.
  generalize (iota_fun_e   R  H H1).
  intros H0; apply iota_fun_e; auto.
 Qed.
@@ -70,38 +70,38 @@ Qed.
 
 
 Section f_given.
-   
+
   Variable f : A -> B.
 
   (** relational representation *)
-  
-  Variable Rf : A -> B -> Prop. 
 
-   
+  Variable Rf : A -> B -> Prop.
+
+
   (** abstract properties of a function (relational representation ) *)
-  
+
   Definition rel_domain := forall a, In DA a -> exists b, Rf a b .
   Definition rel_codomain := forall a b, In DA a -> Rf a b -> In DB b.
-  Definition rel_functional := forall a b b', In DA a -> 
+  Definition rel_functional := forall a b b', In DA a ->
                               Rf a b -> Rf a b' -> b = b'.
   Definition rel_onto := forall b, In DB b -> exists a, In DA a /\ Rf a b.
-  Definition rel_inj := forall a a' b, In DA a -> 
+  Definition rel_inj := forall a a' b, In DA a ->
                                        In DA a' ->
-                                       Rf a b -> 
-                                       Rf a' b -> 
-                                       a = a'.  
+                                       Rf a b ->
+                                       Rf a' b ->
+                                       a = a'.
 
   Inductive  rel_injection : Prop :=
-   rel_inj_i : rel_domain ->  rel_codomain -> 
-        rel_functional -> 
-        rel_inj -> 
+   rel_inj_i : rel_domain ->  rel_codomain ->
+        rel_functional ->
+        rel_inj ->
         rel_injection.
 
   Inductive  rel_bijection : Prop :=
-   rel_bij_i : rel_domain ->  rel_codomain -> 
-        rel_functional -> 
+   rel_bij_i : rel_domain ->  rel_codomain ->
+        rel_functional ->
         rel_onto ->
-        rel_inj -> 
+        rel_inj ->
         rel_bijection.
 
 
@@ -110,14 +110,14 @@ Section f_given.
 
   Definition fun_codomain := forall a, In DA a ->  In DB (f a).
   Definition fun_onto := forall b, In DB b -> exists a, In DA a /\ f a = b.
-  Definition fun_inj := forall a a' , In DA a -> In DA a' -> f a = f a' -> 
-                 a = a'.  
+  Definition fun_inj := forall a a' , In DA a -> In DA a' -> f a = f a' ->
+                 a = a'.
 
   Definition image := fun b => exists a, In DA a /\ f a = b.
 
 
   Inductive  fun_injection : Prop :=
-   fun_inj_i :  fun_codomain -> 
+   fun_inj_i :  fun_codomain ->
                             fun_inj -> fun_injection.
 
   Inductive  fun_bijection : Prop :=
@@ -125,23 +125,23 @@ Section f_given.
                             fun_inj -> fun_bijection.
 
   Definition rel_inv := fun b a => In DA a /\ In DB b /\ Rf a b.
- 
+
 
 End f_given.
 
 
 
- 
+
 (** Conversion from a relational definition : A->B->Prop into a partial
     function of type A->B *)
 
  Section rel_to_fun.
 
- Variables 
+ Variables
            (Rf : A -> B -> Prop).
 
  Definition r2i := iota_fun   Rf.
- 
+
 End rel_to_fun.
 End AB_given.
 
@@ -151,16 +151,16 @@ Section inversion_of_bijection.
            (DA : Ensemble A)
            (DB : Ensemble B)
            (f : A -> B).
- 
+
  Let inv_spec := fun y x => In DA x /\ In DB y /\ f x = y.
- 
-
- Definition inv_fun := r2i   inhA DB DA inv_spec. 
-
- Hypothesis f_b : fun_bijection DA DB f. 
 
 
-Lemma inv_compose :  
+ Definition inv_fun := r2i   inhA DB DA inv_spec.
+
+ Hypothesis f_b : fun_bijection DA DB f.
+
+
+Lemma inv_compose :
   forall x, DA x -> inv_fun (f x) = x.
 Proof.
   intros x H;  unfold inv_fun, r2i.
@@ -171,7 +171,7 @@ Proof.
   - exists x; split.
    +  split.
     *   destruct f_b;   split;auto.
-    *  auto. 
+    *  auto.
    +   intros x' H0;   destruct f_b as [f0 f1 f2].
        apply f2;  auto.
       now destruct H0.
@@ -193,8 +193,8 @@ Proof.
  - case (H1 b H); intros x (H',H5); exists x;auto.
    repeat split; trivial.
    intros x' [H3 H4]; subst b ;  apply H2; auto.
-   now   destruct H3 as [_ [H3 H5]]. 
- - destruct 1 as [[H0 _] _];  destruct H0; tauto. 
+   now   destruct H3 as [_ [H3 H5]].
+ - destruct 1 as [[H0 _] _];  destruct H0; tauto.
 Qed.
 
 Lemma inv_fun_bij : fun_bijection DB DA inv_fun.

--- a/theories/ordinals/Schutte/PartialFun.v
+++ b/theories/ordinals/Schutte/PartialFun.v
@@ -9,10 +9,10 @@
 
 
 From Coq Require Import Ensembles  ClassicalDescription .
+From ZornsLemma Require Import EnsemblesImplicit.
 From hydras Require Import MoreEpsilonIota.
 
 Set Implicit Arguments.
-Arguments In {U} _ _.
 
 Section AB_given.
   Variables (A B : Type)

--- a/theories/ordinals/Schutte/Schutte.v
+++ b/theories/ordinals/Schutte/Schutte.v
@@ -2,7 +2,7 @@
 (**
 
   Axiomatic definition of countable ordinal numbers (after Kurt Schutte's
-  "Proof Theory" 
+  "Proof Theory"
 
  Pierre Casteran (LaBRI, University of Bordeaux)
  with contributions by Florian Hatat (formerly student at ENS Lyon)
@@ -17,20 +17,20 @@ From hydras Require Export Schutte_basics Ordering_Functions
 (** * Warning
 
 
-This directory contains an adaptation to Coq of the mathematical 
+This directory contains an adaptation to Coq of the mathematical
 presentation of the set of countable ordinal numbers by K. Schutte.
 
-In order to respect as most as possible the style of that presentation, 
+In order to respect as most as possible the style of that presentation,
 we chosed to work in classical logic augmented by Hilbert's [[epsilon]]
-operator. 
+operator.
 
 So, all the construction herein is powered by six axioms, three of them are
 Schutte's axioms, and the other ones allow us to work in that "classical" framework, still using the Coq proof assistant and its libraries.
 
 
-** Schutte's Axioms 
+** Schutte's Axioms
 
- We consider a type [ON] (Ordinal numbers), well-ordered by some relation 
+ We consider a type [ON] (Ordinal numbers), well-ordered by some relation
  [lt], and such that every subset [X] of [Ord] is countable iff [X] is bounded.
 
 
@@ -43,12 +43,12 @@ Axiom AX2 : forall X: Ensemble Ord, (exists a,  (forall y, X y -> y < a)) ->
 
 
 Axiom AX3 : forall X : Ensemble Ord,
-              countable X -> 
+              countable X ->
               exists a,  forall y, X y -> y < a.
 
 ]]
 
-** Classical logic and Hilbert style 
+** Classical logic and Hilbert style
 
 *** From [Coq.Logic.Classical]
 
@@ -66,7 +66,7 @@ Axiom epsilon_statement :
   forall (A : Type) (P : A->Prop), inhabited A ->
     { x : A | (exists x, P x) -> P x }.
 
-]] 
+]]
 
 
 *** Needed for [epsilon] to work properly.
@@ -77,31 +77,31 @@ Axiom inh_Ord : inhabited Ord.
 ]]
 **)
 (* begin snippet Ex42a:: no-out *)
-Example Ex42: omega + 42 + omega^2 = omega^2. 
+Example Ex42: omega + 42 + omega^2 = omega^2.
 (* end snippet Ex42a *)
 Proof.
 
   (* begin snippet Ex42b *)
   assert (HAP:= AP_phi0 2). (* .no-out *)
-  elim  HAP; intros _ H0; apply H0; clear H0. 
+  elim  HAP; intros _ H0; apply H0; clear H0.
   (* end snippet Ex42b *)
   (* begin snippet Ex42d *)
   Check AP_plus_closed. (* .unfold .no-goals *)
   (* end snippet Ex42d *)
   (* begin snippet Ex42c *)
-  assert (Hlt: omega < omega^2) by 
+  assert (Hlt: omega < omega^2) by
       (rewrite omega_eqn; apply phi0_mono, finite_mono;
         auto with arith).
   (* end  snippet Ex42c *)
-  
+
 
   (* begin snippet Ex42e:: no-hyps *)
-  apply AP_plus_closed; trivial. 
+  apply AP_plus_closed; trivial.
   (* ... *)
   (* end snippet Ex42e *)
-  -  apply lt_trans with omega; [| trivial]. 
-     apply finite_lt_omega. 
-Qed. 
+  -  apply lt_trans with omega; [| trivial].
+     apply finite_lt_omega.
+Qed.
 
 
 

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -19,9 +19,6 @@ Declare Scope schutte_scope.
 Set Implicit Arguments.
 
 #[global] Hint Unfold In : schutte.
-Arguments Included [U] _ _.
-Arguments countable [U] _.
-Arguments Same_set [U] _ _.
 
 Delimit Scope schutte_scope with sch.
 Open Scope schutte_scope.
@@ -36,10 +33,8 @@ Parameter Ord : Type.
 Parameter lt : relation Ord.
 Infix "<" := lt : schutte_scope.
 
-Definition ordinal : Ensemble Ord := Full_set Ord.
+Notation ordinal := (@Full_set Ord).
 Definition big0 alpha : Ensemble Ord := fun beta =>  beta < alpha.
-
-#[global] Hint Unfold ordinal : schutte.
 
 (* end snippet OrdDecl *)
 
@@ -209,7 +204,7 @@ Definition progressive (P : Ord -> Prop) : Prop :=
 (* begin snippet ClosedDef *)
 
 Definition Closed (B : Ensemble Ord) : Prop :=
-  forall M, Included M B -> Inhabited _ M -> countable M ->
+  forall M, Included M B -> Inhabited M -> countable M ->
                             In B (|_| M).
 
 (* end snippet ClosedDef *)
@@ -217,7 +212,7 @@ Definition Closed (B : Ensemble Ord) : Prop :=
 Definition  continuous (f:Ord->Ord)(A B : Ensemble Ord) : Prop :=
   fun_codomain A B f /\
   Closed A /\
-  (forall U, Included U A -> Inhabited _ U ->
+  (forall U, Included U A -> Inhabited U ->
              countable U -> |_| (image U f) = f (|_| U)).
 
 
@@ -376,7 +371,7 @@ Qed.
 (** ** Global properties *)
 
 
-Theorem Non_denum : ~ countable (Full_set Ord).
+Theorem Non_denum : ~ countable ordinal.
 Proof.
   red; intro H; case (AX3  H); auto.
   intros x H0; case (@lt_irrefl x);apply H0; split.
@@ -384,7 +379,7 @@ Qed.
 
 
 
-Lemma Inh_ord : Inhabited _ ordinal.
+Lemma Inh_ord : Inhabited ordinal.
 Proof.
   destruct inh_Ord as [x];  exists x; split.
 Qed.
@@ -398,7 +393,7 @@ Proof.
     unfold X0, Included, In; intuition.
     now exists alpha.
   }
-  pose (X:= Add  _ X0 alpha).
+  pose (X:= Add X0 alpha).
   assert (countable X).
   {  unfold X; unfold Add; apply countable_union.
      auto.
@@ -413,8 +408,8 @@ Proof.
 Qed.
 
 
-Lemma the_least_ok : forall X, Inhabited Ord X ->
-                               forall a, In X a -> the_least X <= a.
+Lemma the_least_ok : forall X : Ensemble Ord,
+    Inhabited X -> forall a, In X a -> the_least X <= a.
 Proof.
   intros X H a H0;   pattern X, (the_least X).
   unfold the_least, the;apply iota_ind.
@@ -477,7 +472,7 @@ Proof. (* .no-out *)
   (* begin snippet succOkb *)
 
   (*| .. coq:: no-out |*)
-  destruct (@AX3 (Singleton _ alpha)).
+  destruct (@AX3 (Singleton alpha)).
   - apply countable_singleton.
   - unfold succ_spec; apply the_least_unicity; exists x; intuition.
 Qed.
@@ -1130,7 +1125,7 @@ Qed.
 (* begin snippet BadBottoma:: no-out *)
 Module Bad.
 
-  Definition bottom := the_least (Empty_set Ord).
+  Definition bottom := the_least Empty_set.
 (* end snippet BadBottoma *)
 
   (* begin snippet trivialProps:: no-out *)
@@ -1151,56 +1146,3 @@ End Bad.
 (* end snippet Failure *)
 
 End iota_demo.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -104,11 +104,11 @@ A subset X of Ord is bounded iff X is countable *)
 Axiom AX2 :
   forall X: Ensemble Ord,
     (exists a,  (forall y, In X y -> y < a)) ->
-    countable X.
+    Countable X.
 
 Axiom AX3 :
   forall X : Ensemble Ord,
-    countable X ->
+    Countable X ->
     exists a,  forall y, In X y -> y < a.
 
 (* end snippet AX23 *)
@@ -205,7 +205,7 @@ Definition progressive (P : Ord -> Prop) : Prop :=
 (* begin snippet ClosedDef *)
 
 Definition Closed (B : Ensemble Ord) : Prop :=
-  forall M, Included M B -> Inhabited M -> countable M ->
+  forall M, Included M B -> Inhabited M -> Countable M ->
                             In B (|_| M).
 
 (* end snippet ClosedDef *)
@@ -214,7 +214,7 @@ Definition  continuous (f:Ord->Ord)(A B : Ensemble Ord) : Prop :=
   fun_codomain A B f /\
   Closed A /\
   (forall U, Included U A -> Inhabited U ->
-             countable U -> |_| (image U f) = f (|_| U)).
+             Countable U -> |_| (image U f) = f (|_| U)).
 
 
 (** *  Basic properties
@@ -223,7 +223,7 @@ Definition  continuous (f:Ord->Ord)(A B : Ensemble Ord) : Prop :=
 
 
 Lemma Unbounded_not_countable (X: Ensemble Ord) :
-    Unbounded X -> not (countable X).
+    Unbounded X -> not (Countable X).
 Proof.
   intros  H  H1; case (AX3 H1); intros x Hx.
   destruct (H x) as [x0 [H0 H2]].
@@ -231,7 +231,7 @@ Proof.
 Qed.
 
 Lemma countable_not_Unbounded : forall X,
-    countable  X -> not (Unbounded X).
+    Countable  X -> not (Unbounded X).
 Proof.
   red;intros; apply Unbounded_not_countable with X;auto.
 Qed.
@@ -372,7 +372,7 @@ Qed.
 (** ** Global properties *)
 
 
-Theorem Non_denum : ~ countable ordinal.
+Theorem Non_denum : ~ Countable ordinal.
 Proof.
   red; intro H; case (AX3  H); auto.
   intros x H0; case (@lt_irrefl x);apply H0; split.
@@ -389,13 +389,13 @@ Qed.
 Theorem unbounded : forall alpha,  exists beta,  alpha < beta.
 Proof.
   intros alpha ; pose (X0 := fun z =>  z < alpha).
-  assert (countable X0).
+  assert (Countable X0).
   { apply AX2.
     unfold X0, Included, In; intuition.
     now exists alpha.
   }
   pose (X:= Add X0 alpha).
-  assert (countable X).
+  assert (Countable X).
   {  apply countable_union2.
      auto.
      apply countable_singleton.
@@ -615,7 +615,7 @@ Qed.
 
 (**  ** Building limits *)
 
-Lemma sup_exists : forall X, countable  X ->
+Lemma sup_exists : forall X, Countable  X ->
                              ex (sup_spec  X).
 Proof.
   intros X H; case (AX3 H); auto.
@@ -636,7 +636,7 @@ Proof.
 Qed.
 
 Lemma sup_unicity : forall X l l',
-                      (countable  X /\ forall x, X x -> ordinal x) ->
+                      (Countable  X /\ forall x, X x -> ordinal x) ->
                       sup_spec X l -> sup_spec X l' -> l = l'.
 Proof.
   intros X l l' _ H H0; apply le_antisym.
@@ -646,7 +646,7 @@ Proof.
   case (H5 l H);auto with schutte.
 Qed.
 
-Lemma sup_spec_unicity (X:Ensemble Ord) (HX : countable X) :
+Lemma sup_spec_unicity (X:Ensemble Ord) (HX : Countable X) :
   exists! u, sup_spec X u.
 Proof.
   destruct (sup_exists  HX).
@@ -658,14 +658,14 @@ Proof.
 Qed.
 
 
-Lemma sup_ok1 (X: Ensemble Ord)(HX : countable X) :
+Lemma sup_ok1 (X: Ensemble Ord)(HX : Countable X) :
   sup_spec X (sup X).
 Proof.
   unfold sup, the;  apply iota_spec;  now apply sup_spec_unicity.
 Qed.
 
 Lemma sup_upper_bound (X : Ensemble Ord) (alpha : Ord):
-  countable X ->  In X alpha -> alpha <= |_|  X.
+  Countable X ->  In X alpha -> alpha <= |_|  X.
 Proof.
   intros  H  H1;  generalize (sup_ok1   H).
   intro H2;  destruct H2 as [H2 [H3 H4]].
@@ -674,7 +674,7 @@ Qed.
 
 
 Lemma sup_least_upper_bound (X : Ensemble Ord) (alpha : Ord) :
-  countable X -> (forall y, In X y -> y <= alpha) -> sup  X <= alpha.
+  Countable X -> (forall y, In X y -> y <= alpha) -> sup  X <= alpha.
 Proof.
    intros  H H0;  specialize (sup_ok1   H) as H1.
     destruct H1 as [H1 [H2 H3]].
@@ -685,7 +685,7 @@ Qed.
 Lemma sup_of_leq (alpha : Ord) :
     alpha = |_| (fun x : Ord =>  x <= alpha).
 Proof.
- assert (DD :countable (fun x : Ord =>  x <= alpha)).
+ assert (DD :Countable (fun x : Ord =>  x <= alpha)).
   {
     apply AX2.
     -   exists (succ alpha);
@@ -698,8 +698,8 @@ Qed.
 
 
 Lemma sup_mono (X Y : Ensemble Ord) :
-    countable X ->
-    countable Y ->
+    Countable X ->
+    Countable Y ->
     (forall x, In X x -> exists y, In Y y /\ x <= y) ->
 |_| X <= |_| Y.
 Proof.
@@ -711,7 +711,7 @@ Proof.
 Qed.
 
 Lemma sup_eq_intro (X Y : Ensemble Ord):
-  countable X -> countable Y ->
+  Countable X -> Countable Y ->
   Included X Y -> Included Y X ->
 |_| X = |_| Y.
 Proof.
@@ -722,7 +722,7 @@ Qed.
 
 
 Lemma lt_sup_exists_leq (X: Ensemble Ord) :
-  countable X ->
+  Countable X ->
   forall y, y < sup X ->
             exists x, In X x /\ y <= x.
 Proof.
@@ -748,7 +748,7 @@ Proof.
 Qed.
 
 Lemma lt_sup_exists_lt (X : Ensemble Ord) :
-  countable X ->
+  Countable X ->
   forall y,  y < sup X -> exists x, In X x /\ y < x.
 Proof.
   intros  H y H0;
@@ -924,7 +924,7 @@ Lemma lt_omega_finite (alpha : Ord) :
 Proof.
   intro H0; unfold omega_limit in H0.
   generalize (lt_sup_exists_leq (X:=(seq_range finite))  ).
-  intros;  assert (countable (seq_range finite)) by
+  intros;  assert (Countable (seq_range finite)) by
     apply seq_range_countable.
   generalize (H H1);clear H;intros.
   generalize (H _ H0);clear H;intros.
@@ -981,7 +981,7 @@ Qed.
 
 (** ** About members *)
 
-Lemma countable_members (alpha : Ord): countable (members alpha).
+Lemma countable_members (alpha : Ord): Countable (members alpha).
 Proof.
  apply AX2;   now exists alpha.
 Qed.
@@ -1060,7 +1060,7 @@ Qed.
 
 
 Lemma Not_Unbounded_countable (X : Ensemble Ord) :
-  ~ Unbounded X ->   countable X.
+  ~ Unbounded X ->   Countable X.
 Proof.
   intros;eapply AX2;eauto.
   case (Not_Unbounded_bounded H);auto.
@@ -1068,7 +1068,7 @@ Proof.
 Qed.
 
 Lemma not_countable_unbounded (X : Ensemble Ord):
-    ~ countable X -> Unbounded X.
+    ~ Countable X -> Unbounded X.
 Proof.
   intros H;  apply NNPP; intro H0.
   apply H,  Not_Unbounded_countable;auto.

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -1,6 +1,6 @@
 
 (**  Ordinals of the first and second class,
-   After Kurt Schuttes book : Proof theory 
+   After Kurt Schuttes book : Proof theory
 
  *)
 
@@ -51,7 +51,7 @@ Qed.
 
 (* end hide *)
 
-#[global] Hint Resolve ordinal_ok : schutte. 
+#[global] Hint Resolve ordinal_ok : schutte.
 
 (** * The three axioms by Schutte *)
 
@@ -63,12 +63,12 @@ Axiom AX1 : WO lt.
 (* end snippet AX1 *)
 
 
-#[global] Hint Resolve AX1 : schutte. 
+#[global] Hint Resolve AX1 : schutte.
 
 #[global] Instance WO_ord : WO  lt := AX1.
 
 (** Stuff for using Coq.Logic.Epsilon *)
-(* begin snippet inhOrd *)  
+(* begin snippet inhOrd *)
 
 Axiom inh_Ord : inhabited Ord.
 
@@ -76,7 +76,7 @@ Axiom inh_Ord : inhabited Ord.
 Proof. (* .no-out *)
   exact inh_Ord. (* .no-out *)
 Qed. (* .no-out *)
-(* end snippet inhOrd *)  
+(* end snippet inhOrd *)
 
 
 #[ global ] Instance Inh_OSets : InH (Ensemble Ord).
@@ -99,7 +99,7 @@ Definition le := Le lt.
 Infix "<=" := le : schutte_scope.
 
 
-(** Second and third axioms from Schutte 
+(** Second and third axioms from Schutte
 
 A subset X of Ord is bounded iff X is countable *)
 
@@ -112,12 +112,12 @@ Axiom AX2 :
 
 Axiom AX3 :
   forall X : Ensemble Ord,
-    countable X -> 
+    countable X ->
     exists a,  forall y, In X y -> y < a.
 
 (* end snippet AX23 *)
 
-(** * First definitions  
+(** * First definitions
 *)
 
 Definition ge alpha : Ensemble Ord := fun beta => alpha <= beta.
@@ -125,7 +125,7 @@ Definition ge alpha : Ensemble Ord := fun beta => alpha <= beta.
 Definition Unbounded (X : Ensemble Ord) :=
   forall x: Ord,  exists y, In X y /\ x < y.
 
- 
+
 
 
 
@@ -176,7 +176,7 @@ Notation "'|_|' X" := (sup X) (at level 29) : schutte_scope.
 
 (* begin snippet omegaDef *)
 
-Definition omega_limit (s:nat->Ord) : Ord 
+Definition omega_limit (s:nat->Ord) : Ord
   := |_| (seq_range s).
 
 Definition _omega := omega_limit finite.
@@ -208,7 +208,7 @@ Definition progressive (P : Ord -> Prop) : Prop :=
 
 (* begin snippet ClosedDef *)
 
-Definition Closed (B : Ensemble Ord) : Prop := 
+Definition Closed (B : Ensemble Ord) : Prop :=
   forall M, Included M B -> Inhabited _ M -> countable M ->
                             In B (|_| M).
 
@@ -217,11 +217,11 @@ Definition Closed (B : Ensemble Ord) : Prop :=
 Definition  continuous (f:Ord->Ord)(A B : Ensemble Ord) : Prop :=
   fun_codomain A B f /\
   Closed A /\
-  (forall U, Included U A -> Inhabited _ U -> 
+  (forall U, Included U A -> Inhabited _ U ->
              countable U -> |_| (image U f) = f (|_| U)).
 
 
-(** *  Basic properties 
+(** *  Basic properties
 
 *)
 
@@ -231,7 +231,7 @@ Lemma Unbounded_not_countable (X: Ensemble Ord) :
 Proof.
   intros  H  H1; case (AX3 H1); intros x Hx.
   destruct (H x) as [x0 [H0 H2]].
-  case (Lt_irreflexive (a:=x));  eapply (Lt_trans (WO:=AX1)); eauto.  
+  case (Lt_irreflexive (a:=x));  eapply (Lt_trans (WO:=AX1)); eauto.
 Qed.
 
 Lemma countable_not_Unbounded : forall X,
@@ -251,7 +251,7 @@ Proof.
   intros Hp; case (classic  (forall a : Ord,  P a));
   [trivial|idtac].
   intro H; case (not_all_ex_not _ (fun a =>  P a) H).
-  intros x Hx.  
+  intros x Hx.
   assert False.
   {  case (well_order  (fun z => ~ P z) _ Hx (WO := AX1)).
      intros x0 H0; assert (forall b,  b < x0 -> P b).
@@ -327,7 +327,7 @@ Proof.
   -  intros H0 H1;case (@lt_irrefl a);eapply lt_trans;eauto.
 Qed.
 
-#[global] Hint Resolve eq_le lt_le lt_trans le_trans le_lt_trans 
+#[global] Hint Resolve eq_le lt_le lt_trans le_trans le_lt_trans
      lt_le_trans lt_irrefl le_not_gt:
   schutte.
 
@@ -342,16 +342,16 @@ Qed.
 Lemma all_ord_acc : forall alpha : Ord,  Acc lt alpha.
 Proof.
   intros alpha ;  pattern alpha;  apply transfinite_induction; auto.
-  apply Progressive_Acc; auto.  
+  apply Progressive_Acc; auto.
 Qed.
 
-Lemma trichotomy : forall a b : Ord , 
+Lemma trichotomy : forall a b : Ord ,
                                a < b \/ a = b \/ b < a.
 Proof (Lt_connect AX1).
 
 (* begin hide *)
 
-Ltac tricho t u Hname := 
+Ltac tricho t u Hname :=
                          case (@trichotomy t u);
                      [
                        intro Hname |
@@ -368,7 +368,7 @@ Qed.
 
 Lemma not_gt_le : forall a b,  ~ b < a  -> a <= b.
 Proof.
-  intros a b  H1; tricho a b H2; auto with schutte;  contradiction.  
+  intros a b  H1; tricho a b H2; auto with schutte;  contradiction.
 Qed.
 
 #[global] Hint Unfold Included : schutte.
@@ -390,16 +390,16 @@ Proof.
 Qed.
 
 
-Theorem unbounded : forall alpha,  exists beta,  alpha < beta. 
+Theorem unbounded : forall alpha,  exists beta,  alpha < beta.
 Proof.
   intros alpha ; pose (X0 := fun z =>  z < alpha).
-  assert (countable X0). 
+  assert (countable X0).
   { apply AX2.
     unfold X0, Included, In; intuition.
-    now exists alpha.  
+    now exists alpha.
   }
   pose (X:= Add  _ X0 alpha).
-  assert (countable X). 
+  assert (countable X).
   {  unfold X; unfold Add; apply countable_union.
      auto.
      apply countable_singleton.
@@ -413,15 +413,15 @@ Proof.
 Qed.
 
 
-Lemma the_least_ok : forall X, Inhabited Ord X -> 
+Lemma the_least_ok : forall X, Inhabited Ord X ->
                                forall a, In X a -> the_least X <= a.
 Proof.
   intros X H a H0;   pattern X, (the_least X).
   unfold the_least, the;apply iota_ind.
   -  apply the_least_unicity.
-    now exists a.      
+    now exists a.
   - intros a0 H2;  destruct H2;  now apply H1.
-Qed. 
+Qed.
 
 
 (** ** About zero *)
@@ -433,7 +433,7 @@ Lemma zero_le (alpha : Ord) : zero <= alpha. (* .no-out *)
 Proof. (* .no-out *)
   unfold zero, the_least, the; apply iota_ind.
   -  (* .no-out *) apply the_least_unicity, Inh_ord.
-  -  (* .no-out *) destruct 1 as [[_ H1] _]; apply H1; split. 
+  -  (* .no-out *) destruct 1 as [[_ H1] _]; apply H1; split.
 Qed.
 
 (* end snippet zeroLe *)
@@ -443,7 +443,7 @@ Proof.
   intros;apply le_not_gt; apply zero_le;auto.
 Qed.
 
-Lemma zero_or_greater : forall alpha : Ord, 
+Lemma zero_or_greater : forall alpha : Ord,
     alpha = zero \/ exists beta, beta < alpha.
 Proof.
   intros a; tricho zero a t;auto with schutte.
@@ -480,7 +480,7 @@ Proof. (* .no-out *)
   destruct (@AX3 (Singleton _ alpha)).
   - apply countable_singleton.
   - unfold succ_spec; apply the_least_unicity; exists x; intuition.
-Qed.     
+Qed.
 (*||*)
 (* end snippet succOkb *)
 
@@ -498,7 +498,7 @@ Qed.
 Lemma lt_succ_le (alpha beta : Ord):
   alpha < beta -> succ alpha <= beta.
 Proof with eauto with schutte.
-  intros  H;  pattern (succ alpha); apply the_least_ok ... 
+  intros  H;  pattern (succ alpha); apply the_least_ok ...
   exists (succ alpha); red;apply lt_succ ...
 Qed.
 (*||*)
@@ -546,7 +546,7 @@ Proof.
     rewrite H; intro; case (@lt_irrefl (succ beta));auto.
   - generalize (succ_mono  t).
    rewrite H; intro; case (@lt_irrefl (succ beta));auto.
-Qed. 
+Qed.
 (*||*)
 
 Lemma succ_zero_diff (alpha : Ord): succ alpha <> zero. (* .no-out *)
@@ -583,7 +583,7 @@ Qed.
 (** Less than finite is finite ... *)
 
 Lemma finite_lt_inv : forall i o,
-    o < F i -> 
+    o < F i ->
     exists j:nat , (j<i)%nat /\ o = F j.
 Proof.
   induction i.
@@ -607,10 +607,10 @@ Qed.
 
 Lemma finite_inj : forall i j, F i = F j -> i = j.
 Proof.
-  intros i j H; case (lt_eq_lt_dec i j). 
+  intros i j H; case (lt_eq_lt_dec i j).
   -  destruct 1.
      +  case (@lt_irrefl (F i)).
-        *  pattern (F i) at 2 ; rewrite H. 
+        *  pattern (F i) at 2 ; rewrite H.
            apply finite_mono;auto.
      + auto.
   -  intro;  case (@lt_irrefl (F i)).
@@ -623,10 +623,10 @@ Lemma sup_exists : forall X, countable  X ->
                              ex (sup_spec  X).
 Proof.
   intros X H; case (AX3 H); auto.
-  intros x H'x; 
+  intros x H'x;
   assert (H''x : forall y : Ord, X y -> y=x \/ lt y x) by  intuition.
   generalize  (@well_order   Ord lt  AX1
-                             (fun z => 
+                             (fun z =>
                                 (forall y,   X y -> y = z \/ y < z))
                              x ).
   intros H1; destruct H1 as [  x0 H0].
@@ -634,7 +634,7 @@ Proof.
   exists x0; unfold least_member in H0; repeat split.
   -   case H0; intros; intuition.
         red in H1;   red;  intros; auto.
-    -  intros y H1 H2;  decompose [and] H0. 
+    -  intros y H1 H2;  decompose [and] H0.
        red in H2;  destruct (H4 y); auto.
        intros y0 H5;  specialize (H2 y0);  apply H2; auto with schutte.
 Qed.
@@ -644,9 +644,9 @@ Lemma sup_unicity : forall X l l',
                       sup_spec X l -> sup_spec X l' -> l = l'.
 Proof.
   intros X l l' _ H H0; apply le_antisym.
-  destruct H, H0; intuition.  
+  destruct H, H0; intuition.
   case (H4 l' H0);auto with schutte.
-  destruct H, H0; intuition.  
+  destruct H, H0; intuition.
   case (H5 l H);auto with schutte.
 Qed.
 
@@ -666,7 +666,7 @@ Lemma sup_ok1 (X: Ensemble Ord)(HX : countable X) :
   sup_spec X (sup X).
 Proof.
   unfold sup, the;  apply iota_spec;  now apply sup_spec_unicity.
-Qed.  
+Qed.
 
 Lemma sup_upper_bound (X : Ensemble Ord) (alpha : Ord):
   countable X ->  In X alpha -> alpha <= |_|  X.
@@ -686,7 +686,7 @@ Proof.
     red;  intros;  apply H0; auto.
 Qed.
 
-Lemma sup_of_leq (alpha : Ord) : 
+Lemma sup_of_leq (alpha : Ord) :
     alpha = |_| (fun x : Ord =>  x <= alpha).
 Proof.
  assert (DD :countable (fun x : Ord =>  x <= alpha)).
@@ -709,7 +709,7 @@ Lemma sup_mono (X Y : Ensemble Ord) :
 Proof.
   intros H H0 H1;
   apply sup_least_upper_bound; auto with schutte.
-  intros x Hx; case (H1 x Hx); intros y (Hy,Hy'). 
+  intros x Hx; case (H1 x Hx); intros y (Hy,Hy').
   apply le_trans  with y;auto with schutte.
   apply sup_upper_bound;auto with schutte.
 Qed.
@@ -748,7 +748,7 @@ Proof.
       case ( @lt_irrefl y).
       eapply lt_le_trans with (|_|X);eauto.
       apply sup_least_upper_bound;auto with schutte.
-  -  intros x Hx; exists x;auto.  
+  -  intros x Hx; exists x;auto.
 Qed.
 
 Lemma lt_sup_exists_lt (X : Ensemble Ord) :
@@ -763,14 +763,14 @@ Proof.
        intro H5.
        assert (y < n).
        { case (@trichotomy n y).
-         -   intro H6;   case H5;auto with schutte.  
+         -   intro H6;   case H5;auto with schutte.
          -  destruct 1.
             +   case H5;auto with schutte.
             +   auto.
        }
        case (H1 n); split;auto with schutte.
     }
-    assert (sup X <= y). 
+    assert (sup X <= y).
     {  apply sup_least_upper_bound; auto. }
     case (@Lt_irreflexive Ord  lt AX1  y).
     eapply Lt_Le_trans;eauto with schutte.
@@ -792,7 +792,7 @@ Lemma sup_members_succ (alpha : Ord) :
   sup (members alpha) < alpha -> alpha = succ (|_| (members alpha)).
 Proof.
   intros  H;pose (A := sup (members alpha)).
-  fold A;  generalize (@lt_succ_le  A alpha). 
+  fold A;  generalize (@lt_succ_le  A alpha).
   intros H0.
   case (le_eq_or_lt  (H0  H)).
   -   symmetry;auto.
@@ -842,7 +842,7 @@ Qed.
 
 
 Lemma seq_mono_inj (s : nat -> Ord) :
-  seq_mono s -> injective _ _ s. 
+  seq_mono s -> injective _ _ s.
 Proof.
   unfold injective;intros  H i j H0.
   case (lt_eq_lt_dec i j).
@@ -870,14 +870,14 @@ Qed.
 
 Lemma omega_limit_least (s : nat -> Ord) :
     seq_mono s ->
-    forall y : Ord,  
+    forall y : Ord,
       (forall i, s i < y) ->
       omega_limit s <=  y.
 Proof.
   intros  H y  H1.
   unfold omega_limit;apply sup_least_upper_bound;auto with schutte.
   intro y0; destruct 1 as [x [_ e]]; subst y0;auto.
-  right; auto. 
+  right; auto.
 Qed.
 
 
@@ -907,7 +907,7 @@ Qed.
 (** ** Properties of omega *)
 
 (* begin snippet omegaPropsa:: no-out *)
-Lemma finite_lt_omega (i : nat) : i < omega. 
+Lemma finite_lt_omega (i : nat) : i < omega.
 (* end snippet omegaPropsa *)
 Proof.
    intros; apply lt_omega_limit; auto with schutte.
@@ -915,7 +915,7 @@ Qed.
 
 
 (* begin snippet omegaPropsb:: no-out *)
-Lemma zero_lt_omega : zero < omega. 
+Lemma zero_lt_omega : zero < omega.
 Proof.
   change zero with (F 0); apply finite_lt_omega.
 Qed.
@@ -923,12 +923,12 @@ Qed.
 
 (* begin snippet omegaPropsc:: no-out *)
 Lemma lt_omega_finite (alpha : Ord) :
-  alpha < omega ->  exists i:nat, alpha = i. 
+  alpha < omega ->  exists i:nat, alpha = i.
 (* end snippet omegaPropsc *)
 Proof.
   intro H0; unfold omega_limit in H0.
   generalize (lt_sup_exists_leq (X:=(seq_range finite))  ).
-  intros;  assert (countable (seq_range finite)) by 
+  intros;  assert (countable (seq_range finite)) by
     apply seq_range_countable.
   generalize (H H1);clear H;intros.
   generalize (H _ H0);clear H;intros.
@@ -941,7 +941,7 @@ Proof.
 Qed.
 
 (* begin snippet omegaPropsd:: no-out *)
-Lemma is_limit_omega : is_limit omega. 
+Lemma is_limit_omega : is_limit omega.
 (* end snippet omegaPropsd *)
 Proof.
   repeat split; auto with schutte.
@@ -963,7 +963,7 @@ Qed.
 
 Lemma not_is_succ_zero : ~ is_succ zero.
 Proof.
-   intros (b, Hb);  apply (succ_zero_diff  b); now symmetry. 
+   intros (b, Hb);  apply (succ_zero_diff  b); now symmetry.
 Qed.
 
 
@@ -1042,7 +1042,7 @@ Proof.
 Qed.
 
 
-Lemma Not_Unbounded_bounded (X: Ensemble Ord): 
+Lemma Not_Unbounded_bounded (X: Ensemble Ord):
    ~ Unbounded X ->
    exists beta : Ord, forall x, In X x -> x < beta.
 Proof.
@@ -1055,7 +1055,7 @@ Proof.
    +  case (H1 x).
       split;auto with schutte.
    +  case (H1 x);split;auto with schutte.
-  } 
+  }
   clear H0;  case H; intro x.
   destruct (H1 (succ x)) as [y [H2 H3]].
   exists y;split;auto with schutte.
@@ -1064,14 +1064,14 @@ Qed.
 
 
 Lemma Not_Unbounded_countable (X : Ensemble Ord) :
-  ~ Unbounded X ->   countable X. 
+  ~ Unbounded X ->   countable X.
 Proof.
   intros;eapply AX2;eauto.
   case (Not_Unbounded_bounded H);auto.
   intros x H0; exists x;auto.
 Qed.
 
-Lemma not_countable_unbounded (X : Ensemble Ord): 
+Lemma not_countable_unbounded (X : Ensemble Ord):
     ~ countable X -> Unbounded X.
 Proof.
   intros H;  apply NNPP; intro H0.
@@ -1092,8 +1092,8 @@ Proof.
  destruct i.
  -  simpl; apply not_is_limit_zero.
  -  simpl. intros [_ H0]; apply H0;   now exists (F i).
-Qed. 
- 
+Qed.
+
 
 (* begin hide *)
 
@@ -1103,8 +1103,8 @@ Module iota_demo.
   Remark R : exists! z : Ord, least_member lt  ordinal z.
   Proof.
     destruct inh_Ord as [a ];
-      apply least_member_ex_unique with a. 
-    - apply AX1. 
+      apply least_member_ex_unique with a.
+    - apply AX1.
     - split.
   Qed.
   (* end snippet iotaDemoa *)
@@ -1123,24 +1123,24 @@ Definition zero: Ord := iota inh_Ord (least_member lt ordinal).
 
 Lemma zero_le (alpha : Ord) :  zero <= alpha.
 Proof.
-  generalize (iota_spec inh_Ord _ R). 
+  generalize (iota_spec inh_Ord _ R).
   destruct 1 as [_ H]; apply H; split.
 Qed.
 
 (* begin snippet BadBottoma:: no-out *)
 Module Bad.
-  
+
   Definition bottom := the_least (Empty_set Ord).
 (* end snippet BadBottoma *)
 
-  (* begin snippet trivialProps:: no-out *) 
-  Lemma le_zero_bottom : zero <= bottom. 
+  (* begin snippet trivialProps:: no-out *)
+  Lemma le_zero_bottom : zero <= bottom.
   Proof. apply zero_le. Qed.
 
   Lemma bottom_eq : bottom = bottom.
   Proof. trivial. Qed.
   (* end snippet trivialProps *)
-  
+
   (* begin snippet Failure *)
   Lemma le_bottom_zero : bottom <= zero. (* .no-out *)
   Proof. (* .no-out *)
@@ -1162,30 +1162,6 @@ End iota_demo.
 
 
 
- 
-
-
-
- 
- 
- 
- 
-
-
-
-
-
-
-
-
- 
- 
-
-
- 
- 
- 
- 
 
 
 
@@ -1196,11 +1172,35 @@ End iota_demo.
 
 
 
- 
- 
- 
 
- 
- 
- 
- 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -395,7 +395,7 @@ Proof.
   }
   pose (X:= Add X0 alpha).
   assert (countable X).
-  {  unfold X; unfold Add; apply countable_union.
+  {  apply CountableTypes.countable_union2.
      auto.
      apply countable_singleton.
   }
@@ -837,7 +837,7 @@ Qed.
 
 
 Lemma seq_mono_inj (s : nat -> Ord) :
-  seq_mono s -> injective _ _ s.
+  seq_mono s -> injective s.
 Proof.
   unfold injective;intros  H i j H0.
   case (lt_eq_lt_dec i j).

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -9,6 +9,7 @@
 
 
 From Coq Require Import Relations  Classical   Classical_sets.
+From ZornsLemma Require Import CountableTypes.
 From hydras Require Import  Well_Orders Lub Countable.
 
 Import   Compare_dec  Coq.Sets.Image  PartialFun MoreEpsilonIota.
@@ -395,7 +396,7 @@ Proof.
   }
   pose (X:= Add X0 alpha).
   assert (countable X).
-  {  apply CountableTypes.countable_union2.
+  {  apply countable_union2.
      auto.
      apply countable_singleton.
   }

--- a/theories/ordinals/Schutte/Schutte_basics.v
+++ b/theories/ordinals/Schutte/Schutte_basics.v
@@ -855,11 +855,7 @@ Qed.
 
 #[global] Hint Resolve Countable.seq_range_countable seq_mono_intro : schutte.
 
-
-Lemma In_full {A:Type} (a:A) : In (Full_set A ) a.
-Proof. split. Qed.
-
-#[global] Hint Resolve In_full: core.
+#[global] Hint Constructors Full_set: core.
 
 Lemma lt_omega_limit (s : nat -> Ord) :
   seq_mono s -> forall i, s i <  omega_limit s.

--- a/theories/ordinals/Schutte/Well_Orders.v
+++ b/theories/ordinals/Schutte/Well_Orders.v
@@ -51,7 +51,7 @@ Section the_context.
 
     Lemma  Lt_connect : forall a b,  Lt a b \/ a = b \/ Lt b a.
     Proof.
-      intros a b ; generalize (well_order  (Couple _ a b) a ).
+      intros a b ; generalize (well_order  (Couple a b) a ).
       destruct 1 as [ c H1].
       - left.
       -  destruct H1  as [H2 H3].
@@ -162,7 +162,7 @@ Definition the_least {M: Type} {Lt}
 
 Lemma  the_least_unicity {M: Type} {Lt}
        {inh : InH M} {WO: WO Lt} (X: Ensemble M)
-       (HX: Inhabited _ X )
+       (HX: Inhabited X)
   : exists! l , least_member   Lt X l.
 Proof.
   destruct HX as [x Hx].
@@ -197,5 +197,3 @@ split.
        }
        destruct (H x0 H6 H4);  exists x1;  auto.
 Qed.
-
-

--- a/theories/ordinals/Schutte/Well_Orders.v
+++ b/theories/ordinals/Schutte/Well_Orders.v
@@ -23,16 +23,16 @@ Section the_context.
             (Lt : relation M).
 
   Definition Le (a b:M) :=  a = b \/ Lt a b.
-  
+
   Definition least_member  (X:Ensemble M) (a:M) :=
     In X a /\ forall x,  In X x -> Le a x.
   (* end snippet MDecl *)
-  
+
   Definition least_fixpoint (f : M -> M) (x:M) :=
     f x = x /\ forall y: M,  f y = y -> Le x y.
-  
+
   (** Well Ordering *)
-  
+
   (* begin snippet WODef *)
   Class WO : Type:=
     {
@@ -43,23 +43,23 @@ Section the_context.
         exists a0:M, least_member  X a0
     }.
   (* end snippet WODef *)
-  
+
   (* Some derived properties of well ordered sets *)
-  
+
   Section About_WO.
     Context (Wo : WO).
-    
+
     Lemma  Lt_connect : forall a b,  Lt a b \/ a = b \/ Lt b a.
     Proof.
       intros a b ; generalize (well_order  (Couple _ a b) a ).
       destruct 1 as [ c H1].
-      - left. 
+      - left.
       -  destruct H1  as [H2 H3].
-         destruct H2.  
+         destruct H2.
          +  destruct (H3 b);auto; now right.
-         +  destruct (H3 a);auto; now left.       
+         +  destruct (H3 a);auto; now left.
     Qed.
-    
+
     Lemma Le_refl : forall x:M, Le x x.
     Proof.
       red;unfold Le;auto.
@@ -69,14 +69,14 @@ Section the_context.
     Proof.
       intros a b  H H'; case H; case H' ; try tauto.
       - symmetry; tauto.
-      - intros;case (Lt_irreflexive (a:=a)); eapply (Lt_trans );eauto. 
+      - intros;case (Lt_irreflexive (a:=a)); eapply (Lt_trans );eauto.
     Qed.
 
-    #[global] Instance  Le_trans : Transitive  Le. 
+    #[global] Instance  Le_trans : Transitive  Le.
     Proof.
       unfold Transitive, Le;intros.
       case H;case H0.
-      - intros; left ; congruence.   
+      - intros; left ; congruence.
       -  intros H1 H2; right;subst x;auto.
       -  intros H1 H3; right ; subst y; auto.
       -  right;apply Lt_trans with y;eauto.
@@ -89,7 +89,7 @@ Section the_context.
       -  now subst y.
       - eapply Lt_trans; eauto.
     Qed.
-    
+
     Lemma Lt_Le_trans : forall x y z, Lt x y -> Le y z -> Lt x z.
     Proof.
       intros x y z Hxy Hyz; destruct Hyz as [H0 | H].
@@ -102,43 +102,43 @@ Section the_context.
       intros x y  H H'; case (Lt_irreflexive (a:=x)).
       eapply Lt_trans; eauto.
     Qed.
-    
+
     Lemma least_member_lower_bound : forall X a,
         least_member  X a -> forall b, In X b ->  Le a b.
     Proof.
       intros X a H; case H.
       unfold In; intuition.
     Qed.
-    
+
     Lemma least_member_glb :
       forall X a,
-        least_member  X a -> 
+        least_member  X a ->
         forall b, (forall c, In X c ->  Le b c) ->
                   Le b a.
     Proof.
       intros X a H b H0; case H;intros H1 H2;  apply H0; auto.
     Qed.
 
-    
-    Theorem least_member_unicity : forall  X a b, 
+
+    Theorem least_member_unicity : forall  X a b,
         least_member  X a -> least_member  X b -> a = b.
     Proof.
       intros X a b H H0;  case H;case H0;intros.
       - apply Le_antisym;auto.
     Qed.
-    
-    
+
+
     Theorem least_member_ex_unique :
-      forall   X  x 
-               (inhX: In X x), 
+      forall   X  x
+               (inhX: In X x),
       exists! a,  least_member  X a.
     Proof.
       intros;destruct (well_order X x); auto.
       exists x0; split; auto.
       intros; eapply least_member_unicity;eauto.
     Qed.
-    
-    
+
+
     Theorem least_member_of_eq : forall (X Y : Ensemble M) a b ,
         Included X Y -> Included Y X ->
         least_member  X a ->
@@ -149,7 +149,7 @@ Section the_context.
     Qed.
 
   End About_WO.
-  
+
 End the_context.
 
 (* begin snippet theLeast *)
@@ -162,14 +162,14 @@ Definition the_least {M: Type} {Lt}
 
 Lemma  the_least_unicity {M: Type} {Lt}
        {inh : InH M} {WO: WO Lt} (X: Ensemble M)
-       (HX: Inhabited _ X ) 
+       (HX: Inhabited _ X )
   : exists! l , least_member   Lt X l.
 Proof.
   destruct HX as [x Hx].
   case  WO; intros.
   destruct (well_order0 X x Hx) as [x0 H0].
   exists x0; split; auto.
-  intros; eapply least_member_unicity;eauto . 
+  intros; eapply least_member_unicity;eauto .
 Qed.
 
 
@@ -186,7 +186,7 @@ split.
      * exists x; auto.
      * unfold least_member in H1;     destruct (not_and_or _ _ H1).
        contradiction.
-       destruct (not_all_ex_not _ _ H2).     
+       destruct (not_all_ex_not _ _ H2).
        destruct (imply_to_and _ _ H3).
        assert (lt x0 x). {
          destruct (Compare_dec.lt_eq_lt_dec x0 x).

--- a/theories/ordinals/solutions_exercises/Limit_Infinity.v
+++ b/theories/ordinals/solutions_exercises/Limit_Infinity.v
@@ -9,7 +9,7 @@ From Coq Require Import Ensembles Image Compare_dec.
 
 
 Definition Infinite {A: Type} (E: Ensemble A) :=
-  exists s: nat -> A, injective nat A s /\ forall i, In  E (s i).
+  exists s: nat -> A, injective s /\ forall i, In  E (s i).
 
 Section On_alpha.
 
@@ -49,9 +49,9 @@ Section On_alpha.
         apply plus_smono_LT_r; eauto with T1.
     Qed.
 
-    
-    Lemma L3: injective _ _ s.
-      assert (mono: forall i j, i < j -> s i t1< s j).      
+
+    Lemma L3: injective s.
+      assert (mono: forall i j, i < j -> s i t1< s j).
       {
         induction 1.
         - apply L2.
@@ -108,4 +108,3 @@ Section On_alpha.
   Qed.
   
 End On_alpha.
-


### PR DESCRIPTION
Initial discussion on Zulip:
https://coq.zulipchat.com/#narrow/stream/344515-Hydras-.26-Co.2E-universe/topic/Library.20for.20countability.3F/near/341893039
The file theories/ordinals/Schutte/Countable.v provides some theory about countable `Ensemble`. The [coq-zorns-lemma](https://github.com/coq-community/topology) package contains very similar results already.
This commit is a first try to use as many results from coq-zorns-lemma as possible, instead of defining them in here.

This commit still contains some rough edges:
- The lemma `countable_singleton` can be moved to `ZornsLemma`.
- In some files we can't use From ZornsLemma Require Import CountableTypes. because it messes up the set of open scopes. I consider this a bug of ZornsLemma and will look into it.
- ~~All edits have been done in Countable.v, but statements like `image_as_Im` could be moved to ordinals/Schutte/PartialFun.v.~~
- ~~The following lemmas could be removed from Countable.v, if at the corresponding places we'd use the corresponding lemma of ZornsLemma:
  `countable_union`, `countable_inclusion`, `countable_union_qcq`~~
- ~~The following lemmas could be incorporated in coq-zorns-lemma, instead of introducing them here: `countable_empty`, `countable_singleton`, `seq_range_countable`.~~
- ~~The proof of `countable_bij_fun` and `countable_bij` uses a very rough translation between `fun_bijection` and
`ZornsLemma.FunctionProperties.bijective`.~~
- ~~ZornsLemma defines implicit arguments for most operations on `Ensembles` like `Union`, `Full_set`, etc. Somehow this is infectuous and now also appeared in Countable.v. We might want to change this behaviour of ZornsLemma. What is the right change to `ZornsLemma`? Change all `Require Export EnsemblesImplicit` to `Require Import EnsemblesImplicit`?~~
~~Edit: The approach using `Require Import` does not work. The `Arguments` infect all files that transitively `Import` them.~~